### PR TITLE
feat(cli): plumb privileged container flag through manifest → release manifest

### DIFF
--- a/cli/src/change/service.rs
+++ b/cli/src/change/service.rs
@@ -896,6 +896,7 @@ export interface {pascal_case_name}EventRecord extends WorkerEventEntity {{
                 project.metadata = Some(ProjectMetadata {
                     r#type: Some(worker_type.to_string()),
                     hosting_type: None,
+                    privileged: None,
                 });
             }
         }

--- a/cli/src/core/manifest.rs
+++ b/cli/src/core/manifest.rs
@@ -122,6 +122,16 @@ pub(crate) struct ProjectMetadata {
     /// when absent. Allowed: "ecs-fargate" | "ecs-ec2".
     #[serde(rename = "hostingType", alias = "hosting_type", default, skip_serializing_if = "Option::is_none")]
     pub(crate) hosting_type: Option<String>,
+    /// Run the component's container in privileged mode. Required for nsjail's
+    /// namespace clone in the deploy sandbox; only valid with hostingType
+    /// "ecs-ec2" (Fargate forbids privileged mode). Optional — absent means false.
+    #[serde(
+        rename = "privileged",
+        alias = "privileged",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub(crate) privileged: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Content, Clone)]

--- a/cli/src/core/sync/artifacts.rs
+++ b/cli/src/core/sync/artifacts.rs
@@ -91,6 +91,7 @@ impl ProjectSyncMetadata {
         self.worker_type.map(|wt| ProjectMetadata {
             r#type: Some(wt.to_string()),
             hosting_type: None,
+            privileged: None,
         })
     }
 }

--- a/cli/src/init/worker.rs
+++ b/cli/src/init/worker.rs
@@ -257,6 +257,7 @@ fn add_worker_to_artifacts(
         Some(ProjectMetadata {
             r#type: Some(manifest_data.worker_type_lowercase.clone()),
             hosting_type: None,
+            privileged: None,
         }),
     )
     .with_context(|| ERROR_FAILED_TO_ADD_PROJECT_METADATA_TO_MANIFEST)?;

--- a/cli/src/release/manifest_generator.rs
+++ b/cli/src/release/manifest_generator.rs
@@ -252,6 +252,8 @@ pub(crate) struct ServiceConfig {
     pub health_check: Option<Value>,
     #[serde(rename = "isWorkerService", skip_serializing_if = "Option::is_none")]
     pub is_worker_service: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub privileged: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -285,6 +287,8 @@ pub(crate) struct WorkerConfig {
     pub hosting_type: Option<String>,
     #[serde(rename = "healthCheck", skip_serializing_if = "Option::is_none")]
     pub health_check: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub privileged: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -498,6 +502,7 @@ pub(crate) fn generate_release_manifest(
                         .and_then(|m| m.hosting_type.clone()),
                     health_check: None,
                     is_worker_service: None,
+                    privileged: project.metadata.as_ref().and_then(|m| m.privileged),
                 }),
                 build_context: if app_root
                     .join(&manifest.modules_path)
@@ -636,6 +641,7 @@ pub(crate) fn generate_release_manifest(
                         .and_then(|m| m.hosting_type.clone()),
                     health_check: None,
                     is_worker_service: Some(true),
+                    privileged: project.metadata.as_ref().and_then(|m| m.privileged),
                 }),
                 build_context: if app_root
                     .join(&manifest.modules_path)
