### PR TITLE
feat(cli): app create, config set, release/deploy info, audit dimension scorecard

### DIFF
--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -1,0 +1,35 @@
+use anyhow::Result;
+use clap::{ArgMatches, Command};
+use create::CreateCommand;
+
+use crate::{CliCommand, core::command::command};
+
+mod create;
+
+#[derive(Debug)]
+pub(crate) struct AppCommand {
+    create: CreateCommand,
+}
+
+impl AppCommand {
+    pub(crate) fn new() -> Self {
+        Self {
+            create: CreateCommand::new(),
+        }
+    }
+}
+
+impl CliCommand for AppCommand {
+    fn command(&self) -> Command {
+        command("app", "Manage platform applications")
+            .subcommand_required(true)
+            .subcommand(self.create.command())
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        match matches.subcommand() {
+            Some(("create", matches)) => self.create.handler(matches),
+            _ => unreachable!(),
+        }
+    }
+}

--- a/cli/src/app/create.rs
+++ b/cli/src/app/create.rs
@@ -1,0 +1,194 @@
+use std::{fs::write, io::Write};
+
+use anyhow::{Context, Result, bail};
+use clap::{Arg, ArgAction, ArgMatches, Command};
+use reqwest::blocking::Client;
+use serde::{Deserialize, Serialize};
+use termcolor::{Color, ColorChoice, StandardStream, WriteColor};
+use toml::to_string_pretty;
+
+use crate::{
+    CliCommand,
+    constants::{ERROR_FAILED_TO_SEND_REQUEST, get_platform_management_api_url},
+    core::{
+        command::command,
+        manifest::application::ApplicationManifestData,
+        validate::{require_auth, require_manifest},
+    },
+};
+
+#[derive(Debug, Deserialize)]
+struct MeIdentity {
+    id: String,
+    #[serde(rename = "organizationId")]
+    organization_id: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct CreatedApplication {
+    id: String,
+    name: String,
+    #[serde(rename = "organizationId")]
+    organization_id: String,
+}
+
+#[derive(Debug)]
+pub(crate) struct CreateCommand;
+
+impl CreateCommand {
+    pub(crate) fn new() -> Self {
+        Self {}
+    }
+}
+
+impl CliCommand for CreateCommand {
+    fn command(&self) -> Command {
+        command(
+            "create",
+            "Create a platform application and integrate the local project in one step",
+        )
+        .arg(
+            Arg::new("name")
+                .long("name")
+                .short('n')
+                .help("Application name (defaults to the local app_name from manifest.toml)"),
+        )
+        .arg(
+            Arg::new("description")
+                .long("description")
+                .short('D')
+                .help("Application description"),
+        )
+        .arg(
+            Arg::new("no_integrate")
+                .long("no-integrate")
+                .action(ArgAction::SetTrue)
+                .help("Only create the platform application; skip linking the local project"),
+        )
+        .arg(
+            Arg::new("base_path")
+                .long("path")
+                .short('p')
+                .help("Path to application root (optional)"),
+        )
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        let mut stdout = StandardStream::stdout(ColorChoice::Always);
+
+        let token = require_auth()?;
+        let (app_root, manifest) = require_manifest(matches)?;
+        let skip_integrate = matches.get_flag("no_integrate");
+
+        if !skip_integrate {
+            if let Some(existing_id) = &manifest.platform_application_id {
+                bail!(
+                    "This application is already integrated with platform application ID: {}. Use --no-integrate to create another platform app without linking, or remove platform_application_id from .forklaunch/manifest.toml first.",
+                    existing_id
+                );
+            }
+        }
+
+        let name = matches
+            .get_one::<String>("name")
+            .cloned()
+            .unwrap_or_else(|| manifest.app_name.clone());
+        let description = matches
+            .get_one::<String>("description")
+            .cloned()
+            .unwrap_or_else(|| manifest.app_description.clone());
+
+        let api_url = get_platform_management_api_url();
+        let client = Client::new();
+
+        // Resolve the caller's identity — createApplication requires the
+        // owning userId + organizationId, which live server-side on /me.
+        let me: MeIdentity = client
+            .get(format!("{}/user-profile/me", api_url))
+            .bearer_auth(&token)
+            .send()
+            .with_context(|| ERROR_FAILED_TO_SEND_REQUEST)?
+            .error_for_status()
+            .with_context(|| "Failed to resolve current user (are you logged in?)")?
+            .json()
+            .with_context(|| "Failed to parse /user-profile/me response")?;
+
+        log_info!(stdout, "Creating platform application '{}'...", name);
+        let create_response = client
+            .post(format!("{}/applications/", api_url))
+            .bearer_auth(&token)
+            .json(&serde_json::json!({
+                "name": name,
+                "description": description,
+                "userId": me.id,
+                "organizationId": me.organization_id,
+                "isDeleted": false
+            }))
+            .send()
+            .with_context(|| ERROR_FAILED_TO_SEND_REQUEST)?;
+
+        let status = create_response.status();
+        if !status.is_success() {
+            bail!(
+                "Failed to create application '{}': {} ({})",
+                name,
+                create_response.text().unwrap_or_default(),
+                status
+            );
+        }
+
+        let app: CreatedApplication = create_response
+            .json()
+            .with_context(|| "Failed to parse created application response")?;
+        log_ok!(stdout, "Created platform application: {} ({})", app.name, app.id);
+
+        if skip_integrate {
+            log_info!(
+                stdout,
+                "Skipping integration (--no-integrate). Link later with: forklaunch integrate --app {}",
+                app.id
+            );
+            return Ok(());
+        }
+
+        // Same linking flow as `forklaunch integrate --app <id>`.
+        log_info!(stdout, "Integrating local project...");
+        let integrate_response = client
+            .post(format!("{}/applications/{}/integrate", api_url, app.id))
+            .bearer_auth(&token)
+            .send()
+            .with_context(|| ERROR_FAILED_TO_SEND_REQUEST)?;
+
+        if !integrate_response.status().is_success() {
+            bail!(
+                "Application {} was created but integration failed ({}). Link manually with: forklaunch integrate --app {}",
+                app.id,
+                integrate_response.status(),
+                app.id
+            );
+        }
+
+        let manifest_path = app_root.join(".forklaunch").join("manifest.toml");
+        let manifest_content = std::fs::read_to_string(&manifest_path)
+            .with_context(|| format!("Failed to read manifest at {:?}", manifest_path))?;
+        let mut manifest: ApplicationManifestData =
+            toml::from_str(&manifest_content).with_context(|| "Failed to parse manifest.toml")?;
+        manifest.platform_application_id = Some(app.id.clone());
+        manifest.platform_organization_id = Some(app.organization_id.clone());
+        let updated_manifest =
+            to_string_pretty(&manifest).with_context(|| "Failed to serialize updated manifest")?;
+        write(&manifest_path, updated_manifest)
+            .with_context(|| format!("Failed to write manifest at {:?}", manifest_path))?;
+
+        log_header!(stdout, Color::Green, "\nApplication created and integrated!");
+        log_info!(stdout, "Platform App ID: {}", app.id);
+        log_info!(stdout, "\nYou can now use:");
+        writeln!(stdout, "  forklaunch release create --version <version>")?;
+        writeln!(
+            stdout,
+            "  forklaunch deploy create --release <version> --environment <env> --region <region>"
+        )?;
+
+        Ok(())
+    }
+}

--- a/cli/src/compliance/audit.rs
+++ b/cli/src/compliance/audit.rs
@@ -196,6 +196,7 @@ impl CliCommand for AuditCommand {
             Ok(resp) => {
                 if show_all || show_risk_score {
                     print_risk_score(&mut stdout, resp)?;
+                    print_scorecard(&mut stdout, resp)?;
                     print_findings(&mut stdout, resp)?;
                 }
 
@@ -332,6 +333,109 @@ fn print_summary(out: &mut StandardStream, report: &ComplianceReport) -> Result<
         writeln!(out, "(none configured)")?;
     } else {
         writeln!(out, "{}", report.data_residency.allowed_regions.join(", "))?;
+    }
+
+    Ok(())
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+struct DimensionScores {
+    compliance: f64,
+    security: f64,
+    scale: f64,
+    observability: f64,
+    governance: f64,
+    #[serde(default)]
+    coverage: Option<DimensionCoverage>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+struct DimensionCoverage {
+    #[serde(default)]
+    unscored: Vec<String>,
+}
+
+/// Client-side fallback for platforms that predate server-computed
+/// dimension scores: derive the scorecard from finding categories using
+/// the same mapping the platform uses.
+fn derive_dimension_scores(findings: &[PlatformFinding]) -> DimensionScores {
+    fn dims_for(category: &str) -> &'static [&'static str] {
+        match category {
+            "encryption" => &["security", "compliance"],
+            "access-control" => &["security", "governance"],
+            "tenant-isolation" => &["security", "compliance"],
+            "data-retention" => &["compliance", "governance"],
+            "multi-az" | "capacity" => &["scale"],
+            "alerting" => &["observability"],
+            "logging" => &["observability", "governance"],
+            "audit" => &["governance", "compliance"],
+            _ => &["compliance"],
+        }
+    }
+    let mut totals: std::collections::HashMap<&str, f64> = Default::default();
+    let mut touched: std::collections::HashSet<&str> = Default::default();
+    for finding in findings {
+        for dim in dims_for(&finding.category) {
+            *totals.entry(dim).or_insert(0.0) += finding.points;
+            touched.insert(dim);
+        }
+    }
+    let score = |dim: &str| ((100.0 - totals.get(dim).copied().unwrap_or(0.0)).max(0.0) * 10.0).round() / 10.0;
+    DimensionScores {
+        compliance: score("compliance"),
+        security: score("security"),
+        scale: score("scale"),
+        observability: score("observability"),
+        governance: score("governance"),
+        coverage: Some(DimensionCoverage {
+            unscored: ["scale", "observability"]
+                .iter()
+                .filter(|d| !touched.contains(**d))
+                .map(|d| d.to_string())
+                .collect(),
+        }),
+    }
+}
+
+fn print_scorecard(out: &mut StandardStream, resp: &PlatformAuditResponse) -> Result<()> {
+    let scores = resp
+        .dimension_scores
+        .clone()
+        .unwrap_or_else(|| derive_dimension_scores(&resp.findings));
+
+    writeln!(out)?;
+    out.set_color(ColorSpec::new().set_fg(Some(Color::White)).set_bold(true))?;
+    writeln!(out, "  ── Scorecard ──")?;
+    out.reset()?;
+
+    let unscored = scores
+        .coverage
+        .as_ref()
+        .map(|c| c.unscored.clone())
+        .unwrap_or_default();
+    for (label, value) in [
+        ("Compliance", scores.compliance),
+        ("Security", scores.security),
+        ("Scale", scores.scale),
+        ("Observability", scores.observability),
+        ("Governance", scores.governance),
+    ] {
+        let color = if value >= 90.0 {
+            Color::Green
+        } else if value >= 70.0 {
+            Color::Yellow
+        } else {
+            Color::Red
+        };
+        write!(out, "  {:<14}", format!("{}:", label))?;
+        out.set_color(ColorSpec::new().set_fg(Some(color)).set_bold(true))?;
+        write!(out, "{:>5.1}/100", value)?;
+        out.reset()?;
+        if unscored.iter().any(|d| d.eq_ignore_ascii_case(label)) {
+            write!(out, "  (no audit signals yet)")?;
+        }
+        writeln!(out)?;
     }
 
     Ok(())
@@ -701,6 +805,8 @@ struct PlatformAuditResponse {
     risk_score: f64,
     risk_level: String,
     findings: Vec<PlatformFinding>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    dimension_scores: Option<DimensionScores>,
     #[serde(skip_serializing_if = "Option::is_none")]
     data_flow_diagram: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/cli/src/compliance/audit.rs
+++ b/cli/src/compliance/audit.rs
@@ -389,7 +389,7 @@ fn derive_dimension_scores(findings: &[PlatformFinding]) -> DimensionScores {
         observability: score("observability"),
         governance: score("governance"),
         coverage: Some(DimensionCoverage {
-            unscored: ["scale", "observability"]
+            unscored: ["scale", "observability", "compliance", "security", "governance"]
                 .iter()
                 .filter(|d| !touched.contains(**d))
                 .map(|d| d.to_string())

--- a/cli/src/compliance/audit.rs
+++ b/cli/src/compliance/audit.rs
@@ -432,7 +432,7 @@ fn derive_dimension_scores(findings: &[PlatformFinding]) -> DimensionScores {
         observability: score("observability"),
         governance: score("governance"),
         coverage: Some(DimensionCoverage {
-            unscored: ["scale", "observability"]
+            unscored: ["scale", "observability", "compliance", "security", "governance"]
                 .iter()
                 .filter(|d| !touched.contains(**d))
                 .map(|d| d.to_string())

--- a/cli/src/compliance/audit.rs
+++ b/cli/src/compliance/audit.rs
@@ -223,6 +223,7 @@ impl CliCommand for AuditCommand {
             Ok(resp) => {
                 if show_all || show_risk_score {
                     print_risk_score(&mut stdout, resp)?;
+                    print_scorecard(&mut stdout, resp)?;
                     print_findings(&mut stdout, resp)?;
                 }
 
@@ -375,6 +376,109 @@ fn print_summary(
         writeln!(out, "(none configured)")?;
     } else {
         writeln!(out, "{}", report.data_residency.allowed_regions.join(", "))?;
+    }
+
+    Ok(())
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+struct DimensionScores {
+    compliance: f64,
+    security: f64,
+    scale: f64,
+    observability: f64,
+    governance: f64,
+    #[serde(default)]
+    coverage: Option<DimensionCoverage>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+struct DimensionCoverage {
+    #[serde(default)]
+    unscored: Vec<String>,
+}
+
+/// Client-side fallback for platforms that predate server-computed
+/// dimension scores: derive the scorecard from finding categories using
+/// the same mapping the platform uses.
+fn derive_dimension_scores(findings: &[PlatformFinding]) -> DimensionScores {
+    fn dims_for(category: &str) -> &'static [&'static str] {
+        match category {
+            "encryption" => &["security", "compliance"],
+            "access-control" => &["security", "governance"],
+            "tenant-isolation" => &["security", "compliance"],
+            "data-retention" => &["compliance", "governance"],
+            "multi-az" | "capacity" => &["scale"],
+            "alerting" => &["observability"],
+            "logging" => &["observability", "governance"],
+            "audit" => &["governance", "compliance"],
+            _ => &["compliance"],
+        }
+    }
+    let mut totals: std::collections::HashMap<&str, f64> = Default::default();
+    let mut touched: std::collections::HashSet<&str> = Default::default();
+    for finding in findings {
+        for dim in dims_for(&finding.category) {
+            *totals.entry(dim).or_insert(0.0) += finding.points;
+            touched.insert(dim);
+        }
+    }
+    let score = |dim: &str| ((100.0 - totals.get(dim).copied().unwrap_or(0.0)).max(0.0) * 10.0).round() / 10.0;
+    DimensionScores {
+        compliance: score("compliance"),
+        security: score("security"),
+        scale: score("scale"),
+        observability: score("observability"),
+        governance: score("governance"),
+        coverage: Some(DimensionCoverage {
+            unscored: ["scale", "observability"]
+                .iter()
+                .filter(|d| !touched.contains(**d))
+                .map(|d| d.to_string())
+                .collect(),
+        }),
+    }
+}
+
+fn print_scorecard(out: &mut StandardStream, resp: &PlatformAuditResponse) -> Result<()> {
+    let scores = resp
+        .dimension_scores
+        .clone()
+        .unwrap_or_else(|| derive_dimension_scores(&resp.findings));
+
+    writeln!(out)?;
+    out.set_color(ColorSpec::new().set_fg(Some(Color::White)).set_bold(true))?;
+    writeln!(out, "  ── Scorecard ──")?;
+    out.reset()?;
+
+    let unscored = scores
+        .coverage
+        .as_ref()
+        .map(|c| c.unscored.clone())
+        .unwrap_or_default();
+    for (label, value) in [
+        ("Compliance", scores.compliance),
+        ("Security", scores.security),
+        ("Scale", scores.scale),
+        ("Observability", scores.observability),
+        ("Governance", scores.governance),
+    ] {
+        let color = if value >= 90.0 {
+            Color::Green
+        } else if value >= 70.0 {
+            Color::Yellow
+        } else {
+            Color::Red
+        };
+        write!(out, "  {:<14}", format!("{}:", label))?;
+        out.set_color(ColorSpec::new().set_fg(Some(color)).set_bold(true))?;
+        write!(out, "{:>5.1}/100", value)?;
+        out.reset()?;
+        if unscored.iter().any(|d| d.eq_ignore_ascii_case(label)) {
+            write!(out, "  (no audit signals yet)")?;
+        }
+        writeln!(out)?;
     }
 
     Ok(())
@@ -786,6 +890,8 @@ struct PlatformAuditResponse {
     risk_score: f64,
     risk_level: String,
     findings: Vec<PlatformFinding>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    dimension_scores: Option<DimensionScores>,
     #[serde(skip_serializing_if = "Option::is_none")]
     data_flow_diagram: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -2,16 +2,19 @@ use anyhow::Result;
 use clap::{ArgMatches, Command};
 use pull::PullCommand;
 use push::PushCommand;
+use set::SetCommand;
 
 use crate::{CliCommand, core::command::command};
 
 mod pull;
 mod push;
+mod set;
 
 #[derive(Debug)]
 pub(crate) struct ConfigCommand {
     pull: PullCommand,
     push: PushCommand,
+    set: SetCommand,
 }
 
 impl ConfigCommand {
@@ -19,6 +22,7 @@ impl ConfigCommand {
         Self {
             pull: PullCommand::new(),
             push: PushCommand::new(),
+            set: SetCommand::new(),
         }
     }
 }
@@ -32,12 +36,14 @@ impl CliCommand for ConfigCommand {
         .subcommand_required(true)
         .subcommand(self.pull.command())
         .subcommand(self.push.command())
+        .subcommand(self.set.command())
     }
 
     fn handler(&self, matches: &ArgMatches) -> Result<()> {
         match matches.subcommand() {
             Some(("pull", matches)) => self.pull.handler(matches),
             Some(("push", matches)) => self.push.handler(matches),
+            Some(("set", matches)) => self.set.handler(matches),
             _ => unreachable!(),
         }
     }

--- a/cli/src/config/set.rs
+++ b/cli/src/config/set.rs
@@ -1,0 +1,205 @@
+use std::io::Write;
+
+use anyhow::{Context, Result, bail};
+use clap::{Arg, ArgMatches, Command};
+use termcolor::{ColorChoice, StandardStream, WriteColor};
+
+use super::{CliCommand, push::reconstruct_env_content};
+use crate::{
+    constants::{ERROR_FAILED_TO_SEND_REQUEST, get_platform_management_api_url},
+    core::{
+        command::command,
+        env::{EnvFileItem, parse_env_items_from_str},
+        http_client,
+        validate::{require_auth, require_integration, require_manifest},
+    },
+};
+
+#[derive(Debug)]
+pub(crate) struct SetCommand;
+
+impl SetCommand {
+    pub(crate) fn new() -> Self {
+        Self {}
+    }
+}
+
+/// Match a pulled section header (e.g. `# application` or
+/// `# my-service (uuid)`) against a target scope name.
+fn header_matches_scope(header: &str, scope: &str) -> bool {
+    let name = header
+        .trim_start_matches('#')
+        .trim()
+        .split(' ')
+        .next()
+        .unwrap_or("");
+    name == scope
+}
+
+impl CliCommand for SetCommand {
+    fn command(&self) -> Command {
+        command(
+            "set",
+            "Set a single environment variable without touching the rest of the scope",
+        )
+        .arg(
+            Arg::new("pair")
+                .required(true)
+                .help("KEY=VALUE to set (quote values containing spaces)"),
+        )
+        .arg(
+            Arg::new("region")
+                .short('r')
+                .long("region")
+                .required(true)
+                .help("Region (e.g. us-east-1)"),
+        )
+        .arg(
+            Arg::new("environment")
+                .short('e')
+                .long("environment")
+                .required(true)
+                .help("Environment name (e.g. production, staging)"),
+        )
+        .arg(
+            Arg::new("service")
+                .short('s')
+                .long("service")
+                .help("Scope to a specific service/worker (defaults to application scope)"),
+        )
+        .arg(
+            Arg::new("base_path")
+                .long("path")
+                .short('p')
+                .help("Path to application root (optional)"),
+        )
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        let _token = require_auth()?;
+        let (_app_root, manifest) = require_manifest(matches)?;
+        let app = require_integration(&manifest)?;
+        let mut stdout = StandardStream::stdout(ColorChoice::Always);
+
+        let pair = matches.get_one::<String>("pair").expect("pair required");
+        let Some((key, value)) = pair.split_once('=') else {
+            bail!("Expected KEY=VALUE, got '{}'", pair);
+        };
+        let key = key.trim();
+        if key.is_empty() {
+            bail!("Variable name cannot be empty");
+        }
+        // The deploy env-editor incident class: a value that itself looks
+        // like an assignment is almost always a paste error and produces
+        // values like `S3_BUCKET=S3_BUCKET=real-value` server-side.
+        if value
+            .split_once('=')
+            .is_some_and(|(maybe_key, _)| maybe_key.chars().all(|c| c.is_ascii_uppercase() || c == '_') && !maybe_key.is_empty())
+        {
+            bail!(
+                "Value '{}' looks like another KEY=VALUE assignment — this is usually a paste error. Quote the value if it is intentional.",
+                value
+            );
+        }
+
+        let region = matches.get_one::<String>("region").expect("required");
+        let environment = matches
+            .get_one::<String>("environment")
+            .expect("required");
+        let scope = matches
+            .get_one::<String>("service")
+            .cloned()
+            .unwrap_or_else(|| "application".to_string());
+
+        // The push endpoint is authoritative per scope: any var present in
+        // the pushed scope but missing from the payload is cleared. So a
+        // single-var set must round-trip the FULL current scope.
+        let pull_url = format!(
+            "{}/config/pull?applicationId={}&region={}&environment={}",
+            get_platform_management_api_url(),
+            app,
+            region,
+            environment
+        );
+        let pull_response =
+            http_client::get(&pull_url).with_context(|| ERROR_FAILED_TO_SEND_REQUEST)?;
+        if !pull_response.status().is_success() {
+            bail!(
+                "Failed to pull current config: {}",
+                pull_response.text().unwrap_or_default()
+            );
+        }
+        let current = pull_response.text()?;
+        let items = parse_env_items_from_str(&current);
+
+        // Extract just the target scope's items, applying the set.
+        let mut scoped: Vec<EnvFileItem> = Vec::new();
+        let mut in_scope = scope == "application"; // leading section may be implicit
+        let mut scope_seen = false;
+        let mut replaced = false;
+        for item in items {
+            match item {
+                EnvFileItem::SectionHeader(header) => {
+                    in_scope = header_matches_scope(&header, &scope);
+                    if in_scope {
+                        scope_seen = true;
+                        scoped.push(EnvFileItem::SectionHeader(header));
+                    }
+                }
+                EnvFileItem::KeyValue(k, v) => {
+                    if in_scope {
+                        if k == key {
+                            scoped.push(EnvFileItem::KeyValue(k, value.to_string()));
+                            replaced = true;
+                        } else {
+                            scoped.push(EnvFileItem::KeyValue(k, v));
+                        }
+                    }
+                }
+            }
+        }
+        if !scope_seen && scope != "application" {
+            bail!(
+                "Scope '{}' not found in the current configuration. Known scopes appear as '# <name> (id)' section headers in `forklaunch config pull` output.",
+                scope
+            );
+        }
+        if scoped.is_empty() {
+            scoped.push(EnvFileItem::SectionHeader(format!("# {}", scope)));
+        }
+        if !replaced {
+            scoped.push(EnvFileItem::KeyValue(key.to_string(), value.to_string()));
+        }
+
+        let content = reconstruct_env_content(scoped);
+        let push_url = format!("{}/config/push", get_platform_management_api_url());
+        let body = serde_json::json!({
+            "applicationId": app,
+            "region": region,
+            "environment": environment,
+            "content": content
+        });
+        let response =
+            http_client::post(&push_url, body).with_context(|| ERROR_FAILED_TO_SEND_REQUEST)?;
+
+        if response.status().is_success() {
+            log_ok!(
+                stdout,
+                "{} {} in scope '{}' for {} ({})",
+                if replaced { "Updated" } else { "Added" },
+                key,
+                scope,
+                environment,
+                region
+            );
+            log_info!(
+                stdout,
+                "Running tasks keep their existing environment — redeploy to apply."
+            );
+            Ok(())
+        } else {
+            let err_text = response.text()?;
+            bail!("Failed to set variable: {}", err_text);
+        }
+    }
+}

--- a/cli/src/core/env.rs
+++ b/cli/src/core/env.rs
@@ -302,6 +302,12 @@ pub(crate) fn parse_env_file_items(path: &Path) -> Result<Vec<EnvFileItem>> {
     let content = fs::read_to_string(path)
         .with_context(|| format!("Failed to read env file: {}", path.display()))?;
 
+    Ok(parse_env_items_from_str(&content))
+}
+
+/// String-based variant of `parse_env_file_items` for content fetched over
+/// the wire (e.g. `config set` pulling the current scope before merging).
+pub(crate) fn parse_env_items_from_str(content: &str) -> Vec<EnvFileItem> {
     let lines: Vec<&str> = content.lines().collect();
     let mut items: Vec<EnvFileItem> = Vec::new();
     let mut i = 0;
@@ -332,7 +338,7 @@ pub(crate) fn parse_env_file_items(path: &Path) -> Result<Vec<EnvFileItem>> {
         i += 1;
     }
 
-    Ok(items)
+    items
 }
 
 pub(crate) fn load_env_file(path: &Path) -> Result<HashMap<String, String>> {

--- a/cli/src/core/env.rs
+++ b/cli/src/core/env.rs
@@ -262,6 +262,12 @@ pub(crate) fn parse_env_file_items(path: &Path) -> Result<Vec<EnvFileItem>> {
     let content = fs::read_to_string(path)
         .with_context(|| format!("Failed to read env file: {}", path.display()))?;
 
+    Ok(parse_env_items_from_str(&content))
+}
+
+/// String-based variant of `parse_env_file_items` for content fetched over
+/// the wire (e.g. `config set` pulling the current scope before merging).
+pub(crate) fn parse_env_items_from_str(content: &str) -> Vec<EnvFileItem> {
     let lines: Vec<&str> = content.lines().collect();
     let mut items: Vec<EnvFileItem> = Vec::new();
     let mut i = 0;
@@ -292,7 +298,7 @@ pub(crate) fn parse_env_file_items(path: &Path) -> Result<Vec<EnvFileItem>> {
         i += 1;
     }
 
-    Ok(items)
+    items
 }
 
 pub(crate) fn load_env_file(path: &Path) -> Result<HashMap<String, String>> {

--- a/cli/src/deploy/info.rs
+++ b/cli/src/deploy/info.rs
@@ -1,0 +1,162 @@
+use std::io::Write;
+
+use anyhow::{Context, Result, bail};
+use clap::{Arg, ArgMatches, Command};
+use serde::Deserialize;
+use termcolor::{ColorChoice, ColorSpec, StandardStream, WriteColor};
+
+use crate::{
+    CliCommand,
+    constants::{ERROR_FAILED_TO_SEND_REQUEST, get_platform_management_api_url},
+    core::{
+        command::command,
+        http_client,
+        validate::{require_auth, require_integration, require_manifest},
+    },
+};
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DeploymentSummary {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    environment: Option<String>,
+    #[serde(default)]
+    region: Option<String>,
+    #[serde(default)]
+    release_version: Option<String>,
+    #[serde(default)]
+    deployed_by: Option<String>,
+    #[serde(default)]
+    started_at: Option<String>,
+    #[serde(default)]
+    completed_at: Option<String>,
+    #[serde(default)]
+    error_message: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DeploymentListResponse {
+    #[serde(default)]
+    deployments: Vec<DeploymentSummary>,
+}
+
+fn print_field(out: &mut StandardStream, label: &str, value: &Option<String>) -> Result<()> {
+    if let Some(v) = value {
+        out.set_color(ColorSpec::new().set_bold(true))?;
+        write!(out, "  {:<12}", label)?;
+        out.reset()?;
+        writeln!(out, "{}", v)?;
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+pub(crate) struct InfoCommand;
+
+impl InfoCommand {
+    pub(crate) fn new() -> Self {
+        Self {}
+    }
+}
+
+impl CliCommand for InfoCommand {
+    fn command(&self) -> Command {
+        command(
+            "info",
+            "Show deployment status (latest per environment/region, or one by id)",
+        )
+        .arg(
+            Arg::new("deployment")
+                .long("deployment")
+                .short('d')
+                .help("Deployment id to show"),
+        )
+        .arg(
+            Arg::new("environment")
+                .long("environment")
+                .short('e')
+                .help("Filter to an environment"),
+        )
+        .arg(
+            Arg::new("region")
+                .long("region")
+                .short('r')
+                .help("Filter to a region"),
+        )
+        .arg(
+            Arg::new("base_path")
+                .long("path")
+                .short('p')
+                .help("Path to application root (optional)"),
+        )
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        let _token = require_auth()?;
+        let (_app_root, manifest) = require_manifest(matches)?;
+        let app = require_integration(&manifest)?;
+        let mut stdout = StandardStream::stdout(ColorChoice::Always);
+
+        let mut url = format!(
+            "{}/deployments/?applicationId={}&limit=25",
+            get_platform_management_api_url(),
+            app
+        );
+        if let Some(environment) = matches.get_one::<String>("environment") {
+            url.push_str(&format!("&environment={}", environment));
+        }
+        if let Some(region) = matches.get_one::<String>("region") {
+            url.push_str(&format!("&region={}", region));
+        }
+
+        let response = http_client::get(&url).with_context(|| ERROR_FAILED_TO_SEND_REQUEST)?;
+        if !response.status().is_success() {
+            bail!(
+                "Failed to list deployments: {}",
+                response.text().unwrap_or_default()
+            );
+        }
+        let list: DeploymentListResponse = response
+            .json()
+            .with_context(|| "Failed to parse deployment list response")?;
+
+        let deployments: Vec<&DeploymentSummary> =
+            match matches.get_one::<String>("deployment") {
+                Some(id) => {
+                    let Some(found) = list
+                        .deployments
+                        .iter()
+                        .find(|d| d.id.as_deref() == Some(id))
+                    else {
+                        bail!("Deployment '{}' not found in the latest 25.", id);
+                    };
+                    vec![found]
+                }
+                None => list.deployments.iter().take(5).collect(),
+            };
+
+        if deployments.is_empty() {
+            log_info!(stdout, "No deployments found for the given filters.");
+            return Ok(());
+        }
+
+        for deployment in deployments {
+            writeln!(stdout)?;
+            print_field(&mut stdout, "Id:", &deployment.id)?;
+            print_field(&mut stdout, "Status:", &deployment.status)?;
+            print_field(&mut stdout, "Env:", &deployment.environment)?;
+            print_field(&mut stdout, "Region:", &deployment.region)?;
+            print_field(&mut stdout, "Release:", &deployment.release_version)?;
+            print_field(&mut stdout, "By:", &deployment.deployed_by)?;
+            print_field(&mut stdout, "Started:", &deployment.started_at)?;
+            print_field(&mut stdout, "Completed:", &deployment.completed_at)?;
+            print_field(&mut stdout, "Error:", &deployment.error_message)?;
+        }
+
+        Ok(())
+    }
+}

--- a/cli/src/deploy/info.rs
+++ b/cli/src/deploy/info.rs
@@ -101,50 +101,65 @@ impl CliCommand for InfoCommand {
         let app = require_integration(&manifest)?;
         let mut stdout = StandardStream::stdout(ColorChoice::Always);
 
-        let mut url = format!(
-            "{}/deployments/?applicationId={}&limit=25",
-            get_platform_management_api_url(),
-            app
-        );
-        if let Some(environment) = matches.get_one::<String>("environment") {
-            url.push_str(&format!("&environment={}", environment));
-        }
-        if let Some(region) = matches.get_one::<String>("region") {
-            url.push_str(&format!("&region={}", region));
-        }
-
-        let response = http_client::get(&url).with_context(|| ERROR_FAILED_TO_SEND_REQUEST)?;
-        if !response.status().is_success() {
-            bail!(
-                "Failed to list deployments: {}",
-                response.text().unwrap_or_default()
-            );
-        }
-        let list: DeploymentListResponse = response
-            .json()
-            .with_context(|| "Failed to parse deployment list response")?;
-
-        let deployments: Vec<&DeploymentSummary> =
-            match matches.get_one::<String>("deployment") {
-                Some(id) => {
-                    let Some(found) = list
-                        .deployments
-                        .iter()
-                        .find(|d| d.id.as_deref() == Some(id))
-                    else {
-                        bail!("Deployment '{}' not found in the latest 25.", id);
-                    };
-                    vec![found]
+        // When an explicit deployment id is given, fetch it directly by id so we
+        // never miss deployments that fall outside a capped list page.
+        let owned: Vec<DeploymentSummary> = match matches.get_one::<String>("deployment") {
+            Some(id) => {
+                let url = format!(
+                    "{}/deployments/{}",
+                    get_platform_management_api_url(),
+                    id
+                );
+                let response =
+                    http_client::get(&url).with_context(|| ERROR_FAILED_TO_SEND_REQUEST)?;
+                if response.status().as_u16() == 404 {
+                    bail!("Deployment '{}' not found.", id);
                 }
-                None => list.deployments.iter().take(5).collect(),
-            };
+                if !response.status().is_success() {
+                    bail!(
+                        "Failed to get deployment: {}",
+                        response.text().unwrap_or_default()
+                    );
+                }
+                let deployment: DeploymentSummary = response
+                    .json()
+                    .with_context(|| "Failed to parse deployment response")?;
+                vec![deployment]
+            }
+            None => {
+                let mut url = format!(
+                    "{}/deployments/?applicationId={}&limit=25",
+                    get_platform_management_api_url(),
+                    app
+                );
+                if let Some(environment) = matches.get_one::<String>("environment") {
+                    url.push_str(&format!("&environment={}", environment));
+                }
+                if let Some(region) = matches.get_one::<String>("region") {
+                    url.push_str(&format!("&region={}", region));
+                }
 
-        if deployments.is_empty() {
+                let response =
+                    http_client::get(&url).with_context(|| ERROR_FAILED_TO_SEND_REQUEST)?;
+                if !response.status().is_success() {
+                    bail!(
+                        "Failed to list deployments: {}",
+                        response.text().unwrap_or_default()
+                    );
+                }
+                let list: DeploymentListResponse = response
+                    .json()
+                    .with_context(|| "Failed to parse deployment list response")?;
+                list.deployments.into_iter().take(5).collect()
+            }
+        };
+
+        if owned.is_empty() {
             log_info!(stdout, "No deployments found for the given filters.");
             return Ok(());
         }
 
-        for deployment in deployments {
+        for deployment in &owned {
             writeln!(stdout)?;
             print_field(&mut stdout, "Id:", &deployment.id)?;
             print_field(&mut stdout, "Status:", &deployment.status)?;

--- a/cli/src/deploy/mod.rs
+++ b/cli/src/deploy/mod.rs
@@ -2,17 +2,20 @@ use anyhow::Result;
 use clap::{ArgMatches, Command};
 use create::CreateCommand;
 use destroy::DestroyCommand;
+use info::InfoCommand;
 
 use crate::{CliCommand, core::command::command};
 
 mod create;
 mod destroy;
+mod info;
 pub(crate) mod utils;
 
 #[derive(Debug)]
 pub(crate) struct DeployCommand {
     create: CreateCommand,
     destroy: DestroyCommand,
+    info: InfoCommand,
 }
 
 impl DeployCommand {
@@ -20,6 +23,7 @@ impl DeployCommand {
         Self {
             create: CreateCommand::new(),
             destroy: DestroyCommand::new(),
+            info: InfoCommand::new(),
         }
     }
 }
@@ -29,12 +33,14 @@ impl CliCommand for DeployCommand {
         command("deploy", "Deployment management")
             .subcommand(self.create.command())
             .subcommand(self.destroy.command())
+            .subcommand(self.info.command())
     }
 
     fn handler(&self, matches: &ArgMatches) -> Result<()> {
         match matches.subcommand() {
             Some(("create", sub_matches)) => self.create.handler(sub_matches),
             Some(("destroy", sub_matches)) => self.destroy.handler(sub_matches),
+            Some(("info", sub_matches)) => self.info.handler(sub_matches),
             // Default to create for convenience - preserving existing behavior but usually nice to be explicit
             None => self.create.handler(matches),
             _ => unreachable!(),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -9,6 +9,7 @@ use deploy::DeployCommand;
 use eject::EjectCommand;
 use environment::EnvironmentCommand;
 use init::InitCommand;
+use app::AppCommand;
 use integrate::IntegrateCommand;
 use login::LoginCommand;
 use logout::LogoutCommand;
@@ -23,6 +24,7 @@ use crate::sdk::SdkCommand;
 mod constants;
 #[macro_use]
 mod core;
+mod app;
 mod change;
 mod compliance;
 mod config;
@@ -59,6 +61,7 @@ fn main() -> Result<()> {
     let deploy = DeployCommand::new();
     let eject = EjectCommand::new();
     let environment = EnvironmentCommand::new();
+    let app = AppCommand::new();
     let integrate = IntegrateCommand::new();
     let login = LoginCommand::new();
     let logout = LogoutCommand::new();
@@ -73,6 +76,7 @@ fn main() -> Result<()> {
         .propagate_version(true)
         .arg_required_else_help(true)
         .subcommand_required(true)
+        .subcommand(app.command())
         .subcommand(init.command())
         .subcommand(delete.command())
         .subcommand(change.command())

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -13,6 +13,7 @@ use environment::EnvironmentCommand;
 use github::GithubCommand;
 use infra::InfraCommand;
 use init::InitCommand;
+use app::AppCommand;
 use integrate::IntegrateCommand;
 use login::LoginCommand;
 use logout::LogoutCommand;
@@ -29,6 +30,7 @@ mod analyze;
 mod constants;
 #[macro_use]
 mod core;
+mod app;
 mod change;
 mod compliance;
 mod config;
@@ -73,6 +75,7 @@ fn main() -> Result<()> {
     let environment = EnvironmentCommand::new();
     let infra = InfraCommand::new();
     let github = GithubCommand::new();
+    let app = AppCommand::new();
     let integrate = IntegrateCommand::new();
     let login = LoginCommand::new();
     let logout = LogoutCommand::new();
@@ -88,6 +91,7 @@ fn main() -> Result<()> {
         .propagate_version(true)
         .arg_required_else_help(true)
         .subcommand_required(true)
+        .subcommand(app.command())
         .subcommand(init.command())
         .subcommand(analyze.command())
         .subcommand(delete.command())
@@ -118,6 +122,7 @@ fn main() -> Result<()> {
     }
 
     let result = match matches.subcommand() {
+        Some(("app", sub_matches)) => app.handler(sub_matches),
         Some(("init", sub_matches)) => init.handler(sub_matches),
         Some(("analyze", sub_matches)) => analyze.handler(sub_matches),
         Some(("change", sub_matches)) => change.handler(sub_matches),

--- a/cli/src/release/info.rs
+++ b/cli/src/release/info.rs
@@ -1,0 +1,150 @@
+use std::io::Write;
+
+use anyhow::{Context, Result, bail};
+use clap::{Arg, ArgMatches, Command};
+use serde::Deserialize;
+use termcolor::{ColorChoice, ColorSpec, StandardStream, WriteColor};
+
+use crate::{
+    CliCommand,
+    constants::{ERROR_FAILED_TO_SEND_REQUEST, get_platform_management_api_url},
+    core::{
+        command::command,
+        http_client,
+        validate::{require_auth, require_integration, require_manifest},
+    },
+};
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ReleaseSummary {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    version: Option<String>,
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    created_at: Option<String>,
+    #[serde(default)]
+    git_commit: Option<String>,
+    #[serde(default)]
+    git_branch: Option<String>,
+    #[serde(default)]
+    released_by: Option<String>,
+    #[serde(default)]
+    notes: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReleaseListResponse {
+    #[serde(default)]
+    releases: Vec<ReleaseSummary>,
+}
+
+fn print_field(out: &mut StandardStream, label: &str, value: &Option<String>) -> Result<()> {
+    if let Some(v) = value {
+        out.set_color(ColorSpec::new().set_bold(true))?;
+        write!(out, "  {:<12}", label)?;
+        out.reset()?;
+        writeln!(out, "{}", v)?;
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+pub(crate) struct InfoCommand;
+
+impl InfoCommand {
+    pub(crate) fn new() -> Self {
+        Self {}
+    }
+}
+
+impl CliCommand for InfoCommand {
+    fn command(&self) -> Command {
+        command("info", "Show details for a release (or the most recent releases)")
+            .arg(
+                Arg::new("version")
+                    .long("version")
+                    .short('v')
+                    .help("Release version to show (omit to list the 5 most recent)"),
+            )
+            .arg(
+                Arg::new("base_path")
+                    .long("path")
+                    .short('p')
+                    .help("Path to application root (optional)"),
+            )
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        let _token = require_auth()?;
+        let (_app_root, manifest) = require_manifest(matches)?;
+        let app = require_integration(&manifest)?;
+        let mut stdout = StandardStream::stdout(ColorChoice::Always);
+
+        let url = format!(
+            "{}/releases/?applicationId={}&limit=50",
+            get_platform_management_api_url(),
+            app
+        );
+        let response = http_client::get(&url).with_context(|| ERROR_FAILED_TO_SEND_REQUEST)?;
+        if !response.status().is_success() {
+            bail!(
+                "Failed to list releases: {}",
+                response.text().unwrap_or_default()
+            );
+        }
+        let list: ReleaseListResponse = response
+            .json()
+            .with_context(|| "Failed to parse release list response")?;
+
+        match matches.get_one::<String>("version") {
+            Some(version) => {
+                let Some(release) = list
+                    .releases
+                    .iter()
+                    .find(|r| r.version.as_deref() == Some(version))
+                else {
+                    bail!(
+                        "Release '{}' not found. Known versions: {}",
+                        version,
+                        list.releases
+                            .iter()
+                            .filter_map(|r| r.version.clone())
+                            .take(10)
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    );
+                };
+                writeln!(stdout)?;
+                print_field(&mut stdout, "Version:", &release.version)?;
+                print_field(&mut stdout, "Status:", &release.status)?;
+                print_field(&mut stdout, "Created:", &release.created_at)?;
+                print_field(&mut stdout, "Commit:", &release.git_commit)?;
+                print_field(&mut stdout, "Branch:", &release.git_branch)?;
+                print_field(&mut stdout, "By:", &release.released_by)?;
+                print_field(&mut stdout, "Notes:", &release.notes)?;
+                print_field(&mut stdout, "Id:", &release.id)?;
+            }
+            None => {
+                writeln!(stdout)?;
+                for release in list.releases.iter().take(5) {
+                    writeln!(
+                        stdout,
+                        "  {}  {}  {}",
+                        release.version.clone().unwrap_or_else(|| "?".into()),
+                        release.status.clone().unwrap_or_default(),
+                        release.created_at.clone().unwrap_or_default()
+                    )?;
+                }
+                if list.releases.is_empty() {
+                    log_info!(stdout, "No releases yet. Create one with: forklaunch release create --version <version>");
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/cli/src/release/mod.rs
+++ b/cli/src/release/mod.rs
@@ -1,10 +1,12 @@
 use anyhow::Result;
 use clap::{ArgMatches, Command};
 use create::CreateCommand;
+use info::InfoCommand;
 
 use crate::{CliCommand, core::command::command};
 
 mod create;
+mod info;
 mod git;
 mod manifest_generator;
 pub(crate) mod s3_upload;
@@ -12,24 +14,29 @@ pub(crate) mod s3_upload;
 #[derive(Debug)]
 pub(crate) struct ReleaseCommand {
     create: CreateCommand,
+    info: InfoCommand,
 }
 
 impl ReleaseCommand {
     pub(crate) fn new() -> Self {
         Self {
             create: CreateCommand::new(),
+            info: InfoCommand::new(),
         }
     }
 }
 
 impl CliCommand for ReleaseCommand {
     fn command(&self) -> Command {
-        command("release", "Release management").subcommand(self.create.command())
+        command("release", "Release management")
+            .subcommand(self.create.command())
+            .subcommand(self.info.command())
     }
 
     fn handler(&self, matches: &ArgMatches) -> Result<()> {
         match matches.subcommand() {
             Some(("create", sub_matches)) => self.create.handler(sub_matches),
+            Some(("info", sub_matches)) => self.info.handler(sub_matches),
             // Default to create for convenience
             None => self.create.handler(matches),
             _ => unreachable!(),


### PR DESCRIPTION
## Summary

Application-lifecycle ergonomics surfaced by a full end-to-end staging exercise (every one of these maps to real friction hit while driving the platform purely from the CLI/API):

- **`fl app create [-n name] [-D desc] [--no-integrate]`** — creates the platform application (owner identity resolved from `/user-profile/me`) and integrates the local project in one step. Previously: manual `POST /applications` + `fl integrate --app <id>`.
- **`fl config set KEY=VALUE -e <env> -r <region> [-s <service>]`** — safe single-variable upsert. The config push endpoint is **authoritative per scope** (pushing a 1-var file clears every other var in that scope — this emptied ~106 application-scope vars on staging before being restored from a snapshot). `set` round-trips the full current scope, and rejects values that look like another `KEY=VALUE` assignment (the paste-error class that produced `S3_BUCKET=S3_BUCKET=…`).
- **`fl release info [--version <v>]`** / **`fl deploy info [-d id | -e env -r region]`** — read-only status without opening the dashboard.
- **`fl compliance audit` scorecard** — five dimensions (compliance, security, scale, observability, governance). Server-provided `dimensionScores` win when present (platform-side computation ships separately); otherwise derived client-side from finding categories. Dimensions with no audit signals yet are labeled rather than silently scored.
- `core/env`: `parse_env_items_from_str` (string-based variant; path fn delegates).

Note: `fl deploy destroy -e <env> -r <region>` already exists and covers environment/region-scoped destroys — no changes needed there.

## Tests
`cargo test`: 266 passed. `cargo build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `app create` to create platform applications, optionally integrate projects, and update local configuration.
  * Added `config set` to update scoped application or service variables.
  * Added `deploy info` to view deployment status and details.
  * Added `release info` to view recent releases or version-specific details.
  * Enhanced audit results with a Scorecard showing risk dimensions and missing signals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->