### PR TITLE
Add Inventory catalog entity

### DIFF
--- a/blueprint/ecommerce-stripe/api/controllers/catalogImport.controller.ts
+++ b/blueprint/ecommerce-stripe/api/controllers/catalogImport.controller.ts
@@ -1,0 +1,163 @@
+import { NotFoundError } from '@mikro-orm/core';
+import {
+  array,
+  boolean,
+  handlers,
+  number,
+  optional,
+  record,
+  schemaValidator,
+  string
+} from '../../schema';
+import { ci, tokens } from '../../bootstrapper';
+
+const openTelemetryCollector = ci.resolve(tokens.OtelCollector);
+const productServiceFactory = ci.scopedResolver(tokens.ProductService);
+const variantServiceFactory = ci.scopedResolver(tokens.VariantService);
+const inventoryServiceFactory = ci.scopedResolver(tokens.InventoryService);
+const HMAC_SECRET_KEY = ci.resolve(tokens.HMAC_SECRET_KEY);
+
+const ImportOptionSchema = {
+  name: string,
+  isPackQuantity: boolean,
+  values: array(string)
+};
+
+const ImportImageSchema = {
+  src: string,
+  position: number
+};
+
+const ImportVariantSchema = {
+  externalId: string,
+  sku: optional(string),
+  title: string,
+  optionValues: optional(record(string, string)),
+  priceCents: number,
+  compareAtPriceCents: optional(number),
+  requiresShipping: optional(boolean),
+  /** Seed stock — no reservation semantics in v1 (ECOM-04). */
+  initialStock: optional(number)
+};
+
+const ImportProductSchema = {
+  externalId: string,
+  handle: string,
+  sourceUrl: optional(string),
+  title: string,
+  descriptionHtml: optional(string),
+  vendor: optional(string),
+  productType: optional(string),
+  tags: optional(array(string)),
+  options: optional(array(ImportOptionSchema)),
+  images: optional(array(ImportImageSchema)),
+  variants: array(ImportVariantSchema)
+};
+
+/**
+ * The bulk catalog-import door — this is the one API surface Guild's
+ * migration/clone tooling loads through (never raw SQL, per the ownership
+ * boundary: we build the import API, Guild builds the tool that calls it).
+ * Idempotent on externalId — re-running an import upserts, never duplicates.
+ */
+export const importCatalog = handlers.post(
+  schemaValidator,
+  '/',
+  {
+    name: 'Import Catalog',
+    access: 'internal',
+    summary: 'Bulk import a normalized product catalog',
+    auth: { hmac: { secretKeys: { default: HMAC_SECRET_KEY } } },
+    body: { products: array(ImportProductSchema) },
+    responses: {
+      200: { productsImported: number, variantsImported: number }
+    }
+  },
+  async (req, res) => {
+    let productsImported = 0;
+    let variantsImported = 0;
+
+    for (const product of req.body.products) {
+      const productService = productServiceFactory();
+      const productFields = {
+        externalId: product.externalId,
+        handle: product.handle,
+        sourceUrl: product.sourceUrl,
+        title: product.title,
+        descriptionHtml: product.descriptionHtml,
+        vendor: product.vendor,
+        productType: product.productType,
+        tags: product.tags,
+        options: product.options,
+        images: product.images
+      };
+
+      // Upsert by externalId — a re-run of the same import (retry, partial
+      // failure recovery) must update the existing row, never duplicate it.
+      let importedProduct;
+      try {
+        const existing = await productService.getProductByExternalId({
+          externalId: product.externalId
+        });
+        importedProduct = await productService.updateProduct({
+          id: existing.id,
+          ...productFields
+        });
+      } catch (err) {
+        if (!(err instanceof NotFoundError)) throw err;
+        importedProduct = await productService.createProduct(productFields);
+      }
+      productsImported++;
+
+      for (const variant of product.variants) {
+        const variantService = variantServiceFactory();
+        const variantFields = {
+          productId: importedProduct.id,
+          externalId: variant.externalId,
+          sku: variant.sku,
+          title: variant.title,
+          optionValues: variant.optionValues,
+          priceCents: variant.priceCents,
+          compareAtPriceCents: variant.compareAtPriceCents,
+          requiresShipping: variant.requiresShipping
+        };
+
+        let importedVariant;
+        try {
+          const existingVariant = await variantService.getVariantByExternalId({
+            externalId: variant.externalId
+          });
+          importedVariant = await variantService.updateVariant({
+            id: existingVariant.id,
+            ...variantFields
+          });
+        } catch (err) {
+          if (!(err instanceof NotFoundError)) throw err;
+          importedVariant = await variantService.createVariant(variantFields);
+        }
+
+        // Inventory is seeded once at first import; re-imports never reset
+        // live stock counts back to the source's snapshot.
+        const inventoryService = inventoryServiceFactory();
+        try {
+          await inventoryService.getInventory({
+            variantId: importedVariant.id
+          });
+        } catch (err) {
+          if (!(err instanceof NotFoundError)) throw err;
+          await inventoryService.createInventory({
+            variantId: importedVariant.id,
+            stock: variant.initialStock ?? 0
+          });
+        }
+        variantsImported++;
+      }
+    }
+
+    openTelemetryCollector.info('Catalog import complete', {
+      productsImported,
+      variantsImported
+    });
+    res.status(200).json({ productsImported, variantsImported });
+  }
+);

--- a/blueprint/ecommerce-stripe/api/controllers/catalogImport.controller.ts
+++ b/blueprint/ecommerce-stripe/api/controllers/catalogImport.controller.ts
@@ -1,14 +1,6 @@
 import { NotFoundError } from '@mikro-orm/core';
-import {
-  array,
-  boolean,
-  handlers,
-  number,
-  optional,
-  record,
-  schemaValidator,
-  string
-} from '../../schema';
+import { array, handlers, number, schemaValidator } from '../../schema';
+import { ImportProductSchema } from '../../domain/schemas/catalogImport.schema';
 import { ci, tokens } from '../../bootstrapper';
 
 const openTelemetryCollector = ci.resolve(tokens.OtelCollector);
@@ -16,43 +8,6 @@ const productServiceFactory = ci.scopedResolver(tokens.ProductService);
 const variantServiceFactory = ci.scopedResolver(tokens.VariantService);
 const inventoryServiceFactory = ci.scopedResolver(tokens.InventoryService);
 const HMAC_SECRET_KEY = ci.resolve(tokens.HMAC_SECRET_KEY);
-
-const ImportOptionSchema = {
-  name: string,
-  isPackQuantity: boolean,
-  values: array(string)
-};
-
-const ImportImageSchema = {
-  src: string,
-  position: number
-};
-
-const ImportVariantSchema = {
-  externalId: string,
-  sku: optional(string),
-  title: string,
-  optionValues: optional(record(string, string)),
-  priceCents: number,
-  compareAtPriceCents: optional(number),
-  requiresShipping: optional(boolean),
-  /** Seed stock — no reservation semantics in v1 (ECOM-04). */
-  initialStock: optional(number)
-};
-
-const ImportProductSchema = {
-  externalId: string,
-  handle: string,
-  sourceUrl: optional(string),
-  title: string,
-  descriptionHtml: optional(string),
-  vendor: optional(string),
-  productType: optional(string),
-  tags: optional(array(string)),
-  options: optional(array(ImportOptionSchema)),
-  images: optional(array(ImportImageSchema)),
-  variants: array(ImportVariantSchema)
-};
 
 /**
  * The bulk catalog-import door — this is the one API surface Guild's

--- a/blueprint/ecommerce-stripe/api/controllers/index.ts
+++ b/blueprint/ecommerce-stripe/api/controllers/index.ts
@@ -1,2 +1,3 @@
+export * from './inventory.controller';
 export * from './variant.controller';
 // Remaining controllers are added incrementally as each PR lands.

--- a/blueprint/ecommerce-stripe/api/controllers/index.ts
+++ b/blueprint/ecommerce-stripe/api/controllers/index.ts
@@ -1,3 +1,5 @@
+export * from './catalogImport.controller';
 export * from './inventory.controller';
+export * from './product.controller';
 export * from './variant.controller';
 // Remaining controllers are added incrementally as each PR lands.

--- a/blueprint/ecommerce-stripe/api/controllers/index.ts
+++ b/blueprint/ecommerce-stripe/api/controllers/index.ts
@@ -2,4 +2,3 @@ export * from './catalogImport.controller';
 export * from './inventory.controller';
 export * from './product.controller';
 export * from './variant.controller';
-// Remaining controllers are added incrementally as each PR lands.

--- a/blueprint/ecommerce-stripe/api/controllers/inventory.controller.ts
+++ b/blueprint/ecommerce-stripe/api/controllers/inventory.controller.ts
@@ -1,0 +1,64 @@
+import {
+  boolean,
+  handlers,
+  number,
+  schemaValidator,
+  string
+} from '../../schema';
+import { ci, tokens } from '../../bootstrapper';
+import { InventoryMapper } from '../../domain/mappers/inventory.mappers';
+
+const serviceFactory = ci.scopedResolver(tokens.InventoryService);
+const HMAC_SECRET_KEY = ci.resolve(tokens.HMAC_SECRET_KEY);
+
+export const getInventory = handlers.get(
+  schemaValidator,
+  '/:variantId',
+  {
+    name: 'Get Inventory',
+    access: 'internal',
+    summary: 'Get inventory for a variant',
+    auth: { hmac: { secretKeys: { default: HMAC_SECRET_KEY } } },
+    params: { variantId: string },
+    responses: { 200: InventoryMapper.schema }
+  },
+  async (req, res) => {
+    res.status(200).json(await serviceFactory().getInventory(req.params));
+  }
+);
+
+/** Manual stock adjustment (ECOM-04) — guards against oversell at the service layer. */
+export const adjustStock = handlers.put(
+  schemaValidator,
+  '/adjust',
+  {
+    name: 'Adjust Stock',
+    access: 'internal',
+    summary: 'Adjust stock for a variant',
+    auth: { hmac: { secretKeys: { default: HMAC_SECRET_KEY } } },
+    body: { variantId: string, delta: number },
+    responses: { 200: InventoryMapper.schema }
+  },
+  async (req, res) => {
+    res.status(200).json(await serviceFactory().adjustStock(req.body));
+  }
+);
+
+/** The synchronous "in stock?" check checkout depends on. */
+export const checkStock = handlers.post(
+  schemaValidator,
+  '/check',
+  {
+    name: 'Check Stock',
+    access: 'internal',
+    summary: 'Check whether requested quantity is available',
+    auth: { hmac: { secretKeys: { default: HMAC_SECRET_KEY } } },
+    body: { variantId: string, requested: number },
+    responses: {
+      200: { variantId: string, available: boolean, stock: number }
+    }
+  },
+  async (req, res) => {
+    res.status(200).json(await serviceFactory().checkStock(req.body));
+  }
+);

--- a/blueprint/ecommerce-stripe/api/controllers/inventory.controller.ts
+++ b/blueprint/ecommerce-stripe/api/controllers/inventory.controller.ts
@@ -27,7 +27,7 @@ export const getInventory = handlers.get(
   }
 );
 