@@ -689,6 +695,7 @@ pub(crate) fn generate_release_manifest(
                     .as_ref()
                     .and_then(|m| m.hosting_type.clone()),
                 health_check: None,
+                privileged: project.metadata.as_ref().and_then(|m| m.privileged),
             };
 
             services.push(ServiceDefinition {
@@ -1099,6 +1106,7 @@ mod tests {
             hosting_type: Some("ecs-ec2".to_string()),
             health_check: None,
             is_worker_service: None,
+            privileged: None,
         };
         let json = serde_json::to_value(&config).unwrap();
         assert_eq!(json["hostingType"], "ecs-ec2");
@@ -1117,6 +1125,7 @@ mod tests {
             hosting_type: None,
             health_check: None,
             is_worker_service: None,
+            privileged: None,
         };
         let json = serde_json::to_value(&config).unwrap();
         assert!(
@@ -1141,9 +1150,57 @@ mod tests {
             instance_size: None,
             hosting_type: Some("ecs-ec2".to_string()),
             health_check: None,
+            privileged: None,
         };
         let json = serde_json::to_value(&config).unwrap();
         assert_eq!(json["hostingType"], "ecs-ec2");
+    }
+
+    #[test]
+    fn test_worker_config_privileged_round_trips() {
+        let config = WorkerConfig {
+            config_type: ConfigType::Worker,
+            worker_type: WorkerType::BullMQ,
+            concurrency: None,
+            timeout: None,
+            max_retries: None,
+            queue: None,
+            priority: None,
+            dead_letter_queue: None,
+            additional: None,
+            runtime_dependencies: None,
+            instance_size: None,
+            hosting_type: Some("ecs-ec2".to_string()),
+            health_check: None,
+            privileged: Some(true),
+        };
+        let json = serde_json::to_value(&config).unwrap();
+        assert_eq!(json["privileged"], true);
+    }
+
+    #[test]
+    fn test_worker_config_privileged_omitted_when_absent() {
+        let config = WorkerConfig {
+            config_type: ConfigType::Worker,
+            worker_type: WorkerType::BullMQ,
+            concurrency: None,
+            timeout: None,
+            max_retries: None,
+            queue: None,
+            priority: None,
+            dead_letter_queue: None,
+            additional: None,
+            runtime_dependencies: None,
+            instance_size: None,
+            hosting_type: None,
+            health_check: None,
+            privileged: None,
+        };
+        let json = serde_json::to_value(&config).unwrap();
+        assert!(
+            json.get("privileged").is_none(),
+            "privileged should be omitted when None"
+        );
     }
 
     #[test]
@@ -1162,6 +1219,7 @@ mod tests {
             instance_size: None,
             hosting_type: None,
             health_check: None,
+            privileged: None,
         };
         let json = serde_json::to_value(&config).unwrap();
         assert!(


### PR DESCRIPTION
## What

Adds an optional `privileged` boolean to a project's `[projects.metadata]` in `manifest.toml`, plumbed into each service/worker `config` object in the generated `release-manifest.json` — mirroring the existing `hostingType` plumbing exactly.

```toml
[projects.metadata]
type = "bullmq"
privileged = true
```

## Why

The deployment-agent-worker reads `config.privileged` to emit a **privileged** ECS container (`pulumi-generator.service.ts` `resolvePrivileged`). A privileged container is required for **nsjail's namespace `clone()`** in the deploy sandbox — only valid on `ecs-ec2` (Fargate forbids privileged mode).

Before this, there was **no way to opt a component into privileged mode**: the worker's `infraOverrides.privileged` is never populated (no DB column / no controller mapping), and `worker.config.privileged` was never emitted into the release manifest. So the EC2 sandbox could never actually run.

## Changes
- `core/manifest.rs` — `privileged: Option<bool>` on `ProjectMetadata`
- `release/manifest_generator.rs` — `privileged` on `ServiceConfig` + `WorkerConfig`, populated from `project.metadata` at all three construction sites
- `init/worker.rs`, `change/service.rs`, `core/sync/artifacts.rs` — `privileged: None` at the remaining `ProjectMetadata` construction sites
- tests — `privileged` round-trip + omitted-when-absent

## Notes
- Pure additive, serde `skip_serializing_if = Option::is_none` (absent ⇒ unchanged output).
- `cargo check` + `cargo test` green.
- ⚠️ Touches `manifest_generator.rs`, same file as #189 — whichever lands second needs a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an optional `privileged` setting in project and release manifests.
  * Generated release manifests now carry this setting for service and worker components when provided.

* **Bug Fixes**
  * Manifest output now omits `privileged` when unset, while preserving it correctly when enabled.
  * Updated metadata handling so the new setting is consistently included across generated project artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->