### PR TITLE
Add Cart catalog entity (Redis-cached)

### DIFF
--- a/blueprint/ecommerce-stripe/api/controllers/cart.controller.ts
+++ b/blueprint/ecommerce-stripe/api/controllers/cart.controller.ts
@@ -1,0 +1,97 @@
+import {
+  handlers,
+  IdSchema,
+  number,
+  schemaValidator,
+  string
+} from '../../schema';
+import { ci, tokens } from '../../bootstrapper';
+import {
+  CartMapper,
+  CreateCartMapper
+} from '../../domain/mappers/cart.mappers';
+
+const serviceFactory = ci.scopedResolver(tokens.CartService);
+const HMAC_SECRET_KEY = ci.resolve(tokens.HMAC_SECRET_KEY);
+
+export const createCart = handlers.post(
+  schemaValidator,
+  '/',
+  {
+    name: 'Create Cart',
+    access: 'internal',
+    summary: 'Create a cart',
+    auth: { hmac: { secretKeys: { default: HMAC_SECRET_KEY } } },
+    body: CreateCartMapper.schema,
+    responses: { 200: CartMapper.schema }
+  },
+  async (req, res) => {
+    res.status(200).json(await serviceFactory().createCart(req.body));
+  }
+);
+
+export const getCart = handlers.get(
+  schemaValidator,
+  '/:id',
+  {
+    name: 'Get Cart',
+    access: 'internal',
+    summary: 'Get a cart',
+    auth: { hmac: { secretKeys: { default: HMAC_SECRET_KEY } } },
+    params: IdSchema,
+    responses: { 200: CartMapper.schema }
+  },
+  async (req, res) => {
+    res.status(200).json(await serviceFactory().getCart(req.params));
+  }
+);
+
+/** Out-of-stock items are allowed in the cart — checked at checkout, not here. */
+export const addCartItem = handlers.post(
+  schemaValidator,
+  '/items',
+  {
+    name: 'Add Cart Item',
+    access: 'internal',
+    summary: 'Add an item to a cart',
+    auth: { hmac: { secretKeys: { default: HMAC_SECRET_KEY } } },
+    body: { cartId: string, variantId: string, quantity: number },
+    responses: { 200: CartMapper.schema }
+  },
+  async (req, res) => {
+    res.status(200).json(await serviceFactory().addItem(req.body));
+  }
+);
+
+export const removeCartItem = handlers.delete(
+  schemaValidator,
+  '/:cartId/items/:variantId',
+  {
+    name: 'Remove Cart Item',
+    access: 'internal',
+    summary: 'Remove an item from a cart',
+    auth: { hmac: { secretKeys: { default: HMAC_SECRET_KEY } } },
+    params: { cartId: string, variantId: string },
+    responses: { 200: CartMapper.schema }
+  },
+  async (req, res) => {
+    res.status(200).json(await serviceFactory().removeItem(req.params));
+  }
+);
+
+export const clearCart = handlers.delete(
+  schemaValidator,
+  '/:id',
+  {
+    name: 'Clear Cart',
+    access: 'internal',
+    summary: 'Clear all items from a cart',
+    auth: { hmac: { secretKeys: { default: HMAC_SECRET_KEY } } },
+    params: IdSchema,
+    responses: { 200: string }
+  },
+  async (req, res) => {
+    await serviceFactory().clearCart(req.params);
+    res.status(200).send('Cleared cart');
+  }
+);

--- a/blueprint/ecommerce-stripe/api/controllers/index.ts
+++ b/blueprint/ecommerce-stripe/api/controllers/index.ts
@@ -1,3 +1,4 @@
+export * from './cart.controller';
 export * from './catalogImport.controller';
 export * from './inventory.controller';
 export * from './product.controller';

--- a/blueprint/ecommerce-stripe/api/routes/cart.routes.ts
+++ b/blueprint/ecommerce-stripe/api/routes/cart.routes.ts
@@ -1,0 +1,26 @@
+import { forklaunchRouter, schemaValidator } from '../../schema';
+import { ci, tokens } from '../../bootstrapper';
+import {
+  addCartItem,
+  clearCart,
+  createCart,
+  getCart,
+  removeCartItem
+} from '../controllers/cart.controller';
+
+const openTelemetryCollector = ci.resolve(tokens.OtelCollector);
+
+export const cartRouter = forklaunchRouter(
+  '/cart',
+  schemaValidator,
+  openTelemetryCollector
+);
+
+export const createCartRoute = cartRouter.post('/', createCart);
+export const addCartItemRoute = cartRouter.post('/items', addCartItem);
+export const removeCartItemRoute = cartRouter.delete(
+  '/:cartId/items/:variantId',
+  removeCartItem
+);
+export const getCartRoute = cartRouter.get('/:id', getCart);
+export const clearCartRoute = cartRouter.delete('/:id', clearCart);

--- a/blueprint/ecommerce-stripe/domain/mappers/cart.mappers.ts
+++ b/blueprint/ecommerce-stripe/domain/mappers/cart.mappers.ts
@@ -1,0 +1,46 @@
+import { schemaValidator } from '../../schema';
+import { requestMapper, responseMapper } from '@forklaunch/core/mappers';
+import { EntityManager } from '@mikro-orm/core';
+import { Cart } from '../../persistence/entities/cart.entity';
+import { CartSchemas } from '../schemas';
+
+export const CreateCartMapper = requestMapper({
+  schemaValidator,
+  schema: CartSchemas.CreateCartSchema,
+  entity: Cart,
+  mapperDefinition: {
+    toEntity: async (dto, em: EntityManager) => {
+      return em.create(Cart, {
+        customerId: dto.customerId ?? null,
+        status: 'open',
+        items: []
+      });
+    }
+  }
+});
+
+export const UpdateCartMapper = requestMapper({
+  schemaValidator,
+  schema: CartSchemas.UpdateCartSchema,
+  entity: Cart,
+  mapperDefinition: {
+    toEntity: async (dto, em: EntityManager) => {
+      const { id, ...rest } = dto;
+      const entity = await em.findOneOrFail(Cart, { id });
+      em.assign(entity, rest);
+      return entity;
+    }
+  }
+});
+
+export const CartMapper = responseMapper({
+  schemaValidator,
+  schema: CartSchemas.CartSchema,
+  entity: Cart,
+  mapperDefinition: {
+    toDto: async (entity) => ({
+      ...entity,
+      customerId: entity.customerId ?? undefined
+    })
+  }
+});