-/** Manual stock adjustment (ECOM-04) — guards against oversell at the service layer. */
+/** Manual stock adjustment — guards against oversell at the service layer. */
 export const adjustStock = handlers.put(
   schemaValidator,
   '/adjust',

--- a/blueprint/ecommerce-stripe/api/controllers/product.controller.ts
+++ b/blueprint/ecommerce-stripe/api/controllers/product.controller.ts
@@ -1,13 +1,5 @@
-import {
-  array,
-  boolean,
-  handlers,
-  IdSchema,
-  number,
-  optional,
-  schemaValidator,
-  string
-} from '../../schema';
+import { array, handlers, IdSchema, schemaValidator, string } from '../../schema';
+import { ProductSearchQuerySchema } from '../../domain/schemas/productSearch.schema';
 import { ci, tokens } from '../../bootstrapper';
 import {
   CreateProductMapper,
@@ -20,16 +12,6 @@ const serviceFactory = ci.scopedResolver(tokens.ProductService);
 const variantServiceFactory = ci.scopedResolver(tokens.VariantService);
 const inventoryServiceFactory = ci.scopedResolver(tokens.InventoryService);
 const HMAC_SECRET_KEY = ci.resolve(tokens.HMAC_SECRET_KEY);
-
-const ProductSearchQuerySchema = {
-  ids: optional(array(string)),
-  title: optional(string),
-  minPriceCents: optional(number),
-  maxPriceCents: optional(number),
-  inStock: optional(boolean),
-  optionName: optional(string),
-  optionValue: optional(string)
-};
 
 export const createProduct = handlers.post(
   schemaValidator,
@@ -170,7 +152,11 @@ export const listProducts = handlers.get(
           (v) => v.optionValues?.[optionName] === optionValue
         );
       }
-      if (inStock) {
+      // `!= null`, not truthiness: `inStock=false` is a real filter for
+      // out-of-stock variants. Testing `if (inStock)` skipped the check
+      // entirely on `false`, so the endpoint returned variants regardless of
+      // stock while implying it had filtered them.
+      if (inStock != null) {
         const stockChecks = await Promise.all(
           candidateVariants.map(async (v) => {
             try {
@@ -184,7 +170,9 @@ export const listProducts = handlers.get(
             }
           })
         );
-        candidateVariants = candidateVariants.filter((_, i) => stockChecks[i]);
+        candidateVariants = candidateVariants.filter(
+          (_, i) => stockChecks[i] === inStock
+        );
       }
 
       const candidateProductIds = [

--- a/blueprint/ecommerce-stripe/api/controllers/product.controller.ts
+++ b/blueprint/ecommerce-stripe/api/controllers/product.controller.ts
@@ -1,0 +1,205 @@
+import {
+  array,
+  boolean,
+  handlers,
+  IdSchema,
+  number,
+  optional,
+  schemaValidator,
+  string
+} from '../../schema';
+import { ci, tokens } from '../../bootstrapper';
+import {
+  CreateProductMapper,
+  ProductMapper,
+  UpdateProductMapper
+} from '../../domain/mappers/product.mappers';
+
+const openTelemetryCollector = ci.resolve(tokens.OtelCollector);
+const serviceFactory = ci.scopedResolver(tokens.ProductService);
+const variantServiceFactory = ci.scopedResolver(tokens.VariantService);
+const inventoryServiceFactory = ci.scopedResolver(tokens.InventoryService);
+const HMAC_SECRET_KEY = ci.resolve(tokens.HMAC_SECRET_KEY);
+
+const ProductSearchQuerySchema = {
+  ids: optional(array(string)),
+  title: optional(string),
+  minPriceCents: optional(number),
+  maxPriceCents: optional(number),
+  inStock: optional(boolean),
+  optionName: optional(string),
+  optionValue: optional(string)
+};
+
+export const createProduct = handlers.post(
+  schemaValidator,
+  '/',
+  {
+    name: 'Create Product',
+    access: 'internal',
+    summary: 'Create a product',
+    auth: { hmac: { secretKeys: { default: HMAC_SECRET_KEY } } },
+    body: CreateProductMapper.schema,
+    responses: { 200: ProductMapper.schema }
+  },
+  async (req, res) => {
+    openTelemetryCollector.debug('Creating product', req.body);
+    res.status(200).json(await serviceFactory().createProduct(req.body));
+  }
+);
+
+export const getProduct = handlers.get(
+  schemaValidator,
+  '/:id',
+  {
+    name: 'Get Product',
+    access: 'internal',
+    summary: 'Get a product',
+    auth: { hmac: { secretKeys: { default: HMAC_SECRET_KEY } } },
+    params: IdSchema,
+    responses: { 200: ProductMapper.schema }
+  },
+  async (req, res) => {
+    res.status(200).json(await serviceFactory().getProduct(req.params));
+  }
+);
+
+export const getProductByHandle = handlers.get(
+  schemaValidator,
+  '/handle/:handle',
+  {
+    name: 'Get Product By Handle',
+    access: 'internal',
+    summary: 'Get a product by its URL handle',
+    auth: { hmac: { secretKeys: { default: HMAC_SECRET_KEY } } },
+    params: { handle: string },
+    responses: { 200: ProductMapper.schema }
+  },
+  async (req, res) => {
+    res
+      .status(200)
+      .json(await serviceFactory().getProductByHandle(req.params));
+  }
+);
+
+export const updateProduct = handlers.put(
+  schemaValidator,
+  '/',
+  {
+    name: 'Update Product',
+    access: 'internal',
+    summary: 'Update a product',
+    auth: { hmac: { secretKeys: { default: HMAC_SECRET_KEY } } },
+    body: UpdateProductMapper.schema,
+    responses: { 200: ProductMapper.schema }
+  },
+  async (req, res) => {
+    res.status(200).json(await serviceFactory().updateProduct(req.body));
+  }
+);
+
+export const deleteProduct = handlers.delete(
+  schemaValidator,
+  '/:id',
+  {
+    name: 'Delete Product',
+    access: 'internal',
+    summary: 'Delete a product',
+    auth: { hmac: { secretKeys: { default: HMAC_SECRET_KEY } } },
+    params: IdSchema,
+    responses: { 200: string }
+  },
+  async (req, res) => {
+    await serviceFactory().deleteProduct(req.params);
+    res.status(200).send('Deleted product');
+  }
+);
+
+/**
+ * Catalog search/filter (ECOM-03). `ids`/`title` are product-level and
+ * resolved directly by the product service. `minPriceCents`/`maxPriceCents`/
+ * `inStock`/`optionName`+`optionValue` are variant-level — Product itself
+ * carries no price — so they're resolved here by narrowing variants first,
+ * then constraining the product query to the productIds that survive.
+ */
+export const listProducts = handlers.get(
+  schemaValidator,
+  '/',
+  {
+    name: 'List Products',
+    access: 'internal',
+    summary: 'List/search products, optionally filtered by title, price, stock, or a variant option value',
+    auth: { hmac: { secretKeys: { default: HMAC_SECRET_KEY } } },
+    query: ProductSearchQuerySchema,
+    responses: { 200: array(ProductMapper.schema) }
+  },
+  async (req, res) => {
+    const {
+      ids,
+      title,
+      minPriceCents,
+      maxPriceCents,
+      inStock,
+      optionName,
+      optionValue
+    } = req.query;
+
+    const hasVariantLevelFilter =
+      minPriceCents != null ||
+      maxPriceCents != null ||
+      inStock != null ||
+      (optionName != null && optionValue != null);
+
+    let productIds = ids;
+
+    if (hasVariantLevelFilter) {
+      let candidateVariants = await variantServiceFactory().listVariants();
+
+      if (minPriceCents != null) {
+        candidateVariants = candidateVariants.filter(
+          (v) => v.priceCents >= minPriceCents
+        );
+      }
+      if (maxPriceCents != null) {
+        candidateVariants = candidateVariants.filter(
+          (v) => v.priceCents <= maxPriceCents
+        );
+      }
+      if (optionName != null && optionValue != null) {
+        candidateVariants = candidateVariants.filter(
+          (v) => v.optionValues?.[optionName] === optionValue
+        );
+      }
+      if (inStock) {
+        const stockChecks = await Promise.all(
+          candidateVariants.map(async (v) => {
+            try {
+              const inventory = await inventoryServiceFactory().getInventory({
+                variantId: v.id
+              });
+              return inventory.stock > 0;
+            } catch {
+              // No inventory record yet — treat as out of stock, not an error.
+              return false;
+            }
+          })
+        );
+        candidateVariants = candidateVariants.filter((_, i) => stockChecks[i]);
+      }
+
+      const candidateProductIds = [
+        ...new Set(candidateVariants.map((v) => v.productId))
+      ];
+      productIds = ids?.length
+        ? ids.filter((id) => candidateProductIds.includes(id))
+        : candidateProductIds;
+    }
+
+    res.status(200).json(
+      await serviceFactory().listProducts({
+        ...(productIds ? { ids: productIds } : {}),
+        ...(title ? { title } : {})
+      })
+    );
+  }
+);

--- a/blueprint/ecommerce-stripe/api/controllers/product.controller.ts
+++ b/blueprint/ecommerce-stripe/api/controllers/product.controller.ts
@@ -1,4 +1,10 @@
-import { array, handlers, IdSchema, schemaValidator, string } from '../../schema';
+import {
+  array,
+  handlers,
+  IdSchema,
+  schemaValidator,
+  string
+} from '../../schema';
 import { ProductSearchQuerySchema } from '../../domain/schemas/productSearch.schema';
 import { ci, tokens } from '../../bootstrapper';
 import {
@@ -58,9 +64,7 @@ export const getProductByHandle = handlers.get(
     responses: { 200: ProductMapper.schema }
   },
   async (req, res) => {
-    res
-      .status(200)
-      .json(await serviceFactory().getProductByHandle(req.params));
+    res.status(200).json(await serviceFactory().getProductByHandle(req.params));
   }
 );
 
@@ -98,7 +102,7 @@ export const deleteProduct = handlers.delete(
 );
 
 /**
- * Catalog search/filter (ECOM-03). `ids`/`title` are product-level and
+ * Catalog search/filter. `ids`/`title` are product-level and
  * resolved directly by the product service. `minPriceCents`/`maxPriceCents`/
  * `inStock`/`optionName`+`optionValue` are variant-level — Product itself
  * carries no price — so they're resolved here by narrowing variants first,
@@ -110,7 +114,8 @@ export const listProducts = handlers.get(
   {
     name: 'List Products',
     access: 'internal',
-    summary: 'List/search products, optionally filtered by title, price, stock, or a variant option value',
+    summary:
+      'List/search products, optionally filtered by title, price, stock, or a variant option value',
     auth: { hmac: { secretKeys: { default: HMAC_SECRET_KEY } } },
     query: ProductSearchQuerySchema,
     responses: { 200: array(ProductMapper.schema) }

--- a/blueprint/ecommerce-stripe/api/controllers/product.controller.ts
+++ b/blueprint/ecommerce-stripe/api/controllers/product.controller.ts
@@ -183,6 +183,18 @@ export const listProducts = handlers.get(
         : candidateProductIds;
     }
 
+    // An empty productIds means the variant-level filters matched nothing —
+    // a real, empty result, not the absence of a filter. It has to be
+    // short-circuited here because neither layer below can tell those apart:
+    // `[]` is truthy, so `{ ids: [] }` is forwarded; listProducts then tests
+    // `searchDto?.ids?.length`, which is 0, so it never constrains the query
+    // and returns the ENTIRE catalog. A shopper filtering for an out-of-stock
+    // or non-existent option would be shown every product as if it matched.
+    if (productIds != null && productIds.length === 0) {
+      res.status(200).json([]);
+      return;
+    }
+
     res.status(200).json(
       await serviceFactory().listProducts({
         ...(productIds ? { ids: productIds } : {}),

--- a/blueprint/ecommerce-stripe/api/routes/catalogImport.routes.ts
+++ b/blueprint/ecommerce-stripe/api/routes/catalogImport.routes.ts
@@ -1,0 +1,16 @@
+import { forklaunchRouter, schemaValidator } from '../../schema';
+import { ci, tokens } from '../../bootstrapper';
+import { importCatalog } from '../controllers/catalogImport.controller';
+
+const openTelemetryCollector = ci.resolve(tokens.OtelCollector);
+
+export const catalogImportRouter = forklaunchRouter(
+  '/catalog-import',
+  schemaValidator,
+  openTelemetryCollector
+);
+
+export const importCatalogRoute = catalogImportRouter.post(
+  '/',
+  importCatalog
+);

--- a/blueprint/ecommerce-stripe/api/routes/inventory.routes.ts
+++ b/blueprint/ecommerce-stripe/api/routes/inventory.routes.ts
@@ -1,0 +1,19 @@
+import { forklaunchRouter, schemaValidator } from '../../schema';
+import { ci, tokens } from '../../bootstrapper';
+import {
+  adjustStock,
+  checkStock,
+  getInventory
+} from '../controllers/inventory.controller';
+
+const openTelemetryCollector = ci.resolve(tokens.OtelCollector);
+
+export const inventoryRouter = forklaunchRouter(
+  '/inventory',
+  schemaValidator,
+  openTelemetryCollector
+);
+
+export const checkStockRoute = inventoryRouter.post('/check', checkStock);
+export const adjustStockRoute = inventoryRouter.put('/adjust', adjustStock);
+export const getInventoryRoute = inventoryRouter.get('/:variantId', getInventory);

--- a/blueprint/ecommerce-stripe/api/routes/product.routes.ts
+++ b/blueprint/ecommerce-stripe/api/routes/product.routes.ts
@@ -1,0 +1,28 @@
+import { forklaunchRouter, schemaValidator } from '../../schema';
+import { ci, tokens } from '../../bootstrapper';
+import {
+  createProduct,
+  deleteProduct,
+  getProduct,
+  getProductByHandle,
+  listProducts,
+  updateProduct
+} from '../controllers/product.controller';
+
+const openTelemetryCollector = ci.resolve(tokens.OtelCollector);
+
+export const productRouter = forklaunchRouter(
+  '/product',
+  schemaValidator,
+  openTelemetryCollector
+);
+
+export const createProductRoute = productRouter.post('/', createProduct);
+export const listProductsRoute = productRouter.get('/', listProducts);
+export const getProductByHandleRoute = productRouter.get(
+  '/handle/:handle',
+  getProductByHandle
+);
+export const getProductRoute = productRouter.get('/:id', getProduct);
+export const updateProductRoute = productRouter.put('/', updateProduct);
+export const deleteProductRoute = productRouter.delete('/:id', deleteProduct);

--- a/blueprint/ecommerce-stripe/domain/mappers/inventory.mappers.ts
+++ b/blueprint/ecommerce-stripe/domain/mappers/inventory.mappers.ts
@@ -1,0 +1,42 @@
+import { schemaValidator } from '../../schema';
+import { requestMapper, responseMapper } from '@forklaunch/core/mappers';
+import { EntityManager } from '@mikro-orm/core';
+import { Inventory } from '../../persistence/entities/inventory.entity';
+import { InventorySchemas } from '../schemas';
+
+export const CreateInventoryMapper = requestMapper({
+  schemaValidator,
+  schema: InventorySchemas.CreateInventorySchema,
+  entity: Inventory,
+  mapperDefinition: {
+    toEntity: async (dto, em: EntityManager) => {
+      return em.create(Inventory, {
+        variantId: dto.variantId,
+        stock: dto.stock
+      });
+    }
+  }
+});
+
+export const UpdateInventoryMapper = requestMapper({
+  schemaValidator,
+  schema: InventorySchemas.UpdateInventorySchema,
+  entity: Inventory,
+  mapperDefinition: {
+    toEntity: async (dto, em: EntityManager) => {
+      const { id, ...rest } = dto;
+      const entity = await em.findOneOrFail(Inventory, { id });
+      em.assign(entity, rest);
+      return entity;
+    }
+  }
+});
+
+export const InventoryMapper = responseMapper({
+  schemaValidator,
+  schema: InventorySchemas.InventorySchema,
+  entity: Inventory,
+  mapperDefinition: {
+    toDto: async (entity) => ({ ...entity })
+  }
+});

--- a/blueprint/ecommerce-stripe/domain/mappers/product.mappers.ts
+++ b/blueprint/ecommerce-stripe/domain/mappers/product.mappers.ts
@@ -1,0 +1,59 @@
+import { schemaValidator } from '../../schema';
+import { requestMapper, responseMapper } from '@forklaunch/core/mappers';
+import { EntityManager } from '@mikro-orm/core';
+import { Product } from '../../persistence/entities/product.entity';
+import { ProductSchemas } from '../schemas';
+
+export const CreateProductMapper = requestMapper({
+  schemaValidator,
+  schema: ProductSchemas.CreateProductSchema,
+  entity: Product,
+  mapperDefinition: {
+    toEntity: async (dto, em: EntityManager) => {
+      return em.create(Product, {
+        externalId: dto.externalId,
+        handle: dto.handle,
+        sourceUrl: dto.sourceUrl ?? null,
+        title: dto.title,
+        descriptionHtml: dto.descriptionHtml ?? null,
+        vendor: dto.vendor ?? null,
+        productType: dto.productType ?? null,
+        tags: dto.tags ?? null,
+        options: dto.options ?? null,
+        images: dto.images ?? null
+      });
+    }
+  }
+});
+
+export const UpdateProductMapper = requestMapper({
+  schemaValidator,
+  schema: ProductSchemas.UpdateProductSchema,
+  entity: Product,
+  mapperDefinition: {
+    toEntity: async (dto, em: EntityManager) => {
+      const { id, ...rest } = dto;
+      const entity = await em.findOneOrFail(Product, { id });
+      em.assign(entity, rest);
+      return entity;
+    }
+  }
+});
+
+export const ProductMapper = responseMapper({
+  schemaValidator,
+  schema: ProductSchemas.ProductSchema,
+  entity: Product,
+  mapperDefinition: {
+    toDto: async (entity) => ({
+      ...entity,
+      sourceUrl: entity.sourceUrl ?? undefined,
+      descriptionHtml: entity.descriptionHtml ?? undefined,
+      vendor: entity.vendor ?? undefined,
+      productType: entity.productType ?? undefined,
+      tags: entity.tags ?? undefined,
+      options: entity.options ?? undefined,
+      images: entity.images ?? undefined
+    })
+  }
+});

--- a/blueprint/ecommerce-stripe/domain/schemas/catalogImport.schema.ts
+++ b/blueprint/ecommerce-stripe/domain/schemas/catalogImport.schema.ts
@@ -1,11 +1,4 @@
-import {
-  array,
-  boolean,
-  number,
-  optional,
-  record,
-  string
-} from '../../schema';
+import { array, boolean, number, optional, record, string } from '../../schema';
 
 /**
  * Request schemas for the bulk catalog-import endpoint.
@@ -33,7 +26,7 @@ export const ImportVariantSchema = {
   priceCents: number,
   compareAtPriceCents: optional(number),
   requiresShipping: optional(boolean),
-  /** Seed stock — no reservation semantics in v1 (ECOM-04). */
+  /** Seed stock — no reservation semantics in v1. */
   initialStock: optional(number)
 };
 

--- a/blueprint/ecommerce-stripe/domain/schemas/catalogImport.schema.ts
+++ b/blueprint/ecommerce-stripe/domain/schemas/catalogImport.schema.ts
@@ -1,0 +1,52 @@
+import {
+  array,
+  boolean,
+  number,
+  optional,
+  record,
+  string
+} from '../../schema';
+
+/**
+ * Request schemas for the bulk catalog-import endpoint.
+ *
+ * These live here rather than inline in the controller so the controller
+ * stays HTTP concerns only, matching how billing/iam keep schema definitions
+ * out of their controllers.
+ */
+export const ImportOptionSchema = {
+  name: string,
+  isPackQuantity: boolean,
+  values: array(string)
+};
+
+export const ImportImageSchema = {
+  src: string,
+  position: number
+};
+
+export const ImportVariantSchema = {
+  externalId: string,
+  sku: optional(string),
+  title: string,
+  optionValues: optional(record(string, string)),
+  priceCents: number,
+  compareAtPriceCents: optional(number),
+  requiresShipping: optional(boolean),
+  /** Seed stock — no reservation semantics in v1 (ECOM-04). */
+  initialStock: optional(number)
+};
+
+export const ImportProductSchema = {
+  externalId: string,
+  handle: string,
+  sourceUrl: optional(string),
+  title: string,
+  descriptionHtml: optional(string),
+  vendor: optional(string),
+  productType: optional(string),
+  tags: optional(array(string)),
+  options: optional(array(ImportOptionSchema)),
+  images: optional(array(ImportImageSchema)),
+  variants: array(ImportVariantSchema)
+};

--- a/blueprint/ecommerce-stripe/domain/schemas/index.ts
+++ b/blueprint/ecommerce-stripe/domain/schemas/index.ts
@@ -13,7 +13,6 @@ const schemas = mapServiceSchemas(
     InventorySchemas: BaseInventoryServiceSchemas<SchemaValidator>,
     ProductSchemas: BaseProductServiceSchemas<SchemaValidator>,
     VariantSchemas: BaseVariantServiceSchemas<SchemaValidator>
-    // Remaining entities' schemas are added incrementally as each PR lands.
   },
   {
     validator: schemaValidator,

--- a/blueprint/ecommerce-stripe/domain/schemas/index.ts
+++ b/blueprint/ecommerce-stripe/domain/schemas/index.ts
@@ -2,6 +2,7 @@ import { SchemaValidator, schemaValidator } from '../../schema';
 import { mapServiceSchemas } from '@forklaunch/core/mappers';
 import {
   BaseInventoryServiceSchemas,
+  BaseProductServiceSchemas,
   BaseVariantServiceSchemas
 } from '@forklaunch/implementation-ecommerce-base/schemas';
 
@@ -10,6 +11,7 @@ import {
 const schemas = mapServiceSchemas(
   {
     InventorySchemas: BaseInventoryServiceSchemas<SchemaValidator>,
+    ProductSchemas: BaseProductServiceSchemas<SchemaValidator>,
     VariantSchemas: BaseVariantServiceSchemas<SchemaValidator>
     // Remaining entities' schemas are added incrementally as each PR lands.
   },
@@ -19,4 +21,4 @@ const schemas = mapServiceSchemas(
   }
 );
 
-export const { InventorySchemas, VariantSchemas } = schemas;
+export const { InventorySchemas, ProductSchemas, VariantSchemas } = schemas;

--- a/blueprint/ecommerce-stripe/domain/schemas/index.ts
+++ b/blueprint/ecommerce-stripe/domain/schemas/index.ts
@@ -1,11 +1,15 @@
 import { SchemaValidator, schemaValidator } from '../../schema';
 import { mapServiceSchemas } from '@forklaunch/core/mappers';
-import { BaseVariantServiceSchemas } from '@forklaunch/implementation-ecommerce-base/schemas';
+import {
+  BaseInventoryServiceSchemas,
+  BaseVariantServiceSchemas
+} from '@forklaunch/implementation-ecommerce-base/schemas';
 
 // Entity ids are fp.string() (uuid-shaped strings assigned via uuid()), not
 // mikro-orm's uuid column type — uuidId: false matches sqlBaseProperties.
 const schemas = mapServiceSchemas(
   {
+    InventorySchemas: BaseInventoryServiceSchemas<SchemaValidator>,
     VariantSchemas: BaseVariantServiceSchemas<SchemaValidator>
     // Remaining entities' schemas are added incrementally as each PR lands.
   },
@@ -15,4 +19,4 @@ const schemas = mapServiceSchemas(
   }
 );
 
-export const { VariantSchemas } = schemas;
+export const { InventorySchemas, VariantSchemas } = schemas;

--- a/blueprint/ecommerce-stripe/domain/schemas/productSearch.schema.ts
+++ b/blueprint/ecommerce-stripe/domain/schemas/productSearch.schema.ts
@@ -1,0 +1,17 @@
+import { array, boolean, number, optional, string } from '../../schema';
+
+/**
+ * Query schema for the product list/search endpoint.
+ *
+ * Lives here rather than inline in the controller so the controller stays
+ * HTTP concerns only, matching catalogImport.schema.ts and checkout.schema.ts.
+ */
+export const ProductSearchQuerySchema = {
+  ids: optional(array(string)),
+  title: optional(string),
+  minPriceCents: optional(number),
+  maxPriceCents: optional(number),
+  inStock: optional(boolean),
+  optionName: optional(string),
+  optionValue: optional(string)
+};

--- a/blueprint/ecommerce-stripe/domain/types/ecommerceMappers.types.ts
+++ b/blueprint/ecommerce-stripe/domain/types/ecommerceMappers.types.ts
@@ -1,16 +1,33 @@
 import { SchemaValidator } from '../../schema';
 import { Schema } from '@forklaunch/validator';
-import { Inventory, Variant } from '../../persistence/entities';
+import { Inventory, Product, Variant } from '../../persistence/entities';
 import {
   CreateInventoryMapper,
   InventoryMapper,
   UpdateInventoryMapper
 } from '../mappers/inventory.mappers';
 import {
+  CreateProductMapper,
+  ProductMapper,
+  UpdateProductMapper
+} from '../mappers/product.mappers';
+import {
   CreateVariantMapper,
   UpdateVariantMapper,
   VariantMapper
 } from '../mappers/variant.mappers';
+
+// product
+export type ProductMapperTypes = {
+  ProductMapper: typeof Product;
+  CreateProductMapper: typeof Product;
+  UpdateProductMapper: typeof Product;
+};
+export type ProductDtoTypes = {
+  ProductMapper: Schema<typeof ProductMapper.schema, SchemaValidator>;
+  CreateProductMapper: Schema<typeof CreateProductMapper.schema, SchemaValidator>;
+  UpdateProductMapper: Schema<typeof UpdateProductMapper.schema, SchemaValidator>;
+};
 
 // variant
 export type VariantMapperTypes = {

--- a/blueprint/ecommerce-stripe/domain/types/ecommerceMappers.types.ts
+++ b/blueprint/ecommerce-stripe/domain/types/ecommerceMappers.types.ts
@@ -60,3 +60,17 @@ export type InventoryDtoTypes = {
 };
 
 // Remaining entities' mapper/DTO types are added incrementally as each PR lands.
+
+// TS2883 workaround. The dependency container infers through the Base*Service
+// generics, and without at least one of these mapper types nameable here, tsc
+// refuses to emit its declaration ("inferred type cannot be named... not
+// portable"). Empirically one anchor is enough — the compiler then inlines the
+// rest as import("...") in the emitted .d.ts — but all three are re-exported
+// so the list is obvious rather than looking arbitrary. New entities do not
+// strictly need adding here; if TS2883 reappears after a compiler upgrade,
+// this block is the place to look.
+export type {
+  InventoryMappers,
+  ProductMappers,
+  VariantMappers
+} from '@forklaunch/implementation-ecommerce-base/types';

--- a/blueprint/ecommerce-stripe/domain/types/ecommerceMappers.types.ts
+++ b/blueprint/ecommerce-stripe/domain/types/ecommerceMappers.types.ts
@@ -1,6 +1,11 @@
 import { SchemaValidator } from '../../schema';
 import { Schema } from '@forklaunch/validator';
-import { Variant } from '../../persistence/entities';
+import { Inventory, Variant } from '../../persistence/entities';
+import {
+  CreateInventoryMapper,
+  InventoryMapper,
+  UpdateInventoryMapper
+} from '../mappers/inventory.mappers';
 import {
   CreateVariantMapper,
   UpdateVariantMapper,
@@ -17,6 +22,24 @@ export type VariantDtoTypes = {
   VariantMapper: Schema<typeof VariantMapper.schema, SchemaValidator>;
   CreateVariantMapper: Schema<typeof CreateVariantMapper.schema, SchemaValidator>;
   UpdateVariantMapper: Schema<typeof UpdateVariantMapper.schema, SchemaValidator>;
+};
+
+// inventory
+export type InventoryMapperTypes = {
+  InventoryMapper: typeof Inventory;
+  CreateInventoryMapper: typeof Inventory;
+  UpdateInventoryMapper: typeof Inventory;
+};
+export type InventoryDtoTypes = {
+  InventoryMapper: Schema<typeof InventoryMapper.schema, SchemaValidator>;
+  CreateInventoryMapper: Schema<
+    typeof CreateInventoryMapper.schema,
+    SchemaValidator
+  >;
+  UpdateInventoryMapper: Schema<
+    typeof UpdateInventoryMapper.schema,
+    SchemaValidator
+  >;
 };
 
 // Remaining entities' mapper/DTO types are added incrementally as each PR lands.

--- a/blueprint/ecommerce-stripe/domain/types/ecommerceMappers.types.ts
+++ b/blueprint/ecommerce-stripe/domain/types/ecommerceMappers.types.ts
@@ -25,8 +25,14 @@ export type ProductMapperTypes = {
 };
 export type ProductDtoTypes = {
   ProductMapper: Schema<typeof ProductMapper.schema, SchemaValidator>;
-  CreateProductMapper: Schema<typeof CreateProductMapper.schema, SchemaValidator>;
-  UpdateProductMapper: Schema<typeof UpdateProductMapper.schema, SchemaValidator>;
+  CreateProductMapper: Schema<
+    typeof CreateProductMapper.schema,
+    SchemaValidator
+  >;
+  UpdateProductMapper: Schema<
+    typeof UpdateProductMapper.schema,
+    SchemaValidator
+  >;
 };
 
 // variant
@@ -37,8 +43,14 @@ export type VariantMapperTypes = {
 };
 export type VariantDtoTypes = {
   VariantMapper: Schema<typeof VariantMapper.schema, SchemaValidator>;
-  CreateVariantMapper: Schema<typeof CreateVariantMapper.schema, SchemaValidator>;
-  UpdateVariantMapper: Schema<typeof UpdateVariantMapper.schema, SchemaValidator>;
+  CreateVariantMapper: Schema<
+    typeof CreateVariantMapper.schema,
+    SchemaValidator
+  >;
+  UpdateVariantMapper: Schema<
+    typeof UpdateVariantMapper.schema,
+    SchemaValidator
+  >;
 };
 
 // inventory
@@ -58,8 +70,6 @@ export type InventoryDtoTypes = {
     SchemaValidator
   >;
 };
-
-// Remaining entities' mapper/DTO types are added incrementally as each PR lands.
 
 // TS2883 workaround. The dependency container infers through the Base*Service
 // generics, and without at least one of these mapper types nameable here, tsc

--- a/blueprint/ecommerce-stripe/persistence/entities/index.ts
+++ b/blueprint/ecommerce-stripe/persistence/entities/index.ts
@@ -1,3 +1,4 @@
 export { Inventory } from './inventory.entity';
+export { Product } from './product.entity';
 export { Variant } from './variant.entity';
 // Remaining entities are added incrementally as each PR lands.

--- a/blueprint/ecommerce-stripe/persistence/entities/index.ts
+++ b/blueprint/ecommerce-stripe/persistence/entities/index.ts
@@ -1,2 +1,3 @@
+export { Inventory } from './inventory.entity';
 export { Variant } from './variant.entity';
 // Remaining entities are added incrementally as each PR lands.

--- a/blueprint/ecommerce-stripe/persistence/entities/index.ts
+++ b/blueprint/ecommerce-stripe/persistence/entities/index.ts
@@ -1,4 +1,3 @@
 export { Inventory } from './inventory.entity';
 export { Product } from './product.entity';
 export { Variant } from './variant.entity';
-// Remaining entities are added incrementally as each PR lands.

--- a/blueprint/ecommerce-stripe/persistence/entities/inventory.entity.ts
+++ b/blueprint/ecommerce-stripe/persistence/entities/inventory.entity.ts
@@ -1,0 +1,11 @@
+import { sqlBaseProperties } from '../../../core/persistence/sql.base.properties';
+import { defineComplianceEntity, fp } from '@forklaunch/core/persistence';
+
+export const Inventory = defineComplianceEntity({
+  name: 'Inventory',
+  properties: {
+    ...sqlBaseProperties,
+    variantId: fp.string().unique().compliance('none'),
+    stock: fp.integer().compliance('none')
+  }
+});

--- a/blueprint/ecommerce-stripe/persistence/entities/inventory.entity.ts
+++ b/blueprint/ecommerce-stripe/persistence/entities/inventory.entity.ts
@@ -1,4 +1,4 @@
-import { sqlBaseProperties } from '../../../core/persistence/sql.base.properties';
+import { sqlBaseProperties } from '@forklaunch/blueprint-core';
 import { defineComplianceEntity, fp } from '@forklaunch/core/persistence';
 
 export const Inventory = defineComplianceEntity({

--- a/blueprint/ecommerce-stripe/persistence/entities/product.entity.ts
+++ b/blueprint/ecommerce-stripe/persistence/entities/product.entity.ts
@@ -1,0 +1,20 @@
+import { sqlBaseProperties } from '../../../core/persistence/sql.base.properties';
+import { ProductImage, ProductOption } from '@forklaunch/interfaces-ecommerce/types';
+import { defineComplianceEntity, fp } from '@forklaunch/core/persistence';
+
+export const Product = defineComplianceEntity({
+  name: 'Product',
+  properties: {
+    ...sqlBaseProperties,
+    externalId: fp.string().unique().compliance('none'),
+    handle: fp.string().unique().compliance('none'),
+    sourceUrl: fp.string().nullable().compliance('none'),
+    title: fp.string().compliance('none'),
+    descriptionHtml: fp.string().nullable().compliance('none'),
+    vendor: fp.string().nullable().compliance('none'),
+    productType: fp.string().nullable().compliance('none'),
+    tags: fp.string().array().nullable().compliance('none'),
+    options: fp.json<ProductOption[]>().nullable().compliance('none'),
+    images: fp.json<ProductImage[]>().nullable().compliance('none')
+  }
+});

--- a/blueprint/ecommerce-stripe/persistence/entities/product.entity.ts
+++ b/blueprint/ecommerce-stripe/persistence/entities/product.entity.ts
@@ -1,4 +1,4 @@
-import { sqlBaseProperties } from '../../../core/persistence/sql.base.properties';
+import { sqlBaseProperties } from '@forklaunch/blueprint-core';
 import { ProductImage, ProductOption } from '@forklaunch/interfaces-ecommerce/types';
 import { defineComplianceEntity, fp } from '@forklaunch/core/persistence';
 

--- a/blueprint/ecommerce-stripe/registrations.ts
+++ b/blueprint/ecommerce-stripe/registrations.ts
@@ -19,6 +19,7 @@ import {
 } from '@forklaunch/core/services';
 import {
   BaseInventoryService,
+  BaseProductService,
   BaseVariantService
 } from '@forklaunch/implementation-ecommerce-base/services';
 import { ForkOptions } from '@mikro-orm/core';
@@ -29,6 +30,11 @@ import {
   UpdateInventoryMapper
 } from './domain/mappers/inventory.mappers';
 import {
+  CreateProductMapper,
+  ProductMapper,
+  UpdateProductMapper
+} from './domain/mappers/product.mappers';
+import {
   CreateVariantMapper,
   UpdateVariantMapper,
   VariantMapper
@@ -36,6 +42,8 @@ import {
 import {
   InventoryDtoTypes,
   InventoryMapperTypes,
+  ProductDtoTypes,
+  ProductMapperTypes,
   VariantDtoTypes,
   VariantMapperTypes
 } from './domain/types/ecommerceMappers.types';
@@ -178,6 +186,19 @@ const runtimeDependencies = environmentConfig.chain({
 //! defines the service dependencies for the application — one `.chain()`
 //! link per entity, added incrementally as each entity's PR lands.
 const serviceDependencies = runtimeDependencies.chain({
+  ProductService: {
+    lifetime: Lifetime.Scoped,
+    type: BaseProductService<SchemaValidator, ProductMapperTypes, ProductDtoTypes>,
+    factory: ({ EntityManager, OtelCollector }, context, resolve) =>
+      new BaseProductService(
+        context.entityManagerOptions
+          ? resolve('EntityManager', context)
+          : EntityManager,
+        OtelCollector,
+        schemaValidator,
+        { ProductMapper, CreateProductMapper, UpdateProductMapper }
+      )
+  },
   VariantService: {
     lifetime: Lifetime.Scoped,
     type: BaseVariantService<SchemaValidator, VariantMapperTypes, VariantDtoTypes>,

--- a/blueprint/ecommerce-stripe/registrations.ts
+++ b/blueprint/ecommerce-stripe/registrations.ts
@@ -17,15 +17,25 @@ import {
   getEnvVar,
   Lifetime
 } from '@forklaunch/core/services';
-import { BaseVariantService } from '@forklaunch/implementation-ecommerce-base/services';
+import {
+  BaseInventoryService,
+  BaseVariantService
+} from '@forklaunch/implementation-ecommerce-base/services';
 import { ForkOptions } from '@mikro-orm/core';
 import { EntityManager, MikroORM } from '@mikro-orm/postgresql';
+import {
+  CreateInventoryMapper,
+  InventoryMapper,
+  UpdateInventoryMapper
+} from './domain/mappers/inventory.mappers';
 import {
   CreateVariantMapper,
   UpdateVariantMapper,
   VariantMapper
 } from './domain/mappers/variant.mappers';
 import {
+  InventoryDtoTypes,
+  InventoryMapperTypes,
   VariantDtoTypes,
   VariantMapperTypes
 } from './domain/types/ecommerceMappers.types';
@@ -179,6 +189,23 @@ const serviceDependencies = runtimeDependencies.chain({
         OtelCollector,
         schemaValidator,
         { VariantMapper, CreateVariantMapper, UpdateVariantMapper }
+      )
+  },
+  InventoryService: {
+    lifetime: Lifetime.Scoped,
+    type: BaseInventoryService<
+      SchemaValidator,
+      InventoryMapperTypes,
+      InventoryDtoTypes
+    >,
+    factory: ({ EntityManager, OtelCollector }, context, resolve) =>
+      new BaseInventoryService(
+        context.entityManagerOptions
+          ? resolve('EntityManager', context)
+          : EntityManager,
+        OtelCollector,
+        schemaValidator,
+        { InventoryMapper, CreateInventoryMapper, UpdateInventoryMapper }
       )
   }
 });

--- a/blueprint/ecommerce-stripe/registrations.ts
+++ b/blueprint/ecommerce-stripe/registrations.ts
@@ -129,18 +129,15 @@ const environmentConfig = configInjector.chain({
 });
 
 //! defines the runtime dependencies for the application — pure infra, no
-//! entity-specific services yet. Entity services are added incrementally,
-//! one `.chain()` per PR, as each entity lands (same multi-step chain
-//! pattern this file already uses above: configInjector -> environmentConfig
-//! -> runtimeDependencies), so every intermediate PR stays independently
-//! buildable rather than referencing services that don't exist yet.
+//! entity-specific services. Same multi-step chain pattern this file uses
+//! above: configInjector -> environmentConfig -> runtimeDependencies.
 const runtimeDependencies = environmentConfig.chain({
   /**
-   * Cart's fast/temporary-state layer (ECOM-06's original design) — a
-   * read-through cache in front of Postgres, which stays the source of
-   * truth. 30 minutes matches a typical shopping-session/abandonment
-   * window: long enough to serve an active session from cache, short
-   * enough to self-evict abandoned carts rather than accumulate forever.
+   * Cart's fast/temporary-state layer: a read-through cache in front of
+   * Postgres, which stays the source of truth. 30 minutes matches a typical
+   * shopping-session/abandonment window: long enough to serve an active
+   * session from cache, short enough to self-evict abandoned carts rather
+   * than accumulate forever.
    */
   TtlCache: {
     lifetime: Lifetime.Singleton,
@@ -184,11 +181,15 @@ const runtimeDependencies = environmentConfig.chain({
 });
 
 //! defines the service dependencies for the application — one `.chain()`
-//! link per entity, added incrementally as each entity's PR lands.
+//! link per entity.
 const serviceDependencies = runtimeDependencies.chain({
   ProductService: {
     lifetime: Lifetime.Scoped,
-    type: BaseProductService<SchemaValidator, ProductMapperTypes, ProductDtoTypes>,
+    type: BaseProductService<
+      SchemaValidator,
+      ProductMapperTypes,
+      ProductDtoTypes
+    >,
     factory: ({ EntityManager, OtelCollector }, context, resolve) =>
       new BaseProductService(
         context.entityManagerOptions
@@ -201,7 +202,11 @@ const serviceDependencies = runtimeDependencies.chain({
   },
   VariantService: {
     lifetime: Lifetime.Scoped,
-    type: BaseVariantService<SchemaValidator, VariantMapperTypes, VariantDtoTypes>,
+    type: BaseVariantService<
+      SchemaValidator,
+      VariantMapperTypes,
+      VariantDtoTypes
+    >,
     factory: ({ EntityManager, OtelCollector }, context, resolve) =>
       new BaseVariantService(
         context?.entityManagerOptions

--- a/blueprint/ecommerce-stripe/sdk.ts
+++ b/blueprint/ecommerce-stripe/sdk.ts
@@ -19,7 +19,6 @@ import {
   updateVariant
 } from './api/controllers';
 
-//! SDK surface is built up incrementally as each entity's PR lands.
 export type EcommerceSdk = {
   product: {
     createProduct: typeof createProduct;

--- a/blueprint/ecommerce-stripe/sdk.ts
+++ b/blueprint/ecommerce-stripe/sdk.ts
@@ -1,8 +1,11 @@
 import { SchemaValidator } from './schema';
 import { MapToSdk } from '@forklaunch/core/http';
 import {
+  adjustStock,
+  checkStock,
   createVariant,
   deleteVariant,
+  getInventory,
   getVariant,
   listVariants,
   listVariantsByProduct,
@@ -19,6 +22,11 @@ export type EcommerceSdk = {
     deleteVariant: typeof deleteVariant;
     listVariants: typeof listVariants;
   };
+  inventory: {
+    getInventory: typeof getInventory;
+    adjustStock: typeof adjustStock;
+    checkStock: typeof checkStock;
+  };
 };
 
 export const ecommerceSdkClient = {
@@ -29,6 +37,11 @@ export const ecommerceSdkClient = {
     updateVariant,
     deleteVariant,
     listVariants
+  },
+  inventory: {
+    getInventory,
+    adjustStock,
+    checkStock
   }
 } satisfies EcommerceSdk;
 

--- a/blueprint/ecommerce-stripe/sdk.ts
+++ b/blueprint/ecommerce-stripe/sdk.ts
@@ -3,17 +3,32 @@ import { MapToSdk } from '@forklaunch/core/http';
 import {
   adjustStock,
   checkStock,
+  createProduct,
   createVariant,
+  deleteProduct,
   deleteVariant,
   getInventory,
+  getProduct,
+  getProductByHandle,
   getVariant,
+  importCatalog,
+  listProducts,
   listVariants,
   listVariantsByProduct,
+  updateProduct,
   updateVariant
 } from './api/controllers';
 
 //! SDK surface is built up incrementally as each entity's PR lands.
 export type EcommerceSdk = {
+  product: {
+    createProduct: typeof createProduct;
+    getProduct: typeof getProduct;
+    getProductByHandle: typeof getProductByHandle;
+    updateProduct: typeof updateProduct;
+    deleteProduct: typeof deleteProduct;
+    listProducts: typeof listProducts;
+  };
   variant: {
     createVariant: typeof createVariant;
     getVariant: typeof getVariant;
@@ -27,9 +42,20 @@ export type EcommerceSdk = {
     adjustStock: typeof adjustStock;
     checkStock: typeof checkStock;
   };
+  catalogImport: {
+    importCatalog: typeof importCatalog;
+  };
 };
 
 export const ecommerceSdkClient = {
+  product: {
+    createProduct,
+    getProduct,
+    getProductByHandle,
+    updateProduct,
+    deleteProduct,
+    listProducts
+  },
   variant: {
     createVariant,
     getVariant,
@@ -42,6 +68,9 @@ export const ecommerceSdkClient = {
     getInventory,
     adjustStock,
     checkStock
+  },
+  catalogImport: {
+    importCatalog
   }
 } satisfies EcommerceSdk;
 

--- a/blueprint/ecommerce-stripe/server.ts
+++ b/blueprint/ecommerce-stripe/server.ts
@@ -5,7 +5,9 @@ import {
   schemaValidator
 } from './schema';
 import { setupRls, setupTenantFilter } from '@forklaunch/core/persistence';
+import { catalogImportRouter } from './api/routes/catalogImport.routes';
 import { inventoryRouter } from './api/routes/inventory.routes';
+import { productRouter } from './api/routes/product.routes';
 import { variantRouter } from './api/routes/variant.routes';
 import { ci, tokens } from './bootstrapper';
 
@@ -38,8 +40,10 @@ const version = ci.resolve(tokens.VERSION);
 const docsPath = ci.resolve(tokens.DOCS_PATH);
 
 //! routes are mounted here incrementally as each entity's PR lands.
+app.use(productRouter);
 app.use(variantRouter);
 app.use(inventoryRouter);
+app.use(catalogImportRouter);
 
 //! starts the server
 app.listen(port, host, () => {

--- a/blueprint/ecommerce-stripe/server.ts
+++ b/blueprint/ecommerce-stripe/server.ts
@@ -39,7 +39,6 @@ const port = ci.resolve(tokens.PORT);
 const version = ci.resolve(tokens.VERSION);
 const docsPath = ci.resolve(tokens.DOCS_PATH);
 
-//! routes are mounted here incrementally as each entity's PR lands.
 app.use(productRouter);
 app.use(variantRouter);
 app.use(inventoryRouter);

--- a/blueprint/ecommerce-stripe/server.ts
+++ b/blueprint/ecommerce-stripe/server.ts
@@ -5,6 +5,7 @@ import {
   schemaValidator
 } from './schema';
 import { setupRls, setupTenantFilter } from '@forklaunch/core/persistence';
+import { inventoryRouter } from './api/routes/inventory.routes';
 import { variantRouter } from './api/routes/variant.routes';
 import { ci, tokens } from './bootstrapper';
 
@@ -38,6 +39,7 @@ const docsPath = ci.resolve(tokens.DOCS_PATH);
 
 //! routes are mounted here incrementally as each entity's PR lands.
 app.use(variantRouter);
+app.use(inventoryRouter);
 
 //! starts the server
 app.listen(port, host, () => {

--- a/blueprint/implementations/ecommerce/base/__test__/schemaEquality.test.ts
+++ b/blueprint/implementations/ecommerce/base/__test__/schemaEquality.test.ts
@@ -1,16 +1,29 @@
 import { isTrue } from '@forklaunch/common';
 import { describe, expect, it } from 'vitest';
 import {
+  CreateInventoryDto,
   CreateVariantDto,
+  InventoryDto,
+  UpdateInventoryDto,
   UpdateVariantDto,
   VariantDto
 } from '@forklaunch/interfaces-ecommerce/types';
 import { testSchemaEquality } from '@forklaunch/internal';
 import {
+  UpdateInventorySchema as TypeboxUpdateInventorySchema,
+  InventorySchema as TypeboxInventorySchema
+} from '../domain/schemas/typebox/inventory.schema';
+import { CreateInventorySchema as TypeboxCreateInventorySchema } from '../domain/schemas/typebox/inventory.schema';
+import {
   VariantSchema as TypeboxVariantSchema,
   UpdateVariantSchema as TypeboxUpdateVariantSchema
 } from '../domain/schemas/typebox/variant.schema';
 import { CreateVariantSchema as TypeboxCreateVariantSchema } from '../domain/schemas/typebox/variant.schema';
+import {
+  UpdateInventorySchema as ZodUpdateInventorySchema,
+  InventorySchema as ZodInventorySchema
+} from '../domain/schemas/zod/inventory.schema';
+import { CreateInventorySchema as ZodCreateInventorySchema } from '../domain/schemas/zod/inventory.schema';
 import {
   VariantSchema as ZodVariantSchema,
   UpdateVariantSchema as ZodUpdateVariantSchema
@@ -21,6 +34,13 @@ const zodUpdateVariantSchema = ZodUpdateVariantSchema({ uuidId: false });
 const typeboxUpdateVariantSchema = TypeboxUpdateVariantSchema({ uuidId: false });
 const zodVariantSchema = ZodVariantSchema({ uuidId: false });
 const typeboxVariantSchema = TypeboxVariantSchema({ uuidId: false });
+
+const zodUpdateInventorySchema = ZodUpdateInventorySchema({ uuidId: false });
+const typeboxUpdateInventorySchema = TypeboxUpdateInventorySchema({
+  uuidId: false
+});
+const zodInventorySchema = ZodInventorySchema({ uuidId: false });
+const typeboxInventorySchema = TypeboxInventorySchema({ uuidId: false });
 
 // Remaining entities' sample data + schema instantiations are added
 // incrementally as each entity's PR lands.
@@ -68,6 +88,48 @@ describe('schema equality', () => {
           title: 'Black',
           priceCents: 1999
         })
+      )
+    ).toBeTruthy();
+  });
+
+  it('should be equal for inventory', () => {
+    expect(
+      isTrue(
+        testSchemaEquality<CreateInventoryDto>()(
+          ZodCreateInventorySchema,
+          TypeboxCreateInventorySchema,
+          {
+            variantId: 'var-1',
+            stock: 100
+          }
+        )
+      )
+    ).toBeTruthy();
+
+    expect(
+      isTrue(
+        testSchemaEquality<UpdateInventoryDto>()(
+          zodUpdateInventorySchema,
+          typeboxUpdateInventorySchema,
+          {
+            id: 'test',
+            stock: 50
+          }
+        )
+      )
+    ).toBeTruthy();
+
+    expect(
+      isTrue(
+        testSchemaEquality<InventoryDto>()(
+          zodInventorySchema,
+          typeboxInventorySchema,
+          {
+            id: 'test',
+            variantId: 'var-1',
+            stock: 100
+          }
+        )
       )
     ).toBeTruthy();
   });

--- a/blueprint/implementations/ecommerce/base/__test__/schemaEquality.test.ts
+++ b/blueprint/implementations/ecommerce/base/__test__/schemaEquality.test.ts
@@ -2,9 +2,12 @@ import { isTrue } from '@forklaunch/common';
 import { describe, expect, it } from 'vitest';
 import {
   CreateInventoryDto,
+  CreateProductDto,
   CreateVariantDto,
   InventoryDto,
+  ProductDto,
   UpdateInventoryDto,
+  UpdateProductDto,
   UpdateVariantDto,
   VariantDto
 } from '@forklaunch/interfaces-ecommerce/types';
@@ -14,6 +17,11 @@ import {
   InventorySchema as TypeboxInventorySchema
 } from '../domain/schemas/typebox/inventory.schema';
 import { CreateInventorySchema as TypeboxCreateInventorySchema } from '../domain/schemas/typebox/inventory.schema';
+import {
+  ProductSchema as TypeboxProductSchema,
+  UpdateProductSchema as TypeboxUpdateProductSchema
+} from '../domain/schemas/typebox/product.schema';
+import { CreateProductSchema as TypeboxCreateProductSchema } from '../domain/schemas/typebox/product.schema';
 import {
   VariantSchema as TypeboxVariantSchema,
   UpdateVariantSchema as TypeboxUpdateVariantSchema
@@ -25,10 +33,23 @@ import {
 } from '../domain/schemas/zod/inventory.schema';
 import { CreateInventorySchema as ZodCreateInventorySchema } from '../domain/schemas/zod/inventory.schema';
 import {
+  ProductSchema as ZodProductSchema,
+  UpdateProductSchema as ZodUpdateProductSchema
+} from '../domain/schemas/zod/product.schema';
+import { CreateProductSchema as ZodCreateProductSchema } from '../domain/schemas/zod/product.schema';
+import {
   VariantSchema as ZodVariantSchema,
   UpdateVariantSchema as ZodUpdateVariantSchema
 } from '../domain/schemas/zod/variant.schema';
 import { CreateVariantSchema as ZodCreateVariantSchema } from '../domain/schemas/zod/variant.schema';
+
+const zodUpdateProductSchema = ZodUpdateProductSchema({ uuidId: false });
+const typeboxUpdateProductSchema = TypeboxUpdateProductSchema({ uuidId: false });
+const zodProductSchema = ZodProductSchema({ uuidId: false });
+const typeboxProductSchema = TypeboxProductSchema({ uuidId: false });
+
+const sampleOptions = [{ name: 'Size', isPackQuantity: false, values: ['S'] }];
+const sampleImages = [{ src: 'https://example.com/a.jpg', position: 1 }];
 
 const zodUpdateVariantSchema = ZodUpdateVariantSchema({ uuidId: false });
 const typeboxUpdateVariantSchema = TypeboxUpdateVariantSchema({ uuidId: false });
@@ -46,6 +67,55 @@ const typeboxInventorySchema = TypeboxInventorySchema({ uuidId: false });
 // incrementally as each entity's PR lands.
 
 describe('schema equality', () => {
+  it('should be equal for product', () => {
+    expect(
+      isTrue(
+        testSchemaEquality<CreateProductDto>()(
+          ZodCreateProductSchema,
+          TypeboxCreateProductSchema,
+          {
+            externalId: 'ext-1',
+            handle: 'test-product',
+            sourceUrl: 'https://example.com/products/test-product',
+            title: 'Test Product',
+            descriptionHtml: '<p>desc</p>',
+            vendor: 'Test Vendor',
+            productType: 'Supplement',
+            tags: ['a', 'b'],
+            options: sampleOptions,
+            images: sampleImages
+          }
+        )
+      )
+    ).toBeTruthy();
+
+    expect(
+      isTrue(
+        testSchemaEquality<UpdateProductDto>()(
+          zodUpdateProductSchema,
+          typeboxUpdateProductSchema,
+          {
+            id: 'test',
+            title: 'Updated'
+          }
+        )
+      )
+    ).toBeTruthy();
+
+    expect(
+      isTrue(
+        testSchemaEquality<ProductDto>()(zodProductSchema, typeboxProductSchema, {
+          id: 'test',
+          externalId: 'ext-1',
+          handle: 'test-product',
+          title: 'Test Product',
+          options: sampleOptions,
+          images: sampleImages
+        })
+      )
+    ).toBeTruthy();
+  });
+
   it('should be equal for variant', () => {
     expect(
       isTrue(

--- a/blueprint/implementations/ecommerce/base/__test__/schemaEquality.test.ts
+++ b/blueprint/implementations/ecommerce/base/__test__/schemaEquality.test.ts
@@ -44,7 +44,9 @@ import {
 import { CreateVariantSchema as ZodCreateVariantSchema } from '../domain/schemas/zod/variant.schema';
 
 const zodUpdateProductSchema = ZodUpdateProductSchema({ uuidId: false });
-const typeboxUpdateProductSchema = TypeboxUpdateProductSchema({ uuidId: false });
+const typeboxUpdateProductSchema = TypeboxUpdateProductSchema({
+  uuidId: false
+});
 const zodProductSchema = ZodProductSchema({ uuidId: false });
 const typeboxProductSchema = TypeboxProductSchema({ uuidId: false });
 
@@ -52,7 +54,9 @@ const sampleOptions = [{ name: 'Size', isPackQuantity: false, values: ['S'] }];
 const sampleImages = [{ src: 'https://example.com/a.jpg', position: 1 }];
 
 const zodUpdateVariantSchema = ZodUpdateVariantSchema({ uuidId: false });
-const typeboxUpdateVariantSchema = TypeboxUpdateVariantSchema({ uuidId: false });
+const typeboxUpdateVariantSchema = TypeboxUpdateVariantSchema({
+  uuidId: false
+});
 const zodVariantSchema = ZodVariantSchema({ uuidId: false });
 const typeboxVariantSchema = TypeboxVariantSchema({ uuidId: false });
 
@@ -62,9 +66,6 @@ const typeboxUpdateInventorySchema = TypeboxUpdateInventorySchema({
 });
 const zodInventorySchema = ZodInventorySchema({ uuidId: false });
 const typeboxInventorySchema = TypeboxInventorySchema({ uuidId: false });
-
-// Remaining entities' sample data + schema instantiations are added
-// incrementally as each entity's PR lands.
 
 describe('schema equality', () => {
   it('should be equal for product', () => {
@@ -104,14 +105,18 @@ describe('schema equality', () => {
 
     expect(
       isTrue(
-        testSchemaEquality<ProductDto>()(zodProductSchema, typeboxProductSchema, {
-          id: 'test',
-          externalId: 'ext-1',
-          handle: 'test-product',
-          title: 'Test Product',
-          options: sampleOptions,
-          images: sampleImages
-        })
+        testSchemaEquality<ProductDto>()(
+          zodProductSchema,
+          typeboxProductSchema,
+          {
+            id: 'test',
+            externalId: 'ext-1',
+            handle: 'test-product',
+            title: 'Test Product',
+            options: sampleOptions,
+            images: sampleImages
+          }
+        )
       )
     ).toBeTruthy();
   });
@@ -151,13 +156,17 @@ describe('schema equality', () => {
 
     expect(
       isTrue(
-        testSchemaEquality<VariantDto>()(zodVariantSchema, typeboxVariantSchema, {
-          id: 'test',
-          productId: 'prod-1',
-          externalId: 'var-1',
-          title: 'Black',
-          priceCents: 1999
-        })
+        testSchemaEquality<VariantDto>()(
+          zodVariantSchema,
+          typeboxVariantSchema,
+          {
+            id: 'test',
+            productId: 'prod-1',
+            externalId: 'var-1',
+            title: 'Black',
+            priceCents: 1999
+          }
+        )
       )
     ).toBeTruthy();
   });
@@ -203,6 +212,4 @@ describe('schema equality', () => {
       )
     ).toBeTruthy();
   });
-
-  // Remaining entities' equality tests are added incrementally as each PR lands.
 });

--- a/blueprint/implementations/ecommerce/base/domain/schemas/index.ts
+++ b/blueprint/implementations/ecommerce/base/domain/schemas/index.ts
@@ -1,3 +1,4 @@
 export * from './inventory.schema';
+export * from './product.schema';
 export * from './variant.schema';
 // Remaining combined zod/typebox schemas are added incrementally as each entity's PR lands.

--- a/blueprint/implementations/ecommerce/base/domain/schemas/index.ts
+++ b/blueprint/implementations/ecommerce/base/domain/schemas/index.ts
@@ -1,4 +1,3 @@
 export * from './inventory.schema';
 export * from './product.schema';
 export * from './variant.schema';
-// Remaining combined zod/typebox schemas are added incrementally as each entity's PR lands.

--- a/blueprint/implementations/ecommerce/base/domain/schemas/index.ts
+++ b/blueprint/implementations/ecommerce/base/domain/schemas/index.ts
@@ -1,2 +1,3 @@
+export * from './inventory.schema';
 export * from './variant.schema';
 // Remaining combined zod/typebox schemas are added incrementally as each entity's PR lands.

--- a/blueprint/implementations/ecommerce/base/domain/schemas/inventory.schema.ts
+++ b/blueprint/implementations/ecommerce/base/domain/schemas/inventory.schema.ts
@@ -1,0 +1,8 @@
+import { serviceSchemaResolver } from '@forklaunch/internal';
+import { BaseInventoryServiceSchemas as TypeBoxSchemas } from './typebox/inventory.schema';
+import { BaseInventoryServiceSchemas as ZodSchemas } from './zod/inventory.schema';
+
+export const BaseInventoryServiceSchemas = serviceSchemaResolver(
+  TypeBoxSchemas,
+  ZodSchemas
+);

--- a/blueprint/implementations/ecommerce/base/domain/schemas/product.schema.ts
+++ b/blueprint/implementations/ecommerce/base/domain/schemas/product.schema.ts
@@ -1,0 +1,8 @@
+import { serviceSchemaResolver } from '@forklaunch/internal';
+import { BaseProductServiceSchemas as TypeBoxSchemas } from './typebox/product.schema';
+import { BaseProductServiceSchemas as ZodSchemas } from './zod/product.schema';
+
+export const BaseProductServiceSchemas = serviceSchemaResolver(
+  TypeBoxSchemas,
+  ZodSchemas
+);

--- a/blueprint/implementations/ecommerce/base/domain/schemas/typebox/inventory.schema.ts
+++ b/blueprint/implementations/ecommerce/base/domain/schemas/typebox/inventory.schema.ts
@@ -1,0 +1,42 @@
+import {
+  date,
+  number,
+  optional,
+  string,
+  uuid
+} from '@forklaunch/validator/typebox';
+
+export const CreateInventorySchema = {
+  variantId: string,
+  stock: number
+};
+
+export const UpdateInventorySchema = ({ uuidId }: { uuidId: boolean }) => ({
+  id: uuidId ? uuid : string,
+  variantId: optional(string),
+  stock: optional(number)
+});
+
+export const InventorySchema = ({ uuidId }: { uuidId: boolean }) => ({
+  id: uuidId ? uuid : string,
+  variantId: string,
+  stock: number,
+  createdAt: optional(date),
+  updatedAt: optional(date)
+});
+
+export const AdjustStockSchema = {
+  variantId: string,
+  delta: number
+};
+
+export const StockCheckSchema = {
+  variantId: string,
+  requested: number
+};
+
+export const BaseInventoryServiceSchemas = (options: { uuidId: boolean }) => ({
+  CreateInventorySchema,
+  UpdateInventorySchema: UpdateInventorySchema(options),
+  InventorySchema: InventorySchema(options)
+});

--- a/blueprint/implementations/ecommerce/base/domain/schemas/typebox/product.schema.ts
+++ b/blueprint/implementations/ecommerce/base/domain/schemas/typebox/product.schema.ts
@@ -1,0 +1,69 @@
+import {
+  array,
+  boolean,
+  date,
+  number,
+  optional,
+  string,
+  uuid
+} from '@forklaunch/validator/typebox';
+
+const ProductOptionSchema = {
+  name: string,
+  isPackQuantity: boolean,
+  values: array(string)
+};
+
+const ProductImageSchema = {
+  src: string,
+  position: number
+};
+
+export const CreateProductSchema = {
+  externalId: string,
+  handle: string,
+  sourceUrl: optional(string),
+  title: string,
+  descriptionHtml: optional(string),
+  vendor: optional(string),
+  productType: optional(string),
+  tags: optional(array(string)),
+  options: optional(array(ProductOptionSchema)),
+  images: optional(array(ProductImageSchema))
+};
+
+export const UpdateProductSchema = ({ uuidId }: { uuidId: boolean }) => ({
+  id: uuidId ? uuid : string,
+  externalId: optional(string),
+  handle: optional(string),
+  sourceUrl: optional(string),
+  title: optional(string),
+  descriptionHtml: optional(string),
+  vendor: optional(string),
+  productType: optional(string),
+  tags: optional(array(string)),
+  options: optional(array(ProductOptionSchema)),
+  images: optional(array(ProductImageSchema))
+});
+
+export const ProductSchema = ({ uuidId }: { uuidId: boolean }) => ({
+  id: uuidId ? uuid : string,
+  externalId: string,
+  handle: string,
+  sourceUrl: optional(string),
+  title: string,
+  descriptionHtml: optional(string),
+  vendor: optional(string),
+  productType: optional(string),
+  tags: optional(array(string)),
+  options: optional(array(ProductOptionSchema)),
+  images: optional(array(ProductImageSchema)),
+  createdAt: optional(date),
+  updatedAt: optional(date)
+});
+
+export const BaseProductServiceSchemas = (options: { uuidId: boolean }) => ({
+  CreateProductSchema,
+  UpdateProductSchema: UpdateProductSchema(options),
+  ProductSchema: ProductSchema(options)
+});

--- a/blueprint/implementations/ecommerce/base/domain/schemas/zod/inventory.schema.ts
+++ b/blueprint/implementations/ecommerce/base/domain/schemas/zod/inventory.schema.ts
@@ -1,0 +1,42 @@
+import {
+  date,
+  number,
+  optional,
+  string,
+  uuid
+} from '@forklaunch/validator/zod';
+
+export const CreateInventorySchema = {
+  variantId: string,
+  stock: number
+};
+
+export const UpdateInventorySchema = ({ uuidId }: { uuidId: boolean }) => ({
+  id: uuidId ? uuid : string,
+  variantId: optional(string),
+  stock: optional(number)
+});
+
+export const InventorySchema = ({ uuidId }: { uuidId: boolean }) => ({
+  id: uuidId ? uuid : string,
+  variantId: string,
+  stock: number,
+  createdAt: optional(date),
+  updatedAt: optional(date)
+});
+
+export const AdjustStockSchema = {
+  variantId: string,
+  delta: number
+};
+
+export const StockCheckSchema = {
+  variantId: string,
+  requested: number
+};
+
+export const BaseInventoryServiceSchemas = (options: { uuidId: boolean }) => ({
+  CreateInventorySchema,
+  UpdateInventorySchema: UpdateInventorySchema(options),
+  InventorySchema: InventorySchema(options)
+});

--- a/blueprint/implementations/ecommerce/base/domain/schemas/zod/product.schema.ts
+++ b/blueprint/implementations/ecommerce/base/domain/schemas/zod/product.schema.ts
@@ -1,0 +1,69 @@
+import {
+  array,
+  boolean,
+  date,
+  number,
+  optional,
+  string,
+  uuid
+} from '@forklaunch/validator/zod';
+
+const ProductOptionSchema = {
+  name: string,
+  isPackQuantity: boolean,
+  values: array(string)
+};
+
+const ProductImageSchema = {
+  src: string,
+  position: number
+};
+
+export const CreateProductSchema = {
+  externalId: string,
+  handle: string,
+  sourceUrl: optional(string),
+  title: string,
+  descriptionHtml: optional(string),
+  vendor: optional(string),
+  productType: optional(string),
+  tags: optional(array(string)),
+  options: optional(array(ProductOptionSchema)),
+  images: optional(array(ProductImageSchema))
+};
+
+export const UpdateProductSchema = ({ uuidId }: { uuidId: boolean }) => ({
+  id: uuidId ? uuid : string,
+  externalId: optional(string),
+  handle: optional(string),
+  sourceUrl: optional(string),
+  title: optional(string),
+  descriptionHtml: optional(string),
+  vendor: optional(string),
+  productType: optional(string),
+  tags: optional(array(string)),
+  options: optional(array(ProductOptionSchema)),
+  images: optional(array(ProductImageSchema))
+});
+
+export const ProductSchema = ({ uuidId }: { uuidId: boolean }) => ({
+  id: uuidId ? uuid : string,
+  externalId: string,
+  handle: string,
+  sourceUrl: optional(string),
+  title: string,
+  descriptionHtml: optional(string),
+  vendor: optional(string),
+  productType: optional(string),
+  tags: optional(array(string)),
+  options: optional(array(ProductOptionSchema)),
+  images: optional(array(ProductImageSchema)),
+  createdAt: optional(date),
+  updatedAt: optional(date)
+});
+
+export const BaseProductServiceSchemas = (options: { uuidId: boolean }) => ({
+  CreateProductSchema,
+  UpdateProductSchema: UpdateProductSchema(options),
+  ProductSchema: ProductSchema(options)
+});

--- a/blueprint/implementations/ecommerce/base/domain/types/baseEcommerceDto.types.ts
+++ b/blueprint/implementations/ecommerce/base/domain/types/baseEcommerceDto.types.ts
@@ -1,5 +1,8 @@
 import {
+  CreateInventoryDto,
   CreateVariantDto,
+  InventoryDto,
+  UpdateInventoryDto,
   UpdateVariantDto,
   VariantDto
 } from '@forklaunch/interfaces-ecommerce/types';
@@ -9,6 +12,13 @@ export type BaseVariantDtos = {
   VariantMapper: VariantDto;
   CreateVariantMapper: CreateVariantDto;
   UpdateVariantMapper: UpdateVariantDto;
+};
+
+// inventory dto types
+export type BaseInventoryDtos = {
+  InventoryMapper: InventoryDto;
+  CreateInventoryMapper: CreateInventoryDto;
+  UpdateInventoryMapper: UpdateInventoryDto;
 };
 
 // Remaining entities' Dto aggregates are added incrementally as each PR lands.

--- a/blueprint/implementations/ecommerce/base/domain/types/baseEcommerceDto.types.ts
+++ b/blueprint/implementations/ecommerce/base/domain/types/baseEcommerceDto.types.ts
@@ -30,5 +30,3 @@ export type BaseInventoryDtos = {
   CreateInventoryMapper: CreateInventoryDto;
   UpdateInventoryMapper: UpdateInventoryDto;
 };
-
-// Remaining entities' Dto aggregates are added incrementally as each PR lands.

--- a/blueprint/implementations/ecommerce/base/domain/types/baseEcommerceDto.types.ts
+++ b/blueprint/implementations/ecommerce/base/domain/types/baseEcommerceDto.types.ts
@@ -1,11 +1,21 @@
 import {
   CreateInventoryDto,
+  CreateProductDto,
   CreateVariantDto,
   InventoryDto,
+  ProductDto,
   UpdateInventoryDto,
+  UpdateProductDto,
   UpdateVariantDto,
   VariantDto
 } from '@forklaunch/interfaces-ecommerce/types';
+
+// product dto types
+export type BaseProductDtos = {
+  ProductMapper: ProductDto;
+  CreateProductMapper: CreateProductDto;
+  UpdateProductMapper: UpdateProductDto;
+};
 
 // variant dto types
 export type BaseVariantDtos = {

--- a/blueprint/implementations/ecommerce/base/domain/types/baseEcommerceEntity.types.ts
+++ b/blueprint/implementations/ecommerce/base/domain/types/baseEcommerceEntity.types.ts
@@ -1,4 +1,11 @@
-import { Inventory, Variant } from '../../persistence/entities';
+import { Inventory, Product, Variant } from '../../persistence/entities';
+
+// product entity types
+export type BaseProductEntities = {
+  ProductMapper: { '~entity': (typeof Product)['~entity'] };
+  CreateProductMapper: { '~entity': (typeof Product)['~entity'] };
+  UpdateProductMapper: { '~entity': (typeof Product)['~entity'] };
+};
 
 // variant entity types
 export type BaseVariantEntities = {

--- a/blueprint/implementations/ecommerce/base/domain/types/baseEcommerceEntity.types.ts
+++ b/blueprint/implementations/ecommerce/base/domain/types/baseEcommerceEntity.types.ts
@@ -20,5 +20,3 @@ export type BaseInventoryEntities = {
   CreateInventoryMapper: { '~entity': (typeof Inventory)['~entity'] };
   UpdateInventoryMapper: { '~entity': (typeof Inventory)['~entity'] };
 };
-
-// Remaining entities' Entity aggregates are added incrementally as each PR lands.

--- a/blueprint/implementations/ecommerce/base/domain/types/baseEcommerceEntity.types.ts
+++ b/blueprint/implementations/ecommerce/base/domain/types/baseEcommerceEntity.types.ts
@@ -1,10 +1,17 @@
-import { Variant } from '../../persistence/entities';
+import { Inventory, Variant } from '../../persistence/entities';
 
 // variant entity types
 export type BaseVariantEntities = {
   VariantMapper: { '~entity': (typeof Variant)['~entity'] };
   CreateVariantMapper: { '~entity': (typeof Variant)['~entity'] };
   UpdateVariantMapper: { '~entity': (typeof Variant)['~entity'] };
+};
+
+// inventory entity types
+export type BaseInventoryEntities = {
+  InventoryMapper: { '~entity': (typeof Inventory)['~entity'] };
+  CreateInventoryMapper: { '~entity': (typeof Inventory)['~entity'] };
+  UpdateInventoryMapper: { '~entity': (typeof Inventory)['~entity'] };
 };
 
 // Remaining entities' Entity aggregates are added incrementally as each PR lands.

--- a/blueprint/implementations/ecommerce/base/domain/types/index.ts
+++ b/blueprint/implementations/ecommerce/base/domain/types/index.ts
@@ -1,5 +1,6 @@
 export * from './baseEcommerceDto.types';
 export * from './baseEcommerceEntity.types';
 export * from './inventory.mapper.types';
+export * from './product.mapper.types';
 export * from './variant.mapper.types';
 // Remaining per-entity mapper.types exports are added incrementally as each PR lands.

--- a/blueprint/implementations/ecommerce/base/domain/types/index.ts
+++ b/blueprint/implementations/ecommerce/base/domain/types/index.ts
@@ -1,4 +1,5 @@
 export * from './baseEcommerceDto.types';
 export * from './baseEcommerceEntity.types';
+export * from './inventory.mapper.types';
 export * from './variant.mapper.types';
 // Remaining per-entity mapper.types exports are added incrementally as each PR lands.

--- a/blueprint/implementations/ecommerce/base/domain/types/index.ts
+++ b/blueprint/implementations/ecommerce/base/domain/types/index.ts
@@ -3,4 +3,3 @@ export * from './baseEcommerceEntity.types';
 export * from './inventory.mapper.types';
 export * from './product.mapper.types';
 export * from './variant.mapper.types';
-// Remaining per-entity mapper.types exports are added incrementally as each PR lands.

--- a/blueprint/implementations/ecommerce/base/domain/types/inventory.mapper.types.ts
+++ b/blueprint/implementations/ecommerce/base/domain/types/inventory.mapper.types.ts
@@ -1,0 +1,31 @@
+import { EntityManager, InferEntity } from '@mikro-orm/core';
+import { BaseInventoryDtos } from './baseEcommerceDto.types';
+import { BaseInventoryEntities } from './baseEcommerceEntity.types';
+
+export type InventoryMappers<
+  MapperEntities extends BaseInventoryEntities,
+  MapperDomains extends BaseInventoryDtos = BaseInventoryDtos
+> = {
+  InventoryMapper: {
+    entity: MapperEntities['InventoryMapper'];
+    toDto: (
+      entity: InferEntity<MapperEntities['InventoryMapper']>
+    ) => Promise<MapperDomains['InventoryMapper']>;
+  };
+  CreateInventoryMapper: {
+    entity: MapperEntities['CreateInventoryMapper'];
+    toEntity: (
+      dto: MapperDomains['CreateInventoryMapper'],
+      em: EntityManager,
+      ...args: unknown[]
+    ) => Promise<InferEntity<MapperEntities['CreateInventoryMapper']>>;
+  };
+  UpdateInventoryMapper: {
+    entity: MapperEntities['UpdateInventoryMapper'];
+    toEntity: (
+      dto: MapperDomains['UpdateInventoryMapper'],
+      em: EntityManager,
+      ...args: unknown[]
+    ) => Promise<InferEntity<MapperEntities['UpdateInventoryMapper']>>;
+  };
+};

--- a/blueprint/implementations/ecommerce/base/domain/types/product.mapper.types.ts
+++ b/blueprint/implementations/ecommerce/base/domain/types/product.mapper.types.ts
@@ -1,0 +1,31 @@
+import { EntityManager, InferEntity } from '@mikro-orm/core';
+import { BaseProductDtos } from './baseEcommerceDto.types';
+import { BaseProductEntities } from './baseEcommerceEntity.types';
+
+export type ProductMappers<
+  MapperEntities extends BaseProductEntities,
+  MapperDomains extends BaseProductDtos = BaseProductDtos
+> = {
+  ProductMapper: {
+    entity: MapperEntities['ProductMapper'];
+    toDto: (
+      entity: InferEntity<MapperEntities['ProductMapper']>
+    ) => Promise<MapperDomains['ProductMapper']>;
+  };
+  CreateProductMapper: {
+    entity: MapperEntities['CreateProductMapper'];
+    toEntity: (
+      dto: MapperDomains['CreateProductMapper'],
+      em: EntityManager,
+      ...args: unknown[]
+    ) => Promise<InferEntity<MapperEntities['CreateProductMapper']>>;
+  };
+  UpdateProductMapper: {
+    entity: MapperEntities['UpdateProductMapper'];
+    toEntity: (
+      dto: MapperDomains['UpdateProductMapper'],
+      em: EntityManager,
+      ...args: unknown[]
+    ) => Promise<InferEntity<MapperEntities['UpdateProductMapper']>>;
+  };
+};

--- a/blueprint/implementations/ecommerce/base/persistence/entities/index.ts
+++ b/blueprint/implementations/ecommerce/base/persistence/entities/index.ts
@@ -1,4 +1,5 @@
 import { defineComplianceEntity, fp } from '@forklaunch/core/persistence';
+import { ProductImage, ProductOption } from '@forklaunch/interfaces-ecommerce/types';
 
 /**
  * Base template entities — the typing scaffolds the generic base services
@@ -11,6 +12,23 @@ import { defineComplianceEntity, fp } from '@forklaunch/core/persistence';
  *
  * Added incrementally as each entity's PR lands.
  */
+export const Product = defineComplianceEntity({
+  name: 'Product',
+  properties: {
+    id: fp.string().primary().compliance('none'),
+    externalId: fp.string().compliance('none'),
+    handle: fp.string().compliance('none'),
+    sourceUrl: fp.string().nullable().compliance('none'),
+    title: fp.string().compliance('none'),
+    descriptionHtml: fp.string().nullable().compliance('none'),
+    vendor: fp.string().nullable().compliance('none'),
+    productType: fp.string().nullable().compliance('none'),
+    tags: fp.string().array().nullable().compliance('none'),
+    options: fp.json<ProductOption[]>().nullable().compliance('none'),
+    images: fp.json<ProductImage[]>().nullable().compliance('none')
+  }
+});
+
 export const Variant = defineComplianceEntity({
   name: 'Variant',
   properties: {

--- a/blueprint/implementations/ecommerce/base/persistence/entities/index.ts
+++ b/blueprint/implementations/ecommerce/base/persistence/entities/index.ts
@@ -1,5 +1,8 @@
 import { defineComplianceEntity, fp } from '@forklaunch/core/persistence';
-import { ProductImage, ProductOption } from '@forklaunch/interfaces-ecommerce/types';
+import {
+  ProductImage,
+  ProductOption
+} from '@forklaunch/interfaces-ecommerce/types';
 
 /**
  * Base template entities — the typing scaffolds the generic base services
@@ -9,8 +12,6 @@ import { ProductImage, ProductOption } from '@forklaunch/interfaces-ecommerce/ty
  * Catalog data (products, variants, stock) carries no PII/PCI, so every field
  * is compliance('none'). PII/PCI tagging becomes relevant with customer/order
  * entities in later stages.
- *
- * Added incrementally as each entity's PR lands.
  */
 export const Product = defineComplianceEntity({
   name: 'Product',
@@ -37,7 +38,10 @@ export const Variant = defineComplianceEntity({
     externalId: fp.string().compliance('none'),
     sku: fp.string().nullable().compliance('none'),
     title: fp.string().compliance('none'),
-    optionValues: fp.json<Record<string, string>>().nullable().compliance('none'),
+    optionValues: fp
+      .json<Record<string, string>>()
+      .nullable()
+      .compliance('none'),
     priceCents: fp.integer().compliance('none'),
     compareAtPriceCents: fp.integer().nullable().compliance('none'),
     requiresShipping: fp.boolean().compliance('none')

--- a/blueprint/implementations/ecommerce/base/persistence/entities/index.ts
+++ b/blueprint/implementations/ecommerce/base/persistence/entities/index.ts
@@ -25,3 +25,12 @@ export const Variant = defineComplianceEntity({
     requiresShipping: fp.boolean().compliance('none')
   }
 });
+
+export const Inventory = defineComplianceEntity({
+  name: 'Inventory',
+  properties: {
+    id: fp.string().primary().compliance('none'),
+    variantId: fp.string().compliance('none'),
+    stock: fp.integer().compliance('none')
+  }
+});

--- a/blueprint/implementations/ecommerce/base/services/index.ts
+++ b/blueprint/implementations/ecommerce/base/services/index.ts
@@ -1,3 +1,4 @@
+export * from './inventory.service';
 export * from './variant.service';
 // Remaining per-entity services are added incrementally as each PR lands.
 

--- a/blueprint/implementations/ecommerce/base/services/index.ts
+++ b/blueprint/implementations/ecommerce/base/services/index.ts
@@ -1,4 +1,5 @@
 export * from './inventory.service';
+export * from './product.service';
 export * from './variant.service';
 // Remaining per-entity services are added incrementally as each PR lands.
 

--- a/blueprint/implementations/ecommerce/base/services/index.ts
+++ b/blueprint/implementations/ecommerce/base/services/index.ts
@@ -1,7 +1,6 @@
 export * from './inventory.service';
 export * from './product.service';
 export * from './variant.service';
-// Remaining per-entity services are added incrementally as each PR lands.
 
 export * from '@forklaunch/interfaces-ecommerce/interfaces';
 export * from '@forklaunch/interfaces-ecommerce/types';

--- a/blueprint/implementations/ecommerce/base/services/inventory.service.ts
+++ b/blueprint/implementations/ecommerce/base/services/inventory.service.ts
@@ -1,0 +1,161 @@
+import {
+  evaluateTelemetryOptions,
+  MetricsDefinition,
+  OpenTelemetryCollector,
+  TelemetryOptions
+} from '@forklaunch/core/http';
+import { InventoryService } from '@forklaunch/interfaces-ecommerce/interfaces';
+import {
+  AdjustStockDto,
+  CreateInventoryDto,
+  StockCheckDto,
+  StockCheckResultDto
+} from '@forklaunch/interfaces-ecommerce/types';
+import { AnySchemaValidator } from '@forklaunch/validator';
+import { EntityManager, InferEntity, raw } from '@mikro-orm/core';
+import { BaseInventoryDtos } from '../domain/types/baseEcommerceDto.types';
+import { BaseInventoryEntities } from '../domain/types/baseEcommerceEntity.types';
+import { InventoryMappers } from '../domain/types/inventory.mapper.types';
+import { Inventory } from '../persistence/entities';
+
+export class BaseInventoryService<
+  SchemaValidator extends AnySchemaValidator,
+  MapperEntities extends BaseInventoryEntities,
+  MapperDomains extends BaseInventoryDtos = BaseInventoryDtos
+> implements InventoryService
+{
+  private evaluatedTelemetryOptions: {
+    logging?: boolean;
+    metrics?: boolean;
+    tracing?: boolean;
+  };
+  public em: EntityManager;
+  protected openTelemetryCollector: OpenTelemetryCollector<MetricsDefinition>;
+  protected schemaValidator: SchemaValidator;
+  protected mappers: InventoryMappers<MapperEntities, MapperDomains>;
+
+  constructor(
+    em: EntityManager,
+    openTelemetryCollector: OpenTelemetryCollector<MetricsDefinition>,
+    schemaValidator: SchemaValidator,
+    mappers: InventoryMappers<MapperEntities, MapperDomains>,
+    options?: {
+      telemetry?: TelemetryOptions;
+    }
+  ) {
+    this.em = em;
+    this.openTelemetryCollector = openTelemetryCollector;
+    this.schemaValidator = schemaValidator;
+    this.mappers = mappers;
+    this.evaluatedTelemetryOptions = options?.telemetry
+      ? evaluateTelemetryOptions(options.telemetry).enabled
+      : {
+          logging: false,
+          metrics: false,
+          tracing: false
+        };
+  }
+
+  async createInventory(
+    inventoryDto: CreateInventoryDto,
+    em?: EntityManager,
+    ...args: unknown[]
+  ): Promise<MapperDomains['InventoryMapper']> {
+    if (this.evaluatedTelemetryOptions.logging) {
+      this.openTelemetryCollector.info('Creating inventory', inventoryDto);
+    }
+    const inventory = await this.mappers.CreateInventoryMapper.toEntity(
+      inventoryDto,
+      em ?? this.em,
+      ...(args[0] instanceof EntityManager ? args.slice(1) : args)
+    );
+    await (em ?? this.em).transactional(async (innerEm) => {
+      await innerEm.persist(inventory);
+    });
+    return this.mappers.InventoryMapper.toDto(inventory);
+  }
+
+  async getInventory(
+    variantIdDto: { variantId: string },
+    em?: EntityManager
+  ): Promise<MapperDomains['InventoryMapper']> {
+    if (this.evaluatedTelemetryOptions.logging) {
+      this.openTelemetryCollector.info('Getting inventory', variantIdDto);
+    }
+    const inventory = await (em ?? this.em).findOneOrFail(
+      this.mappers.InventoryMapper.entity as typeof Inventory,
+      { variantId: variantIdDto.variantId }
+    );
+    return this.mappers.InventoryMapper.toDto(
+      inventory as InferEntity<MapperEntities['InventoryMapper']>
+    );
+  }
+
+  async adjustStock(
+    adjustDto: AdjustStockDto,
+    em?: EntityManager
+  ): Promise<MapperDomains['InventoryMapper']> {
+    if (this.evaluatedTelemetryOptions.logging) {
+      this.openTelemetryCollector.info('Adjusting stock', adjustDto);
+    }
+    const entityManager = em ?? this.em;
+    const entity = this.mappers.InventoryMapper.entity as typeof Inventory;
+
+    // Atomic conditional adjustment — the decrement/oversell guard lives in
+    // the WHERE clause, not in app memory, so two concurrent orders for the
+    // last unit can't both pass a stale read. Guild's commerce-security guide
+    // is explicit this must never be a read-then-write across an await; this
+    // is the same nativeUpdate+raw idiom used in gift-card/promo redemption.
+    // A decrement (delta < 0) only applies where stock still covers it; a
+    // restock (delta >= 0) is always safe, so no guard is needed.
+    const where =
+      adjustDto.delta < 0
+        ? { variantId: adjustDto.variantId, stock: { $gte: -adjustDto.delta } }
+        : { variantId: adjustDto.variantId };
+    const affected = await entityManager.nativeUpdate(entity, where, {
+      stock: raw('stock + ?', [adjustDto.delta])
+    });
+
+    if (affected === 0) {
+      // Zero rows changed: either the variant has no inventory row, or the
+      // guard blocked an oversell. Disambiguate so the caller gets a useful
+      // error rather than a bare "not found".
+      const existing = await entityManager.findOne(entity, {
+        variantId: adjustDto.variantId
+      });
+      if (!existing) {
+        throw new Error(
+          `No inventory record for variant ${adjustDto.variantId}`
+        );
+      }
+      throw new Error(
+        `Insufficient stock for variant ${adjustDto.variantId}: have ${existing.stock}, requested change ${adjustDto.delta}`
+      );
+    }
+
+    const inventory = await entityManager.findOneOrFail(entity, {
+      variantId: adjustDto.variantId
+    });
+    return this.mappers.InventoryMapper.toDto(
+      inventory as InferEntity<MapperEntities['InventoryMapper']>
+    );
+  }
+
+  async checkStock(
+    stockCheckDto: StockCheckDto,
+    em?: EntityManager
+  ): Promise<StockCheckResultDto> {
+    if (this.evaluatedTelemetryOptions.logging) {
+      this.openTelemetryCollector.info('Checking stock', stockCheckDto);
+    }
+    const inventory = await (em ?? this.em).findOneOrFail(
+      this.mappers.InventoryMapper.entity as typeof Inventory,
+      { variantId: stockCheckDto.variantId }
+    );
+    return {
+      variantId: stockCheckDto.variantId,
+      available: inventory.stock >= stockCheckDto.requested,
+      stock: inventory.stock
+    };
+  }
+}

--- a/blueprint/implementations/ecommerce/base/services/product.service.ts
+++ b/blueprint/implementations/ecommerce/base/services/product.service.ts
@@ -57,7 +57,7 @@ export class BaseProductService<
   }
 
   /**
-   * Product-level half of catalog search/filter (ECOM-03): `ids` and
+   * Product-level half of catalog search/filter: `ids` and
    * `title`. Price/stock/option-value filters are variant-level and are
    * resolved one layer up, at the deployable app's controller — this
    * service only knows about Product, not Variant/Inventory — which then
@@ -176,13 +176,18 @@ export class BaseProductService<
       em ?? this.em,
       ...args
     );
-    const updatedProduct = await (em ?? this.em).transactional(async (innerEm) => {
-      return await innerEm.upsert(product);
-    });
+    const updatedProduct = await (em ?? this.em).transactional(
+      async (innerEm) => {
+        return await innerEm.upsert(product);
+      }
+    );
     return this.mappers.ProductMapper.toDto(updatedProduct);
   }
 
-  async deleteProduct(idDto: { id: string }, em?: EntityManager): Promise<void> {
+  async deleteProduct(
+    idDto: { id: string },
+    em?: EntityManager
+  ): Promise<void> {
     if (this.evaluatedTelemetryOptions.logging) {
       this.openTelemetryCollector.info('Deleting product', idDto);
     }

--- a/blueprint/implementations/ecommerce/base/services/product.service.ts
+++ b/blueprint/implementations/ecommerce/base/services/product.service.ts
@@ -176,9 +176,8 @@ export class BaseProductService<
       em ?? this.em,
       ...args
     );
-    const updatedProduct = await (em ?? this.em).upsert(product);
-    await (em ?? this.em).transactional(async (innerEm) => {
-      await innerEm.persist(product);
+    const updatedProduct = await (em ?? this.em).transactional(async (innerEm) => {
+      return await innerEm.upsert(product);
     });
     return this.mappers.ProductMapper.toDto(updatedProduct);
   }

--- a/blueprint/implementations/ecommerce/base/services/product.service.ts
+++ b/blueprint/implementations/ecommerce/base/services/product.service.ts
@@ -1,0 +1,195 @@
+import { IdDto } from '@forklaunch/common';
+import {
+  evaluateTelemetryOptions,
+  MetricsDefinition,
+  OpenTelemetryCollector,
+  TelemetryOptions
+} from '@forklaunch/core/http';
+import { ProductService } from '@forklaunch/interfaces-ecommerce/interfaces';
+import {
+  CreateProductDto,
+  ProductSearchDto,
+  UpdateProductDto
+} from '@forklaunch/interfaces-ecommerce/types';
+import { AnySchemaValidator } from '@forklaunch/validator';
+import { EntityManager, InferEntity } from '@mikro-orm/core';
+import { BaseProductDtos } from '../domain/types/baseEcommerceDto.types';
+import { BaseProductEntities } from '../domain/types/baseEcommerceEntity.types';
+import { ProductMappers } from '../domain/types/product.mapper.types';
+import { Product } from '../persistence/entities';
+
+export class BaseProductService<
+  SchemaValidator extends AnySchemaValidator,
+  MapperEntities extends BaseProductEntities,
+  MapperDomains extends BaseProductDtos = BaseProductDtos
+> implements ProductService
+{
+  private evaluatedTelemetryOptions: {
+    logging?: boolean;
+    metrics?: boolean;
+    tracing?: boolean;
+  };
+  public em: EntityManager;
+  protected openTelemetryCollector: OpenTelemetryCollector<MetricsDefinition>;
+  protected schemaValidator: SchemaValidator;
+  protected mappers: ProductMappers<MapperEntities, MapperDomains>;
+
+  constructor(
+    em: EntityManager,
+    openTelemetryCollector: OpenTelemetryCollector<MetricsDefinition>,
+    schemaValidator: SchemaValidator,
+    mappers: ProductMappers<MapperEntities, MapperDomains>,
+    options?: {
+      telemetry?: TelemetryOptions;
+    }
+  ) {
+    this.em = em;
+    this.openTelemetryCollector = openTelemetryCollector;
+    this.schemaValidator = schemaValidator;
+    this.mappers = mappers;
+    this.evaluatedTelemetryOptions = options?.telemetry
+      ? evaluateTelemetryOptions(options.telemetry).enabled
+      : {
+          logging: false,
+          metrics: false,
+          tracing: false
+        };
+  }
+
+  /**
+   * Product-level half of catalog search/filter (ECOM-03): `ids` and
+   * `title`. Price/stock/option-value filters are variant-level and are
+   * resolved one layer up, at the deployable app's controller — this
+   * service only knows about Product, not Variant/Inventory — which then
+   * narrows to a candidate `ids` set before calling this.
+   */
+  async listProducts(
+    searchDto?: ProductSearchDto,
+    em?: EntityManager
+  ): Promise<MapperDomains['ProductMapper'][]> {
+    if (this.evaluatedTelemetryOptions.logging) {
+      this.openTelemetryCollector.info('Listing products', searchDto);
+    }
+
+    const where: Record<string, unknown> = {};
+    if (searchDto?.ids?.length) {
+      where.id = { $in: searchDto.ids };
+    }
+    if (searchDto?.title) {
+      where.title = { $ilike: `%${searchDto.title}%` };
+    }
+
+    return Promise.all(
+      (
+        await (em ?? this.em).findAll(
+          this.mappers.ProductMapper.entity as typeof Product,
+          { where: Object.keys(where).length ? where : undefined }
+        )
+      ).map((product) =>
+        this.mappers.ProductMapper.toDto(
+          product as InferEntity<MapperEntities['ProductMapper']>
+        )
+      )
+    );
+  }
+
+  async createProduct(
+    productDto: CreateProductDto,
+    em?: EntityManager,
+    ...args: unknown[]
+  ): Promise<MapperDomains['ProductMapper']> {
+    if (this.evaluatedTelemetryOptions.logging) {
+      this.openTelemetryCollector.info('Creating product', productDto);
+    }
+    const product = await this.mappers.CreateProductMapper.toEntity(
+      productDto,
+      em ?? this.em,
+      ...(args[0] instanceof EntityManager ? args.slice(1) : args)
+    );
+    await (em ?? this.em).transactional(async (innerEm) => {
+      await innerEm.persist(product);
+    });
+    return this.mappers.ProductMapper.toDto(product);
+  }
+
+  async getProduct(
+    idDto: IdDto,
+    em?: EntityManager
+  ): Promise<MapperDomains['ProductMapper']> {
+    if (this.evaluatedTelemetryOptions.logging) {
+      this.openTelemetryCollector.info('Getting product', idDto);
+    }
+    const product = await (em ?? this.em).findOneOrFail(
+      this.mappers.ProductMapper.entity as typeof Product,
+      idDto
+    );
+    return this.mappers.ProductMapper.toDto(
+      product as InferEntity<MapperEntities['ProductMapper']>
+    );
+  }
+
+  async getProductByHandle(
+    handleDto: { handle: string },
+    em?: EntityManager
+  ): Promise<MapperDomains['ProductMapper']> {
+    if (this.evaluatedTelemetryOptions.logging) {
+      this.openTelemetryCollector.info('Getting product by handle', handleDto);
+    }
+    const product = await (em ?? this.em).findOneOrFail(
+      this.mappers.ProductMapper.entity as typeof Product,
+      { handle: handleDto.handle }
+    );
+    return this.mappers.ProductMapper.toDto(
+      product as InferEntity<MapperEntities['ProductMapper']>
+    );
+  }
+
+  async getProductByExternalId(
+    externalIdDto: { externalId: string },
+    em?: EntityManager
+  ): Promise<MapperDomains['ProductMapper']> {
+    if (this.evaluatedTelemetryOptions.logging) {
+      this.openTelemetryCollector.info(
+        'Getting product by externalId',
+        externalIdDto
+      );
+    }
+    const product = await (em ?? this.em).findOneOrFail(
+      this.mappers.ProductMapper.entity as typeof Product,
+      { externalId: externalIdDto.externalId }
+    );
+    return this.mappers.ProductMapper.toDto(
+      product as InferEntity<MapperEntities['ProductMapper']>
+    );
+  }
+
+  async updateProduct(
+    productDto: UpdateProductDto,
+    em?: EntityManager,
+    ...args: unknown[]
+  ): Promise<MapperDomains['ProductMapper']> {
+    if (this.evaluatedTelemetryOptions.logging) {
+      this.openTelemetryCollector.info('Updating product', productDto);
+    }
+    const product = await this.mappers.UpdateProductMapper.toEntity(
+      productDto,
+      em ?? this.em,
+      ...args
+    );
+    const updatedProduct = await (em ?? this.em).upsert(product);
+    await (em ?? this.em).transactional(async (innerEm) => {
+      await innerEm.persist(product);
+    });
+    return this.mappers.ProductMapper.toDto(updatedProduct);
+  }
+
+  async deleteProduct(idDto: { id: string }, em?: EntityManager): Promise<void> {
+    if (this.evaluatedTelemetryOptions.logging) {
+      this.openTelemetryCollector.info('Deleting product', idDto);
+    }
+    await (em ?? this.em).nativeDelete(
+      this.mappers.ProductMapper.entity as typeof Product,
+      idDto
+    );
+  }
+}

--- a/blueprint/interfaces/ecommerce/interfaces/index.ts
+++ b/blueprint/interfaces/ecommerce/interfaces/index.ts
@@ -1,4 +1,3 @@
 export * from './inventory.service.interface';
 export * from './product.service.interface';
 export * from './variant.service.interface';
-// Remaining service interfaces are added incrementally as each entity's PR lands.

--- a/blueprint/interfaces/ecommerce/interfaces/index.ts
+++ b/blueprint/interfaces/ecommerce/interfaces/index.ts
@@ -1,3 +1,4 @@
 export * from './inventory.service.interface';
+export * from './product.service.interface';
 export * from './variant.service.interface';
 // Remaining service interfaces are added incrementally as each entity's PR lands.

--- a/blueprint/interfaces/ecommerce/interfaces/index.ts
+++ b/blueprint/interfaces/ecommerce/interfaces/index.ts
@@ -1,2 +1,3 @@
+export * from './inventory.service.interface';
 export * from './variant.service.interface';
 // Remaining service interfaces are added incrementally as each entity's PR lands.

--- a/blueprint/interfaces/ecommerce/interfaces/inventory.service.interface.ts
+++ b/blueprint/interfaces/ecommerce/interfaces/inventory.service.interface.ts
@@ -4,7 +4,7 @@ import { InventoryServiceParameters } from '../types/inventory.service.types';
 export interface InventoryService<
   Params extends InventoryServiceParameters = InventoryServiceParameters
 > {
-  /** Called once per variant at catalog-import time (ECOM-04/import door). */
+  /** Called once per variant at catalog-import time (import door). */
   createInventory: (
     inventoryDto: Params['CreateInventoryDto'],
     em?: EntityManager

--- a/blueprint/interfaces/ecommerce/interfaces/inventory.service.interface.ts
+++ b/blueprint/interfaces/ecommerce/interfaces/inventory.service.interface.ts
@@ -1,0 +1,24 @@
+import { EntityManager } from '@mikro-orm/core';
+import { InventoryServiceParameters } from '../types/inventory.service.types';
+
+export interface InventoryService<
+  Params extends InventoryServiceParameters = InventoryServiceParameters
+> {
+  /** Called once per variant at catalog-import time (ECOM-04/import door). */
+  createInventory: (
+    inventoryDto: Params['CreateInventoryDto'],
+    em?: EntityManager
+  ) => Promise<Params['InventoryDto']>;
+  getInventory: (
+    variantIdDto: { variantId: string },
+    em?: EntityManager
+  ) => Promise<Params['InventoryDto']>;
+  adjustStock: (
+    adjustDto: Params['AdjustStockDto'],
+    em?: EntityManager
+  ) => Promise<Params['InventoryDto']>;
+  checkStock: (
+    stockCheckDto: Params['StockCheckDto'],
+    em?: EntityManager
+  ) => Promise<Params['StockCheckResultDto']>;
+}

--- a/blueprint/interfaces/ecommerce/interfaces/product.service.interface.ts
+++ b/blueprint/interfaces/ecommerce/interfaces/product.service.interface.ts
@@ -26,7 +26,7 @@ export interface ProductService<
     em?: EntityManager
   ) => Promise<Params['ProductDto']>;
   deleteProduct: (idDto: Params['IdDto'], em?: EntityManager) => Promise<void>;
-  /** Catalog search/filter (ECOM-03) — all fields optional and combinable. */
+  /** Catalog search/filter — all fields optional and combinable. */
   listProducts: (
     searchDto?: Params['SearchDto'],
     em?: EntityManager

--- a/blueprint/interfaces/ecommerce/interfaces/product.service.interface.ts
+++ b/blueprint/interfaces/ecommerce/interfaces/product.service.interface.ts
@@ -1,0 +1,34 @@
+import { EntityManager } from '@mikro-orm/core';
+import { ProductServiceParameters } from '../types/product.service.types';
+
+export interface ProductService<
+  Params extends ProductServiceParameters = ProductServiceParameters
+> {
+  createProduct: (
+    productDto: Params['CreateProductDto'],
+    em?: EntityManager
+  ) => Promise<Params['ProductDto']>;
+  getProduct: (
+    idDto: Params['IdDto'],
+    em?: EntityManager
+  ) => Promise<Params['ProductDto']>;
+  getProductByHandle: (
+    handleDto: { handle: string },
+    em?: EntityManager
+  ) => Promise<Params['ProductDto']>;
+  /** Throws if no product with this externalId exists — used to decide create-vs-update on import. */
+  getProductByExternalId: (
+    externalIdDto: { externalId: string },
+    em?: EntityManager
+  ) => Promise<Params['ProductDto']>;
+  updateProduct: (
+    productDto: Params['UpdateProductDto'],
+    em?: EntityManager
+  ) => Promise<Params['ProductDto']>;
+  deleteProduct: (idDto: Params['IdDto'], em?: EntityManager) => Promise<void>;
+  /** Catalog search/filter (ECOM-03) — all fields optional and combinable. */
+  listProducts: (
+    searchDto?: Params['SearchDto'],
+    em?: EntityManager
+  ) => Promise<Params['ProductDto'][]>;
+}

--- a/blueprint/interfaces/ecommerce/types/index.ts
+++ b/blueprint/interfaces/ecommerce/types/index.ts
@@ -1,3 +1,4 @@
 export * from './inventory.service.types';
+export * from './product.service.types';
 export * from './variant.service.types';
 // Remaining DTO types are added incrementally as each entity's PR lands.

--- a/blueprint/interfaces/ecommerce/types/index.ts
+++ b/blueprint/interfaces/ecommerce/types/index.ts
@@ -1,2 +1,3 @@
+export * from './inventory.service.types';
 export * from './variant.service.types';
 // Remaining DTO types are added incrementally as each entity's PR lands.

--- a/blueprint/interfaces/ecommerce/types/index.ts
+++ b/blueprint/interfaces/ecommerce/types/index.ts
@@ -1,4 +1,3 @@
 export * from './inventory.service.types';
 export * from './product.service.types';
 export * from './variant.service.types';
-// Remaining DTO types are added incrementally as each entity's PR lands.

--- a/blueprint/interfaces/ecommerce/types/inventory.service.types.ts
+++ b/blueprint/interfaces/ecommerce/types/inventory.service.types.ts
@@ -1,0 +1,38 @@
+import { IdDto, RecordTimingDto } from '@forklaunch/common';
+
+export type CreateInventoryDto = Partial<IdDto> & {
+  variantId: string;
+  stock: number;
+};
+
+export type UpdateInventoryDto = Partial<CreateInventoryDto> & IdDto;
+
+export type InventoryDto = CreateInventoryDto & IdDto & Partial<RecordTimingDto>;
+
+/** Manual stock adjustment; `delta` may be negative. No reservation in v1. */
+export type AdjustStockDto = {
+  variantId: string;
+  delta: number;
+};
+
+/** Synchronous "in stock?" check used at checkout. */
+export type StockCheckDto = {
+  variantId: string;
+  requested: number;
+};
+
+export type StockCheckResultDto = {
+  variantId: string;
+  available: boolean;
+  stock: number;
+};
+
+export type InventoryServiceParameters = {
+  CreateInventoryDto: CreateInventoryDto;
+  UpdateInventoryDto: UpdateInventoryDto;
+  InventoryDto: InventoryDto;
+  AdjustStockDto: AdjustStockDto;
+  StockCheckDto: StockCheckDto;
+  StockCheckResultDto: StockCheckResultDto;
+  IdDto: IdDto;
+};

--- a/blueprint/interfaces/ecommerce/types/product.service.types.ts
+++ b/blueprint/interfaces/ecommerce/types/product.service.types.ts
@@ -40,7 +40,7 @@ export type UpdateProductDto = Partial<CreateProductDto> & IdDto;
 export type ProductDto = CreateProductDto & IdDto & Partial<RecordTimingDto>;
 
 /**
- * Catalog search/filter (ECOM-03). `ids` narrows to specific products,
+ * Catalog search/filter. `ids` narrows to specific products,
  * everything else is optional and additive. Price/stock/option filters are
  * variant-level under the hood (Product itself carries no price) — a
  * product matches if at least one of its variants satisfies them.

--- a/blueprint/interfaces/ecommerce/types/product.service.types.ts
+++ b/blueprint/interfaces/ecommerce/types/product.service.types.ts
@@ -1,0 +1,67 @@
+import { IdDto, IdsDto, RecordTimingDto } from '@forklaunch/common';
+
+/**
+ * A product option dimension (e.g. "Color", "Size"). `isPackQuantity` flags the
+ * case surfaced in migration testing where a "Size"-named option actually
+ * encodes pack quantity (1 Can / 4 Pack / 12 Pack) rather than a physical size,
+ * and where pack semantics appear under arbitrary names ("Size", "Cans").
+ */
+export type ProductOption = {
+  name: string;
+  isPackQuantity: boolean;
+  values: string[];
+};
+
+export type ProductImage = {
+  src: string;
+  position: number;
+};
+
+export type CreateProductDto = Partial<IdDto> & {
+  /** Stable id from the source platform; kept so re-imports dedupe. */
+  externalId: string;
+  /** URL slug — preserved so SEO redirects can map old links later. */
+  handle: string;
+  /** Full original product URL, for redirect mapping. */
+  sourceUrl?: string;
+  title: string;
+  descriptionHtml?: string;
+  vendor?: string;
+  productType?: string;
+  tags?: string[];
+  /** 0, 1, or 2+ option dimensions with arbitrary names. */
+  options?: ProductOption[];
+  /** CDN image URLs (media ingestion is the migration tool's concern). */
+  images?: ProductImage[];
+};
+
+export type UpdateProductDto = Partial<CreateProductDto> & IdDto;
+
+export type ProductDto = CreateProductDto & IdDto & Partial<RecordTimingDto>;
+
+/**
+ * Catalog search/filter (ECOM-03). `ids` narrows to specific products,
+ * everything else is optional and additive. Price/stock/option filters are
+ * variant-level under the hood (Product itself carries no price) — a
+ * product matches if at least one of its variants satisfies them.
+ */
+export type ProductSearchDto = Partial<IdsDto> & {
+  /** Case-insensitive partial match against the product title. */
+  title?: string;
+  minPriceCents?: number;
+  maxPriceCents?: number;
+  /** True: at least one variant has stock > 0. */
+  inStock?: boolean;
+  /** Both must be set together — e.g. optionName 'Color', optionValue 'Black'. */
+  optionName?: string;
+  optionValue?: string;
+};
+
+export type ProductServiceParameters = {
+  CreateProductDto: CreateProductDto;
+  UpdateProductDto: UpdateProductDto;
+  ProductDto: ProductDto;
+  IdDto: IdDto;
+  IdsDto: IdsDto;
+  SearchDto: ProductSearchDto;
+};


### PR DESCRIPTION
## Summary

Bottom of stack #272, based on `main`. Full 3-layer Inventory implementation — stock tracking with an atomic conditional decrement.

Stock adjustment uses `nativeUpdate` + `raw()` (the same atomic idiom as gift-card/promo-code redemption elsewhere in this module) rather than a read-then-write across an await — two concurrent orders for the last unit can't both pass the oversell guard, per Guild's commerce-security guide.

## Test plan

- [x] `pnpm build` clean across the whole workspace
- [x] `pnpm test` clean (schemaEquality zod/typebox parity for Variant + Inventory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added product catalog APIs for creating, viewing, searching, updating, and deleting products, including handle-based lookup.
  * Added inventory APIs for viewing stock, adjusting quantities, and checking availability.
  * Added bulk catalog import with product and variant totals.
  * Added typed SDK access for product, inventory, and catalog-import operations.
  * Added filtering by title, price range, stock status, IDs, and variant options.
* **Validation**
  * Added request validation for product, inventory, search, and catalog-import data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->