--- a/blueprint/ecommerce-stripe/domain/schemas/index.ts
+++ b/blueprint/ecommerce-stripe/domain/schemas/index.ts
@@ -1,6 +1,7 @@
 import { SchemaValidator, schemaValidator } from '../../schema';
 import { mapServiceSchemas } from '@forklaunch/core/mappers';
 import {
+  BaseCartServiceSchemas,
   BaseInventoryServiceSchemas,
   BaseProductServiceSchemas,
   BaseVariantServiceSchemas
@@ -10,6 +11,7 @@ import {
 // mikro-orm's uuid column type — uuidId: false matches sqlBaseProperties.
 const schemas = mapServiceSchemas(
   {
+    CartSchemas: BaseCartServiceSchemas<SchemaValidator>,
     InventorySchemas: BaseInventoryServiceSchemas<SchemaValidator>,
     ProductSchemas: BaseProductServiceSchemas<SchemaValidator>,
     VariantSchemas: BaseVariantServiceSchemas<SchemaValidator>
@@ -20,4 +22,4 @@ const schemas = mapServiceSchemas(
   }
 );
 
-export const { InventorySchemas, ProductSchemas, VariantSchemas } = schemas;
+export const { CartSchemas, InventorySchemas, ProductSchemas, VariantSchemas } = schemas;

--- a/blueprint/ecommerce-stripe/domain/schemas/index.ts
+++ b/blueprint/ecommerce-stripe/domain/schemas/index.ts
@@ -1,6 +1,7 @@
 import { SchemaValidator, schemaValidator } from '../../schema';
 import { mapServiceSchemas } from '@forklaunch/core/mappers';
 import {
+  BaseCartServiceSchemas,
   BaseInventoryServiceSchemas,
   BaseProductServiceSchemas,
   BaseVariantServiceSchemas
@@ -10,6 +11,7 @@ import {
 // mikro-orm's uuid column type — uuidId: false matches sqlBaseProperties.
 const schemas = mapServiceSchemas(
   {
+    CartSchemas: BaseCartServiceSchemas<SchemaValidator>,
     InventorySchemas: BaseInventoryServiceSchemas<SchemaValidator>,
     ProductSchemas: BaseProductServiceSchemas<SchemaValidator>,
     VariantSchemas: BaseVariantServiceSchemas<SchemaValidator>
@@ -21,4 +23,4 @@ const schemas = mapServiceSchemas(
   }
 );
 
-export const { InventorySchemas, ProductSchemas, VariantSchemas } = schemas;
+export const { CartSchemas, InventorySchemas, ProductSchemas, VariantSchemas } = schemas;

--- a/blueprint/ecommerce-stripe/domain/types/ecommerceMappers.types.ts
+++ b/blueprint/ecommerce-stripe/domain/types/ecommerceMappers.types.ts
@@ -1,6 +1,11 @@
 import { SchemaValidator } from '../../schema';
 import { Schema } from '@forklaunch/validator';
-import { Inventory, Product, Variant } from '../../persistence/entities';
+import { Cart, Inventory, Product, Variant } from '../../persistence/entities';
+import {
+  CartMapper,
+  CreateCartMapper,
+  UpdateCartMapper
+} from '../mappers/cart.mappers';
 import {
   CreateInventoryMapper,
   InventoryMapper,
@@ -57,6 +62,18 @@ export type InventoryDtoTypes = {
     typeof UpdateInventoryMapper.schema,
     SchemaValidator
   >;
+};
+
+// cart
+export type CartMapperTypes = {
+  CartMapper: typeof Cart;
+  CreateCartMapper: typeof Cart;
+  UpdateCartMapper: typeof Cart;
+};
+export type CartDtoTypes = {
+  CartMapper: Schema<typeof CartMapper.schema, SchemaValidator>;
+  CreateCartMapper: Schema<typeof CreateCartMapper.schema, SchemaValidator>;
+  UpdateCartMapper: Schema<typeof UpdateCartMapper.schema, SchemaValidator>;
 };
 
 // Remaining entities' mapper/DTO types are added incrementally as each PR lands.

--- a/blueprint/ecommerce-stripe/domain/types/ecommerceMappers.types.ts
+++ b/blueprint/ecommerce-stripe/domain/types/ecommerceMappers.types.ts
@@ -1,6 +1,11 @@
 import { SchemaValidator } from '../../schema';
 import { Schema } from '@forklaunch/validator';
-import { Inventory, Product, Variant } from '../../persistence/entities';
+import { Cart, Inventory, Product, Variant } from '../../persistence/entities';
+import {
+  CartMapper,
+  CreateCartMapper,
+  UpdateCartMapper
+} from '../mappers/cart.mappers';
 import {
   CreateInventoryMapper,
   InventoryMapper,
@@ -70,6 +75,19 @@ export type InventoryDtoTypes = {
     SchemaValidator
   >;
 };
+
+// cart
+export type CartMapperTypes = {
+  CartMapper: typeof Cart;
+  CreateCartMapper: typeof Cart;
+  UpdateCartMapper: typeof Cart;
+};
+export type CartDtoTypes = {
+  CartMapper: Schema<typeof CartMapper.schema, SchemaValidator>;
+  CreateCartMapper: Schema<typeof CreateCartMapper.schema, SchemaValidator>;
+  UpdateCartMapper: Schema<typeof UpdateCartMapper.schema, SchemaValidator>;
+};
+
 
 // TS2883 workaround. The dependency container infers through the Base*Service
 // generics, and without at least one of these mapper types nameable here, tsc

--- a/blueprint/ecommerce-stripe/persistence/entities/cart.entity.ts
+++ b/blueprint/ecommerce-stripe/persistence/entities/cart.entity.ts
@@ -1,4 +1,4 @@
-import { sqlBaseProperties } from '../../../core/persistence/sql.base.properties';
+import { sqlBaseProperties } from '@forklaunch/blueprint-core';
 import { CartItemDto } from '@forklaunch/interfaces-ecommerce/types';
 import { defineComplianceEntity, fp } from '@forklaunch/core/persistence';
 

--- a/blueprint/ecommerce-stripe/persistence/entities/cart.entity.ts
+++ b/blueprint/ecommerce-stripe/persistence/entities/cart.entity.ts
@@ -1,0 +1,15 @@
+import { sqlBaseProperties } from '../../../core/persistence/sql.base.properties';
+import { CartItemDto } from '@forklaunch/interfaces-ecommerce/types';
+import { defineComplianceEntity, fp } from '@forklaunch/core/persistence';
+
+export const Cart = defineComplianceEntity({
+  name: 'Cart',
+  properties: {
+    ...sqlBaseProperties,
+    // Reference id only — no customer PII lives on Cart itself, matching
+    // billing's CheckoutSession.customerId precedent.
+    customerId: fp.string().nullable().compliance('none'),
+    status: fp.string().compliance('none'),
+    items: fp.json<CartItemDto[]>().compliance('none')
+  }
+});

--- a/blueprint/ecommerce-stripe/persistence/entities/index.ts
+++ b/blueprint/ecommerce-stripe/persistence/entities/index.ts
@@ -1,3 +1,4 @@
+export { Cart } from './cart.entity';
 export { Inventory } from './inventory.entity';
 export { Product } from './product.entity';
 export { Variant } from './variant.entity';

--- a/blueprint/ecommerce-stripe/registrations.ts
+++ b/blueprint/ecommerce-stripe/registrations.ts
@@ -18,12 +18,18 @@ import {
   Lifetime
 } from '@forklaunch/core/services';
 import {
+  BaseCartService,
   BaseInventoryService,
   BaseProductService,
   BaseVariantService
 } from '@forklaunch/implementation-ecommerce-base/services';
 import { ForkOptions } from '@mikro-orm/core';
 import { EntityManager, MikroORM } from '@mikro-orm/postgresql';
+import {
+  CartMapper,
+  CreateCartMapper,
+  UpdateCartMapper
+} from './domain/mappers/cart.mappers';
 import {
   CreateInventoryMapper,
   InventoryMapper,
@@ -40,6 +46,8 @@ import {
   VariantMapper
 } from './domain/mappers/variant.mappers';
 import {
+  CartDtoTypes,
+  CartMapperTypes,
   InventoryDtoTypes,
   InventoryMapperTypes,
   ProductDtoTypes,
@@ -186,12 +194,26 @@ const runtimeDependencies = environmentConfig.chain({
 //! defines the service dependencies for the application — one `.chain()`
 //! link per entity, added incrementally as each entity's PR lands.
 const serviceDependencies = runtimeDependencies.chain({
+  CartService: {
+    lifetime: Lifetime.Scoped,
+    type: BaseCartService<SchemaValidator, CartMapperTypes, CartDtoTypes>,
+    factory: ({ EntityManager, OtelCollector, TtlCache }, context, resolve) =>
+      new BaseCartService(
+        context?.entityManagerOptions
+          ? resolve('EntityManager', context)
+          : EntityManager,
+        OtelCollector,
+        schemaValidator,
+        { CartMapper, CreateCartMapper, UpdateCartMapper },
+        { cache: TtlCache }
+      )
+  },
   ProductService: {
     lifetime: Lifetime.Scoped,
     type: BaseProductService<SchemaValidator, ProductMapperTypes, ProductDtoTypes>,
     factory: ({ EntityManager, OtelCollector }, context, resolve) =>
       new BaseProductService(
-        context.entityManagerOptions
+        context?.entityManagerOptions
           ? resolve('EntityManager', context)
           : EntityManager,
         OtelCollector,
@@ -221,7 +243,7 @@ const serviceDependencies = runtimeDependencies.chain({
     >,
     factory: ({ EntityManager, OtelCollector }, context, resolve) =>
       new BaseInventoryService(
-        context.entityManagerOptions
+        context?.entityManagerOptions
           ? resolve('EntityManager', context)
           : EntityManager,
         OtelCollector,

--- a/blueprint/ecommerce-stripe/registrations.ts
+++ b/blueprint/ecommerce-stripe/registrations.ts
@@ -18,12 +18,18 @@ import {
   Lifetime
 } from '@forklaunch/core/services';
 import {
+  BaseCartService,
   BaseInventoryService,
   BaseProductService,
   BaseVariantService
 } from '@forklaunch/implementation-ecommerce-base/services';
 import { ForkOptions } from '@mikro-orm/core';
 import { EntityManager, MikroORM } from '@mikro-orm/postgresql';
+import {
+  CartMapper,
+  CreateCartMapper,
+  UpdateCartMapper
+} from './domain/mappers/cart.mappers';
 import {
   CreateInventoryMapper,
   InventoryMapper,
@@ -40,6 +46,8 @@ import {
   VariantMapper
 } from './domain/mappers/variant.mappers';
 import {
+  CartDtoTypes,
+  CartMapperTypes,
   InventoryDtoTypes,
   InventoryMapperTypes,
   ProductDtoTypes,
@@ -183,6 +191,20 @@ const runtimeDependencies = environmentConfig.chain({
 //! defines the service dependencies for the application — one `.chain()`
 //! link per entity.
 const serviceDependencies = runtimeDependencies.chain({
+  CartService: {
+    lifetime: Lifetime.Scoped,
+    type: BaseCartService<SchemaValidator, CartMapperTypes, CartDtoTypes>,
+    factory: ({ EntityManager, OtelCollector, TtlCache }, context, resolve) =>
+      new BaseCartService(
+        context?.entityManagerOptions
+          ? resolve('EntityManager', context)
+          : EntityManager,
+        OtelCollector,
+        schemaValidator,
+        { CartMapper, CreateCartMapper, UpdateCartMapper },
+        { cache: TtlCache }
+      )
+  },
   ProductService: {
     lifetime: Lifetime.Scoped,
     type: BaseProductService<
@@ -192,7 +214,7 @@ const serviceDependencies = runtimeDependencies.chain({
     >,
     factory: ({ EntityManager, OtelCollector }, context, resolve) =>
       new BaseProductService(
-        context.entityManagerOptions
+        context?.entityManagerOptions
           ? resolve('EntityManager', context)
           : EntityManager,
         OtelCollector,
@@ -226,7 +248,7 @@ const serviceDependencies = runtimeDependencies.chain({
     >,
     factory: ({ EntityManager, OtelCollector }, context, resolve) =>
       new BaseInventoryService(
-        context.entityManagerOptions
+        context?.entityManagerOptions
           ? resolve('EntityManager', context)
           : EntityManager,
         OtelCollector,

--- a/blueprint/ecommerce-stripe/server.ts
+++ b/blueprint/ecommerce-stripe/server.ts
@@ -5,6 +5,7 @@ import {
   schemaValidator
 } from './schema';
 import { setupRls, setupTenantFilter } from '@forklaunch/core/persistence';
+import { cartRouter } from './api/routes/cart.routes';
 import { catalogImportRouter } from './api/routes/catalogImport.routes';
 import { inventoryRouter } from './api/routes/inventory.routes';
 import { productRouter } from './api/routes/product.routes';
@@ -43,6 +44,7 @@ app.use(productRouter);
 app.use(variantRouter);
 app.use(inventoryRouter);
 app.use(catalogImportRouter);
+app.use(cartRouter);
 
 //! starts the server
 app.listen(port, host, () => {

--- a/blueprint/ecommerce-stripe/server.ts
+++ b/blueprint/ecommerce-stripe/server.ts
@@ -5,6 +5,7 @@ import {
   schemaValidator
 } from './schema';
 import { setupRls, setupTenantFilter } from '@forklaunch/core/persistence';
+import { cartRouter } from './api/routes/cart.routes';
 import { catalogImportRouter } from './api/routes/catalogImport.routes';
 import { inventoryRouter } from './api/routes/inventory.routes';
 import { productRouter } from './api/routes/product.routes';
@@ -44,6 +45,7 @@ app.use(productRouter);
 app.use(variantRouter);
 app.use(inventoryRouter);
 app.use(catalogImportRouter);
+app.use(cartRouter);
 
 //! starts the server
 app.listen(port, host, () => {

--- a/blueprint/implementations/ecommerce/base/domain/schemas/cart.schema.ts
+++ b/blueprint/implementations/ecommerce/base/domain/schemas/cart.schema.ts
@@ -1,0 +1,8 @@
+import { serviceSchemaResolver } from '@forklaunch/internal';
+import { BaseCartServiceSchemas as TypeBoxSchemas } from './typebox/cart.schema';
+import { BaseCartServiceSchemas as ZodSchemas } from './zod/cart.schema';
+
+export const BaseCartServiceSchemas = serviceSchemaResolver(
+  TypeBoxSchemas,
+  ZodSchemas
+);

--- a/blueprint/implementations/ecommerce/base/domain/schemas/index.ts
+++ b/blueprint/implementations/ecommerce/base/domain/schemas/index.ts
@@ -1,3 +1,4 @@
+export * from './cart.schema';
 export * from './inventory.schema';
 export * from './product.schema';
 export * from './variant.schema';

--- a/blueprint/implementations/ecommerce/base/domain/schemas/typebox/cart.schema.ts
+++ b/blueprint/implementations/ecommerce/base/domain/schemas/typebox/cart.schema.ts
@@ -1,0 +1,45 @@
+import {
+  array,
+  number,
+  optional,
+  string,
+  uuid
+} from '@forklaunch/validator/typebox';
+
+const CartItemSchema = {
+  variantId: string,
+  quantity: number
+};
+
+export const CreateCartSchema = {
+  customerId: optional(string)
+};
+
+export const UpdateCartSchema = ({ uuidId }: { uuidId: boolean }) => ({
+  id: uuidId ? uuid : string,
+  customerId: optional(string)
+});
+
+export const CartSchema = ({ uuidId }: { uuidId: boolean }) => ({
+  id: uuidId ? uuid : string,
+  customerId: optional(string),
+  status: string,
+  items: array(CartItemSchema)
+});
+
+export const AddCartItemSchema = {
+  cartId: string,
+  variantId: string,
+  quantity: number
+};
+
+export const RemoveCartItemSchema = {
+  cartId: string,
+  variantId: string
+};
+
+export const BaseCartServiceSchemas = (options: { uuidId: boolean }) => ({
+  CreateCartSchema,
+  UpdateCartSchema: UpdateCartSchema(options),
+  CartSchema: CartSchema(options)
+});

--- a/blueprint/implementations/ecommerce/base/domain/schemas/zod/cart.schema.ts
+++ b/blueprint/implementations/ecommerce/base/domain/schemas/zod/cart.schema.ts
@@ -1,0 +1,45 @@
+import {
+  array,
+  number,
+  optional,
+  string,
+  uuid
+} from '@forklaunch/validator/zod';
+
+const CartItemSchema = {
+  variantId: string,
+  quantity: number
+};
+
+export const CreateCartSchema = {
+  customerId: optional(string)
+};
+
+export const UpdateCartSchema = ({ uuidId }: { uuidId: boolean }) => ({
+  id: uuidId ? uuid : string,
+  customerId: optional(string)
+});
+
+export const CartSchema = ({ uuidId }: { uuidId: boolean }) => ({
+  id: uuidId ? uuid : string,
+  customerId: optional(string),
+  status: string,
+  items: array(CartItemSchema)
+});
+
+export const AddCartItemSchema = {
+  cartId: string,
+  variantId: string,
+  quantity: number
+};
+
+export const RemoveCartItemSchema = {
+  cartId: string,
+  variantId: string
+};
+
+export const BaseCartServiceSchemas = (options: { uuidId: boolean }) => ({
+  CreateCartSchema,
+  UpdateCartSchema: UpdateCartSchema(options),
+  CartSchema: CartSchema(options)
+});

--- a/blueprint/implementations/ecommerce/base/domain/types/baseEcommerceDto.types.ts
+++ b/blueprint/implementations/ecommerce/base/domain/types/baseEcommerceDto.types.ts
@@ -1,9 +1,12 @@
 import {
+  CartDto,
+  CreateCartDto,
   CreateInventoryDto,
   CreateProductDto,
   CreateVariantDto,
   InventoryDto,
   ProductDto,
+  UpdateCartDto,
   UpdateInventoryDto,
   UpdateProductDto,
   UpdateVariantDto,
@@ -29,6 +32,13 @@ export type BaseInventoryDtos = {
   InventoryMapper: InventoryDto;
   CreateInventoryMapper: CreateInventoryDto;
   UpdateInventoryMapper: UpdateInventoryDto;
+};
+
+// cart dto types
+export type BaseCartDtos = {
+  CartMapper: CartDto;
+  CreateCartMapper: CreateCartDto;
+  UpdateCartMapper: UpdateCartDto;
 };
 
 // Remaining entities' Dto aggregates are added incrementally as each PR lands.

--- a/blueprint/implementations/ecommerce/base/domain/types/baseEcommerceDto.types.ts
+++ b/blueprint/implementations/ecommerce/base/domain/types/baseEcommerceDto.types.ts
@@ -1,9 +1,12 @@
 import {
+  CartDto,
+  CreateCartDto,
   CreateInventoryDto,
   CreateProductDto,
   CreateVariantDto,
   InventoryDto,
   ProductDto,
+  UpdateCartDto,
   UpdateInventoryDto,
   UpdateProductDto,
   UpdateVariantDto,
@@ -30,3 +33,11 @@ export type BaseInventoryDtos = {
   CreateInventoryMapper: CreateInventoryDto;
   UpdateInventoryMapper: UpdateInventoryDto;
 };
+
+// cart dto types
+export type BaseCartDtos = {
+  CartMapper: CartDto;
+  CreateCartMapper: CreateCartDto;
+  UpdateCartMapper: UpdateCartDto;
+};
+

--- a/blueprint/implementations/ecommerce/base/domain/types/baseEcommerceEntity.types.ts
+++ b/blueprint/implementations/ecommerce/base/domain/types/baseEcommerceEntity.types.ts
@@ -1,4 +1,4 @@
-import { Inventory, Product, Variant } from '../../persistence/entities';
+import { Cart, Inventory, Product, Variant } from '../../persistence/entities';
 
 // product entity types
 export type BaseProductEntities = {
@@ -19,6 +19,13 @@ export type BaseInventoryEntities = {
   InventoryMapper: { '~entity': (typeof Inventory)['~entity'] };
   CreateInventoryMapper: { '~entity': (typeof Inventory)['~entity'] };
   UpdateInventoryMapper: { '~entity': (typeof Inventory)['~entity'] };
+};
+
+// cart entity types
+export type BaseCartEntities = {
+  CartMapper: { '~entity': (typeof Cart)['~entity'] };
+  CreateCartMapper: { '~entity': (typeof Cart)['~entity'] };
+  UpdateCartMapper: { '~entity': (typeof Cart)['~entity'] };
 };
 
 // Remaining entities' Entity aggregates are added incrementally as each PR lands.

--- a/blueprint/implementations/ecommerce/base/domain/types/baseEcommerceEntity.types.ts
+++ b/blueprint/implementations/ecommerce/base/domain/types/baseEcommerceEntity.types.ts
@@ -1,4 +1,4 @@
-import { Inventory, Product, Variant } from '../../persistence/entities';
+import { Cart, Inventory, Product, Variant } from '../../persistence/entities';
 
 // product entity types
 export type BaseProductEntities = {
@@ -20,3 +20,11 @@ export type BaseInventoryEntities = {
   CreateInventoryMapper: { '~entity': (typeof Inventory)['~entity'] };
   UpdateInventoryMapper: { '~entity': (typeof Inventory)['~entity'] };
 };
+
+// cart entity types
+export type BaseCartEntities = {
+  CartMapper: { '~entity': (typeof Cart)['~entity'] };
+  CreateCartMapper: { '~entity': (typeof Cart)['~entity'] };
+  UpdateCartMapper: { '~entity': (typeof Cart)['~entity'] };
+};
+

--- a/blueprint/implementations/ecommerce/base/domain/types/cart.mapper.types.ts
+++ b/blueprint/implementations/ecommerce/base/domain/types/cart.mapper.types.ts
@@ -1,0 +1,31 @@
+import { EntityManager, InferEntity } from '@mikro-orm/core';
+import { BaseCartDtos } from './baseEcommerceDto.types';
+import { BaseCartEntities } from './baseEcommerceEntity.types';
+
+export type CartMappers<
+  MapperEntities extends BaseCartEntities,
+  MapperDomains extends BaseCartDtos = BaseCartDtos
+> = {
+  CartMapper: {
+    entity: MapperEntities['CartMapper'];
+    toDto: (
+      entity: InferEntity<MapperEntities['CartMapper']>
+    ) => Promise<MapperDomains['CartMapper']>;
+  };
+  CreateCartMapper: {
+    entity: MapperEntities['CreateCartMapper'];
+    toEntity: (
+      dto: MapperDomains['CreateCartMapper'],
+      em: EntityManager,
+      ...args: unknown[]
+    ) => Promise<InferEntity<MapperEntities['CreateCartMapper']>>;
+  };
+  UpdateCartMapper: {
+    entity: MapperEntities['UpdateCartMapper'];
+    toEntity: (
+      dto: MapperDomains['UpdateCartMapper'],
+      em: EntityManager,
+      ...args: unknown[]
+    ) => Promise<InferEntity<MapperEntities['UpdateCartMapper']>>;
+  };
+};

--- a/blueprint/implementations/ecommerce/base/domain/types/index.ts
+++ b/blueprint/implementations/ecommerce/base/domain/types/index.ts
@@ -1,5 +1,6 @@
 export * from './baseEcommerceDto.types';
 export * from './baseEcommerceEntity.types';
+export * from './cart.mapper.types';
 export * from './inventory.mapper.types';
 export * from './product.mapper.types';
 export * from './variant.mapper.types';

--- a/blueprint/implementations/ecommerce/base/persistence/entities/index.ts
+++ b/blueprint/implementations/ecommerce/base/persistence/entities/index.ts
@@ -1,5 +1,6 @@
 import { defineComplianceEntity, fp } from '@forklaunch/core/persistence';
 import {
+  CartItemDto,
   ProductImage,
   ProductOption
 } from '@forklaunch/interfaces-ecommerce/types';
@@ -45,6 +46,18 @@ export const Variant = defineComplianceEntity({
     priceCents: fp.integer().compliance('none'),
     compareAtPriceCents: fp.integer().nullable().compliance('none'),
     requiresShipping: fp.boolean().compliance('none')
+  }
+});
+
+export const Cart = defineComplianceEntity({
+  name: 'Cart',
+  properties: {
+    id: fp.string().primary().compliance('none'),
+    // Reference id only (no customer PII lives on this entity) — matches
+    // billing's CheckoutSession.customerId precedent (compliance('none')).
+    customerId: fp.string().nullable().compliance('none'),
+    status: fp.string().compliance('none'),
+    items: fp.json<CartItemDto[]>().compliance('none')
   }
 });
 

--- a/blueprint/implementations/ecommerce/base/persistence/entities/index.ts
+++ b/blueprint/implementations/ecommerce/base/persistence/entities/index.ts
@@ -1,5 +1,9 @@
 import { defineComplianceEntity, fp } from '@forklaunch/core/persistence';
-import { ProductImage, ProductOption } from '@forklaunch/interfaces-ecommerce/types';
+import {
+  CartItemDto,
+  ProductImage,
+  ProductOption
+} from '@forklaunch/interfaces-ecommerce/types';
 
 /**
  * Base template entities — the typing scaffolds the generic base services
@@ -41,6 +45,18 @@ export const Variant = defineComplianceEntity({
     priceCents: fp.integer().compliance('none'),
     compareAtPriceCents: fp.integer().nullable().compliance('none'),
     requiresShipping: fp.boolean().compliance('none')
+  }
+});
+
+export const Cart = defineComplianceEntity({
+  name: 'Cart',
+  properties: {
+    id: fp.string().primary().compliance('none'),
+    // Reference id only (no customer PII lives on this entity) — matches
+    // billing's CheckoutSession.customerId precedent (compliance('none')).
+    customerId: fp.string().nullable().compliance('none'),
+    status: fp.string().compliance('none'),
+    items: fp.json<CartItemDto[]>().compliance('none')
   }
 });
 

--- a/blueprint/implementations/ecommerce/base/services/cart.service.ts
+++ b/blueprint/implementations/ecommerce/base/services/cart.service.ts
@@ -31,7 +31,10 @@ function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
   return Promise.race([
     promise,
     new Promise<T>((_, reject) =>
-      setTimeout(() => reject(new Error(`Cache operation timed out after ${ms}ms`)), ms)
+      setTimeout(
+        () => reject(new Error(`Cache operation timed out after ${ms}ms`)),
+        ms
+      )
     )
   ]);
 }
@@ -164,7 +167,7 @@ export class BaseCartService<
 
   /**
    * Out-of-stock items are allowed in the cart — the check happens at
-   * checkout, not here (per ECOM-06).
+   * checkout, not here.
    */
   async addItem(
     addItemDto: AddCartItemDto,

--- a/blueprint/implementations/ecommerce/base/services/cart.service.ts
+++ b/blueprint/implementations/ecommerce/base/services/cart.service.ts
@@ -173,6 +173,20 @@ export class BaseCartService<
     if (this.evaluatedTelemetryOptions.logging) {
       this.openTelemetryCollector.info('Adding cart item', addItemDto);
     }
+    // The schema layer types quantity as a bare number (the codebase-wide
+    // convention), so nothing upstream rejects zero, negatives or fractions.
+    // That matters here because cart quantities flow straight into checkout
+    // pricing and the worker's stock deltas: a negative quantity drives the
+    // order subtotal down (and the final Math.max(0, ...) clamp turns a
+    // crafted cart into a ~$0 total), and flips the worker's `-quantity`
+    // into a positive delta that inflates stock for goods never removed.
+    // Enforce the invariant here, where it holds regardless of transport.
+    if (!Number.isInteger(addItemDto.quantity) || addItemDto.quantity < 1) {
+      throw new Error(
+        `Cart item quantity must be a positive integer, received ${addItemDto.quantity}`
+      );
+    }
+
     const entityManager = em ?? this.em;
     const cart = await entityManager.findOneOrFail(
       this.mappers.CartMapper.entity as typeof Cart,

--- a/blueprint/implementations/ecommerce/base/services/cart.service.ts
+++ b/blueprint/implementations/ecommerce/base/services/cart.service.ts
@@ -1,0 +1,247 @@
+import { TtlCache } from '@forklaunch/core/cache';
+import {
+  evaluateTelemetryOptions,
+  MetricsDefinition,
+  OpenTelemetryCollector,
+  TelemetryOptions
+} from '@forklaunch/core/http';
+import { CartService } from '@forklaunch/interfaces-ecommerce/interfaces';
+import {
+  AddCartItemDto,
+  CreateCartDto,
+  RemoveCartItemDto
+} from '@forklaunch/interfaces-ecommerce/types';
+import { AnySchemaValidator } from '@forklaunch/validator';
+import { EntityManager, InferEntity } from '@mikro-orm/core';
+import { BaseCartDtos } from '../domain/types/baseEcommerceDto.types';
+import { BaseCartEntities } from '../domain/types/baseEcommerceEntity.types';
+import { CartMappers } from '../domain/types/cart.mapper.types';
+import { Cart } from '../persistence/entities';
+
+const cartCacheKey = (id: string) => `cart:${id}`;
+
+/** Cache calls must NEVER hang the caller — a try/catch alone doesn't
+ *  protect against this: a promise that never settles (which the
+ *  underlying Redis client can do when unreachable, confirmed by hand)
+ *  isn't caught by a try/catch, it just blocks forever. A cache being
+ *  "fast/temporary state" is only true if a broken cache can't turn into
+ *  the slowest possible path through the code. */
+const CACHE_TIMEOUT_MS = 750;
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<T>((_, reject) =>
+      setTimeout(() => reject(new Error(`Cache operation timed out after ${ms}ms`)), ms)
+    )
+  ]);
+}
+
+export class BaseCartService<
+  SchemaValidator extends AnySchemaValidator,
+  MapperEntities extends BaseCartEntities,
+  MapperDomains extends BaseCartDtos = BaseCartDtos
+> implements CartService
+{
+  private evaluatedTelemetryOptions: {
+    logging?: boolean;
+    metrics?: boolean;
+    tracing?: boolean;
+  };
+  public em: EntityManager;
+  protected openTelemetryCollector: OpenTelemetryCollector<MetricsDefinition>;
+  protected schemaValidator: SchemaValidator;
+  protected mappers: CartMappers<MapperEntities, MapperDomains>;
+  protected cache?: TtlCache;
+
+  constructor(
+    em: EntityManager,
+    openTelemetryCollector: OpenTelemetryCollector<MetricsDefinition>,
+    schemaValidator: SchemaValidator,
+    mappers: CartMappers<MapperEntities, MapperDomains>,
+    options?: {
+      telemetry?: TelemetryOptions;
+      /**
+       * Optional — carts are "fast/temporary state" per the module's
+       * design (Redis-backed read-through cache in front of Postgres,
+       * which remains the source of truth). Undefined means Postgres-only
+       * behavior, unchanged from before this cache existed.
+       */
+      cache?: TtlCache;
+    }
+  ) {
+    this.em = em;
+    this.openTelemetryCollector = openTelemetryCollector;
+    this.schemaValidator = schemaValidator;
+    this.mappers = mappers;
+    this.cache = options?.cache;
+    this.evaluatedTelemetryOptions = options?.telemetry
+      ? evaluateTelemetryOptions(options.telemetry).enabled
+      : {
+          logging: false,
+          metrics: false,
+          tracing: false
+        };
+  }
+
+  /**
+   * Best-effort cache warm — never allowed to fail the caller. Redis is
+   * explicitly temporary/fast state here, not the source of truth, so a
+   * cache-write failure just means the next read falls back to Postgres,
+   * not a broken request.
+   */
+  private async warmCache(dto: MapperDomains['CartMapper']): Promise<void> {
+    if (!this.cache) return;
+    try {
+      await withTimeout(
+        this.cache.putRecord({
+          key: cartCacheKey((dto as { id: string }).id),
+          value: dto,
+          ttlMilliseconds: this.cache.getTtlMilliseconds()
+        }),
+        CACHE_TIMEOUT_MS
+      );
+    } catch (error) {
+      this.openTelemetryCollector.error('Cart cache write failed', {
+        error
+      });
+    }
+  }
+
+  async createCart(
+    cartDto: CreateCartDto,
+    em?: EntityManager,
+    ...args: unknown[]
+  ): Promise<MapperDomains['CartMapper']> {
+    if (this.evaluatedTelemetryOptions.logging) {
+      this.openTelemetryCollector.info('Creating cart', cartDto);
+    }
+    const cart = await this.mappers.CreateCartMapper.toEntity(
+      cartDto,
+      em ?? this.em,
+      ...(args[0] instanceof EntityManager ? args.slice(1) : args)
+    );
+    await (em ?? this.em).transactional(async (innerEm) => {
+      await innerEm.persist(cart);
+    });
+    const dto = await this.mappers.CartMapper.toDto(cart);
+    await this.warmCache(dto);
+    return dto;
+  }
+
+  /** Read-through: cache first, Postgres (source of truth) on miss or cache failure. */
+  async getCart(
+    idDto: { id: string },
+    em?: EntityManager
+  ): Promise<MapperDomains['CartMapper']> {
+    if (this.evaluatedTelemetryOptions.logging) {
+      this.openTelemetryCollector.info('Getting cart', idDto);
+    }
+
+    if (this.cache) {
+      try {
+        const cached = await withTimeout(
+          this.cache.readRecord<MapperDomains['CartMapper']>(
+            cartCacheKey(idDto.id)
+          ),
+          CACHE_TIMEOUT_MS
+        );
+        return cached.value;
+      } catch {
+        // Cache miss, cache-read failure, or timeout — fall through to Postgres.
+      }
+    }
+
+    const cart = await (em ?? this.em).findOneOrFail(
+      this.mappers.CartMapper.entity as typeof Cart,
+      idDto
+    );
+    const dto = await this.mappers.CartMapper.toDto(
+      cart as InferEntity<MapperEntities['CartMapper']>
+    );
+    await this.warmCache(dto);
+    return dto;
+  }
+
+  /**
+   * Out-of-stock items are allowed in the cart — the check happens at
+   * checkout, not here (per ECOM-06).
+   */
+  async addItem(
+    addItemDto: AddCartItemDto,
+    em?: EntityManager
+  ): Promise<MapperDomains['CartMapper']> {
+    if (this.evaluatedTelemetryOptions.logging) {
+      this.openTelemetryCollector.info('Adding cart item', addItemDto);
+    }
+    const entityManager = em ?? this.em;
+    const cart = await entityManager.findOneOrFail(
+      this.mappers.CartMapper.entity as typeof Cart,
+      { id: addItemDto.cartId }
+    );
+    const items = [...(cart.items ?? [])];
+    const existing = items.find((i) => i.variantId === addItemDto.variantId);
+    if (existing) {
+      existing.quantity += addItemDto.quantity;
+    } else {
+      items.push({
+        variantId: addItemDto.variantId,
+        quantity: addItemDto.quantity
+      });
+    }
+    entityManager.assign(cart, { items });
+    await entityManager.transactional(async (innerEm) => {
+      await innerEm.persist(cart);
+    });
+    const dto = await this.mappers.CartMapper.toDto(
+      cart as InferEntity<MapperEntities['CartMapper']>
+    );
+    await this.warmCache(dto);
+    return dto;
+  }
+
+  async removeItem(
+    removeItemDto: RemoveCartItemDto,
+    em?: EntityManager
+  ): Promise<MapperDomains['CartMapper']> {
+    if (this.evaluatedTelemetryOptions.logging) {
+      this.openTelemetryCollector.info('Removing cart item', removeItemDto);
+    }
+    const entityManager = em ?? this.em;
+    const cart = await entityManager.findOneOrFail(
+      this.mappers.CartMapper.entity as typeof Cart,
+      { id: removeItemDto.cartId }
+    );
+    const items = (cart.items ?? []).filter(
+      (i) => i.variantId !== removeItemDto.variantId
+    );
+    entityManager.assign(cart, { items });
+    await entityManager.transactional(async (innerEm) => {
+      await innerEm.persist(cart);
+    });
+    const dto = await this.mappers.CartMapper.toDto(
+      cart as InferEntity<MapperEntities['CartMapper']>
+    );
+    await this.warmCache(dto);
+    return dto;
+  }
+
+  async clearCart(idDto: { id: string }, em?: EntityManager): Promise<void> {
+    if (this.evaluatedTelemetryOptions.logging) {
+      this.openTelemetryCollector.info('Clearing cart', idDto);
+    }
+    const entityManager = em ?? this.em;
+    const cart = await entityManager.findOneOrFail(
+      this.mappers.CartMapper.entity as typeof Cart,
+      idDto
+    );
+    entityManager.assign(cart, { items: [] });
+    await entityManager.transactional(async (innerEm) => {
+      await innerEm.persist(cart);
+    });
+    await this.warmCache(
+      await this.mappers.CartMapper.toDto(
+        cart as InferEntity<MapperEntities['CartMapper']>
+      )
+    );
+  }
+}

--- a/blueprint/implementations/ecommerce/base/services/index.ts
+++ b/blueprint/implementations/ecommerce/base/services/index.ts
@@ -1,3 +1,4 @@
+export * from './cart.service';
 export * from './inventory.service';
 export * from './product.service';
 export * from './variant.service';

--- a/blueprint/interfaces/ecommerce/interfaces/cart.service.interface.ts
+++ b/blueprint/interfaces/ecommerce/interfaces/cart.service.interface.ts
@@ -1,0 +1,24 @@
+import { EntityManager } from '@mikro-orm/core';
+import { CartServiceParameters } from '../types/cart.service.types';
+
+export interface CartService<
+  Params extends CartServiceParameters = CartServiceParameters
+> {
+  createCart: (
+    cartDto: Params['CreateCartDto'],
+    em?: EntityManager
+  ) => Promise<Params['CartDto']>;
+  getCart: (
+    idDto: Params['IdDto'],
+    em?: EntityManager
+  ) => Promise<Params['CartDto']>;
+  addItem: (
+    addItemDto: Params['AddCartItemDto'],
+    em?: EntityManager
+  ) => Promise<Params['CartDto']>;
+  removeItem: (
+    removeItemDto: Params['RemoveCartItemDto'],
+    em?: EntityManager
+  ) => Promise<Params['CartDto']>;
+  clearCart: (idDto: Params['IdDto'], em?: EntityManager) => Promise<void>;
+}

--- a/blueprint/interfaces/ecommerce/interfaces/index.ts
+++ b/blueprint/interfaces/ecommerce/interfaces/index.ts
@@ -1,3 +1,4 @@
+export * from './cart.service.interface';
 export * from './inventory.service.interface';
 export * from './product.service.interface';
 export * from './variant.service.interface';

--- a/blueprint/interfaces/ecommerce/types/cart.service.types.ts
+++ b/blueprint/interfaces/ecommerce/types/cart.service.types.ts
@@ -1,0 +1,39 @@
+import { IdDto, RecordTimingDto } from '@forklaunch/common';
+
+export type CartItemDto = {
+  variantId: string;
+  quantity: number;
+};
+
+export type CreateCartDto = Partial<IdDto> & {
+  customerId?: string;
+};
+
+export type UpdateCartDto = Partial<CreateCartDto> & IdDto;
+
+export type CartDto = CreateCartDto &
+  IdDto &
+  Partial<RecordTimingDto> & {
+    status: string;
+    items: CartItemDto[];
+  };
+
+export type AddCartItemDto = {
+  cartId: string;
+  variantId: string;
+  quantity: number;
+};
+
+export type RemoveCartItemDto = {
+  cartId: string;
+  variantId: string;
+};
+
+export type CartServiceParameters = {
+  CreateCartDto: CreateCartDto;
+  UpdateCartDto: UpdateCartDto;
+  CartDto: CartDto;
+  AddCartItemDto: AddCartItemDto;
+  RemoveCartItemDto: RemoveCartItemDto;
+  IdDto: IdDto;
+};

--- a/blueprint/interfaces/ecommerce/types/index.ts
+++ b/blueprint/interfaces/ecommerce/types/index.ts
@@ -1,3 +1,4 @@
+export * from './cart.service.types';
 export * from './inventory.service.types';
 export * from './product.service.types';
 export * from './variant.service.types';


### PR DESCRIPTION
## Summary

Second in stack #272, on top of #220. Full 3-layer Cart implementation — Redis-backed read-through cache in front of Postgres, which stays the source of truth.

- 750ms timeout on every cache operation — a broken/unreachable Redis can never hang the caller, it just falls back to Postgres.
- Out-of-stock items are allowed in the cart — checked at checkout, not here (per ECOM-06).
- Also reapplies the transaction-atomicity fix to `updateProduct`/`updateVariant` (upsert now runs inside its own transaction) — this branch's work predated that fix landing on the rest of the stack.

## Test plan

- [x] `pnpm build` clean across the whole workspace
- [x] `pnpm test` clean (schemaEquality: product/variant/inventory — Cart doesn't yet have its own schemaEquality test, worth adding as a follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)