### PR TITLE
Add Payment entity, service and controller

### DIFF
--- a/blueprint/ecommerce-stripe/api/controllers/index.ts
+++ b/blueprint/ecommerce-stripe/api/controllers/index.ts
@@ -2,5 +2,6 @@ export * from './cart.controller';
 export * from './catalogImport.controller';
 export * from './inventory.controller';
 export * from './order.controller';
+export * from './payment.controller';
 export * from './product.controller';
 export * from './variant.controller';

--- a/blueprint/ecommerce-stripe/api/controllers/index.ts
+++ b/blueprint/ecommerce-stripe/api/controllers/index.ts
@@ -2,6 +2,7 @@ export * from './cart.controller';
 export * from './catalogImport.controller';
 export * from './inventory.controller';
 export * from './order.controller';
+export * from './payment.controller';
 export * from './product.controller';
 export * from './variant.controller';
 // Remaining controllers are added incrementally as each PR lands.

--- a/blueprint/ecommerce-stripe/api/controllers/payment.controller.ts
+++ b/blueprint/ecommerce-stripe/api/controllers/payment.controller.ts
@@ -1,0 +1,62 @@
+import {
+  enum_,
+  handlers,
+  IdSchema,
+  number,
+  optional,
+  schemaValidator,
+  string
+} from '../../schema';
+import { ci, tokens } from '../../bootstrapper';
+import { PaymentMapper } from '../../domain/mappers/payment.mappers';
+
+const stripeServiceFactory = ci.scopedResolver(tokens.PaymentService);
+const paypalServiceFactory = ci.scopedResolver(tokens.PaypalPaymentService);
+const HMAC_SECRET_KEY = ci.resolve(tokens.HMAC_SECRET_KEY);
+
+const PaymentProvider = { STRIPE: 'stripe', PAYPAL: 'paypal' } as const;
+
+/** Provider is a routing choice, not a persisted field — Payment has no
+ *  "provider" column, only providerRef (the chosen provider's own id). */
+export const createPayment = handlers.post(
+  schemaValidator,
+  '/',
+  {
+    name: 'Create Payment',
+    access: 'internal',
+    summary:
+      'Create a payment for an order (drives it toward paid). provider defaults to stripe.',
+    auth: { hmac: { secretKeys: { default: HMAC_SECRET_KEY } } },
+    body: {
+      orderId: string,
+      amountCents: number,
+      currency: string,
+      provider: optional(enum_(PaymentProvider))
+    },
+    responses: { 200: PaymentMapper.schema }
+  },
+  async (req, res) => {
+    const { provider, ...paymentDto } = req.body;
+    const serviceFactory =
+      provider === PaymentProvider.PAYPAL
+        ? paypalServiceFactory
+        : stripeServiceFactory;
+    res.status(200).json(await serviceFactory().createPayment(paymentDto));
+  }
+);
+
+export const getPayment = handlers.get(
+  schemaValidator,
+  '/:id',
+  {
+    name: 'Get Payment',
+    access: 'internal',
+    summary: 'Get a payment',
+    auth: { hmac: { secretKeys: { default: HMAC_SECRET_KEY } } },
+    params: IdSchema,
+    responses: { 200: PaymentMapper.schema }
+  },
+  async (req, res) => {
+    res.status(200).json(await stripeServiceFactory().getPayment(req.params));
+  }
+);

--- a/blueprint/ecommerce-stripe/api/routes/payment.routes.ts
+++ b/blueprint/ecommerce-stripe/api/routes/payment.routes.ts
@@ -1,0 +1,17 @@
+import { forklaunchRouter, schemaValidator } from '../../schema';
+import { ci, tokens } from '../../bootstrapper';
+import {
+  createPayment,
+  getPayment
+} from '../controllers/payment.controller';
+
+const openTelemetryCollector = ci.resolve(tokens.OtelCollector);
+
+export const paymentRouter = forklaunchRouter(
+  '/payment',
+  schemaValidator,
+  openTelemetryCollector
+);
+
+export const createPaymentRoute = paymentRouter.post('/', createPayment);
+export const getPaymentRoute = paymentRouter.get('/:id', getPayment);

--- a/blueprint/ecommerce-stripe/domain/mappers/payment.mappers.ts
+++ b/blueprint/ecommerce-stripe/domain/mappers/payment.mappers.ts
@@ -1,0 +1,40 @@
+import { schemaValidator } from '../../schema';
+import { requestMapper, responseMapper } from '@forklaunch/core/mappers';
+import { PaymentStatus } from '@forklaunch/interfaces-ecommerce/types';
+import { EntityManager } from '@mikro-orm/core';
+import Stripe from 'stripe';
+import { Payment } from '../../persistence/entities/payment.entity';
+import { PaymentSchemas } from '../schemas';
+
+export const CreatePaymentMapper = requestMapper({
+  schemaValidator,
+  schema: PaymentSchemas.CreatePaymentSchema,
+  entity: Payment,
+  mapperDefinition: {
+    toEntity: async (
+      dto,
+      em: EntityManager,
+      paymentIntent: Stripe.PaymentIntent
+    ) => {
+      return em.create(Payment, {
+        orderId: dto.orderId,
+        amountCents: dto.amountCents,
+        currency: dto.currency,
+        status: PaymentStatus.PENDING,
+        providerRef: paymentIntent?.id ?? null
+      });
+    }
+  }
+});
+
+export const PaymentMapper = responseMapper({
+  schemaValidator,
+  schema: PaymentSchemas.PaymentSchema,
+  entity: Payment,
+  mapperDefinition: {
+    toDto: async (entity) => ({
+      ...entity,
+      providerRef: entity.providerRef ?? undefined
+    })
+  }
+});

--- a/blueprint/ecommerce-stripe/domain/schemas/index.ts
+++ b/blueprint/ecommerce-stripe/domain/schemas/index.ts
@@ -4,6 +4,7 @@ import {
   BaseCartServiceSchemas,
   BaseInventoryServiceSchemas,
   BaseOrderServiceSchemas,
+  BasePaymentServiceSchemas,
   BaseProductServiceSchemas,
   BaseVariantServiceSchemas
 } from '@forklaunch/implementation-ecommerce-base/schemas';
@@ -15,6 +16,7 @@ const schemas = mapServiceSchemas(
     CartSchemas: BaseCartServiceSchemas<SchemaValidator>,
     InventorySchemas: BaseInventoryServiceSchemas<SchemaValidator>,
     OrderSchemas: BaseOrderServiceSchemas<SchemaValidator>,
+    PaymentSchemas: BasePaymentServiceSchemas<SchemaValidator>,
     ProductSchemas: BaseProductServiceSchemas<SchemaValidator>,
     VariantSchemas: BaseVariantServiceSchemas<SchemaValidator>
   },
@@ -28,6 +30,7 @@ export const {
   CartSchemas,
   InventorySchemas,
   OrderSchemas,
+  PaymentSchemas,
   ProductSchemas,
   VariantSchemas
 } = schemas;

--- a/blueprint/ecommerce-stripe/domain/schemas/index.ts
+++ b/blueprint/ecommerce-stripe/domain/schemas/index.ts
@@ -4,6 +4,7 @@ import {
   BaseCartServiceSchemas,
   BaseInventoryServiceSchemas,
   BaseOrderServiceSchemas,
+  BasePaymentServiceSchemas,
   BaseProductServiceSchemas,
   BaseVariantServiceSchemas
 } from '@forklaunch/implementation-ecommerce-base/schemas';
@@ -15,6 +16,7 @@ const schemas = mapServiceSchemas(
     CartSchemas: BaseCartServiceSchemas<SchemaValidator>,
     InventorySchemas: BaseInventoryServiceSchemas<SchemaValidator>,
     OrderSchemas: BaseOrderServiceSchemas<SchemaValidator>,
+    PaymentSchemas: BasePaymentServiceSchemas<SchemaValidator>,
     ProductSchemas: BaseProductServiceSchemas<SchemaValidator>,
     VariantSchemas: BaseVariantServiceSchemas<SchemaValidator>
     // Remaining entities' schemas are added incrementally as each PR lands.
@@ -29,6 +31,7 @@ export const {
   CartSchemas,
   InventorySchemas,
   OrderSchemas,
+  PaymentSchemas,
   ProductSchemas,
   VariantSchemas
 } = schemas;

--- a/blueprint/ecommerce-stripe/domain/types/ecommerceMappers.types.ts
+++ b/blueprint/ecommerce-stripe/domain/types/ecommerceMappers.types.ts
@@ -1,6 +1,13 @@
 import { SchemaValidator } from '../../schema';
 import { Schema } from '@forklaunch/validator';
-import { Cart, Inventory, Order, Product, Variant } from '../../persistence/entities';
+import {
+  Cart,
+  Inventory,
+  Order,
+  Payment,
+  Product,
+  Variant
+} from '../../persistence/entities';
 import {
   CartMapper,
   CreateCartMapper,
@@ -16,6 +23,7 @@ import {
   OrderMapper,
   UpdateOrderMapper
 } from '../mappers/order.mappers';
+import { CreatePaymentMapper, PaymentMapper } from '../mappers/payment.mappers';
 import {
   CreateProductMapper,
   ProductMapper,
@@ -103,6 +111,16 @@ export type OrderDtoTypes = {
   OrderMapper: Schema<typeof OrderMapper.schema, SchemaValidator>;
   CreateOrderMapper: Schema<typeof CreateOrderMapper.schema, SchemaValidator>;
   UpdateOrderMapper: Schema<typeof UpdateOrderMapper.schema, SchemaValidator>;
+};
+
+// payment (no update mapper — confirm/fail are provider-driven, not user-editable)
+export type PaymentMapperTypes = {
+  PaymentMapper: typeof Payment;
+  CreatePaymentMapper: typeof Payment;
+};
+export type PaymentDtoTypes = {
+  PaymentMapper: Schema<typeof PaymentMapper.schema, SchemaValidator>;
+  CreatePaymentMapper: Schema<typeof CreatePaymentMapper.schema, SchemaValidator>;
 };
 
 

--- a/blueprint/ecommerce-stripe/domain/types/ecommerceMappers.types.ts
+++ b/blueprint/ecommerce-stripe/domain/types/ecommerceMappers.types.ts
@@ -1,6 +1,13 @@
 import { SchemaValidator } from '../../schema';
 import { Schema } from '@forklaunch/validator';
-import { Cart, Inventory, Order, Product, Variant } from '../../persistence/entities';
+import {
+  Cart,
+  Inventory,
+  Order,
+  Payment,
+  Product,
+  Variant
+} from '../../persistence/entities';
 import {
   CartMapper,
   CreateCartMapper,
@@ -16,6 +23,7 @@ import {
   OrderMapper,
   UpdateOrderMapper
 } from '../mappers/order.mappers';
+import { CreatePaymentMapper, PaymentMapper } from '../mappers/payment.mappers';
 import {
   CreateProductMapper,
   ProductMapper,
@@ -91,6 +99,16 @@ export type OrderDtoTypes = {
   OrderMapper: Schema<typeof OrderMapper.schema, SchemaValidator>;
   CreateOrderMapper: Schema<typeof CreateOrderMapper.schema, SchemaValidator>;
   UpdateOrderMapper: Schema<typeof UpdateOrderMapper.schema, SchemaValidator>;
+};
+
+// payment (no update mapper — confirm/fail are provider-driven, not user-editable)
+export type PaymentMapperTypes = {
+  PaymentMapper: typeof Payment;
+  CreatePaymentMapper: typeof Payment;
+};
+export type PaymentDtoTypes = {
+  PaymentMapper: Schema<typeof PaymentMapper.schema, SchemaValidator>;
+  CreatePaymentMapper: Schema<typeof CreatePaymentMapper.schema, SchemaValidator>;
 };
 
 // Remaining entities' mapper/DTO types are added incrementally as each PR lands.

--- a/blueprint/ecommerce-stripe/persistence/entities/index.ts
+++ b/blueprint/ecommerce-stripe/persistence/entities/index.ts
@@ -2,6 +2,7 @@ export { Cart } from './cart.entity';
 export { Inventory } from './inventory.entity';
 export { Order } from './order.entity';
 export { OrderEventRecord } from './orderEvent.entity';
+export { Payment } from './payment.entity';
 export { Product } from './product.entity';
 export { Variant } from './variant.entity';
 // Remaining entities are added incrementally as each PR lands.

--- a/blueprint/ecommerce-stripe/persistence/entities/index.ts
+++ b/blueprint/ecommerce-stripe/persistence/entities/index.ts
@@ -2,5 +2,6 @@ export { Cart } from './cart.entity';
 export { Inventory } from './inventory.entity';
 export { Order } from './order.entity';
 export { OrderEventRecord } from './orderEvent.entity';
+export { Payment } from './payment.entity';
 export { Product } from './product.entity';
 export { Variant } from './variant.entity';

--- a/blueprint/ecommerce-stripe/persistence/entities/payment.entity.ts
+++ b/blueprint/ecommerce-stripe/persistence/entities/payment.entity.ts
@@ -1,0 +1,16 @@
+import { sqlBaseProperties } from '@forklaunch/blueprint-core';
+import { PaymentStatus } from '@forklaunch/interfaces-ecommerce/types';
+import { defineComplianceEntity, fp } from '@forklaunch/core/persistence';
+
+export const Payment = defineComplianceEntity({
+  name: 'Payment',
+  properties: {
+    ...sqlBaseProperties,
+    orderId: fp.string().compliance('none'),
+    amountCents: fp.integer().compliance('none'),
+    currency: fp.string().compliance('none'),
+    status: fp.enum(() => PaymentStatus).compliance('none'),
+    // Stripe PaymentIntent id — never raw card data (Stripe holds that).
+    providerRef: fp.string().nullable().unique().compliance('none')
+  }
+});

--- a/blueprint/ecommerce-stripe/registrations.ts
+++ b/blueprint/ecommerce-stripe/registrations.ts
@@ -21,6 +21,7 @@ import {
   BaseCartService,
   BaseInventoryService,
   BaseOrderService,
+  BasePaymentService,
   BaseProductService,
   BaseVariantService
 } from '@forklaunch/implementation-ecommerce-base/services';
@@ -46,6 +47,10 @@ import {
   UpdateOrderMapper
 } from './domain/mappers/order.mappers';
 import {
+  CreatePaymentMapper,
+  PaymentMapper
+} from './domain/mappers/payment.mappers';
+import {
   CreateProductMapper,
   ProductMapper,
   UpdateProductMapper
@@ -62,6 +67,8 @@ import {
   InventoryMapperTypes,
   OrderDtoTypes,
   OrderMapperTypes,
+  PaymentDtoTypes,
+  PaymentMapperTypes,
   ProductDtoTypes,
   ProductMapperTypes,
   VariantDtoTypes,
@@ -278,6 +285,60 @@ const serviceDependencies = runtimeDependencies.chain({
         OtelCollector,
         schemaValidator,
         { OrderMapper, CreateOrderMapper, UpdateOrderMapper }
+      )
+  },
+  /**
+   * BasePaymentService directly for now, matching the CartService/
+   * OrderService/ProductService/VariantService/InventoryService pattern
+   * above — no provider-specific behavior is needed to typecheck/persist a
+   * payment record yet. PaymentService and PaypalPaymentService are
+   * registered as separate tokens (mirroring payment.controller.ts's
+   * provider routing) but both resolve to the same base implementation
+   * until the stripe/paypal provider packages land in a follow-up PR and
+   * swap these factories to StripePaymentService/PaypalPaymentService.
+   */
+  PaymentService: {
+    lifetime: Lifetime.Scoped,
+    type: BasePaymentService<SchemaValidator, PaymentMapperTypes, PaymentDtoTypes>,
+    factory: ({ EntityManager, OtelCollector }, context, resolve) =>
+      new BasePaymentService(
+        context?.entityManagerOptions
+          ? resolve('EntityManager', context)
+          : EntityManager,
+        OtelCollector,
+        schemaValidator,
+        // CreatePaymentMapper.toEntity takes a Stripe.PaymentIntent 3rd arg
+        // (payment.mappers.ts is provider-shaped) rather than the generic
+        // BasePaymentService mapper signature (...args: unknown[]) — the
+        // cast bridges the two over one shared runtime mapper object, same
+        // pattern PaypalPaymentService uses for this pair once the stripe/
+        // paypal provider packages land.
+        { PaymentMapper, CreatePaymentMapper } as unknown as ConstructorParameters<
+          typeof BasePaymentService<
+            SchemaValidator,
+            PaymentMapperTypes,
+            PaymentDtoTypes
+          >
+        >[3]
+      )
+  },
+  PaypalPaymentService: {
+    lifetime: Lifetime.Scoped,
+    type: BasePaymentService<SchemaValidator, PaymentMapperTypes, PaymentDtoTypes>,
+    factory: ({ EntityManager, OtelCollector }, context, resolve) =>
+      new BasePaymentService(
+        context?.entityManagerOptions
+          ? resolve('EntityManager', context)
+          : EntityManager,
+        OtelCollector,
+        schemaValidator,
+        { PaymentMapper, CreatePaymentMapper } as unknown as ConstructorParameters<
+          typeof BasePaymentService<
+            SchemaValidator,
+            PaymentMapperTypes,
+            PaymentDtoTypes
+          >
+        >[3]
       )
   },
   /**

--- a/blueprint/ecommerce-stripe/registrations.ts
+++ b/blueprint/ecommerce-stripe/registrations.ts
@@ -21,6 +21,7 @@ import {
   BaseCartService,
   BaseInventoryService,
   BaseOrderService,
+  BasePaymentService,
   BaseProductService,
   BaseVariantService
 } from '@forklaunch/implementation-ecommerce-base/services';
@@ -46,6 +47,10 @@ import {
   UpdateOrderMapper
 } from './domain/mappers/order.mappers';
 import {
+  CreatePaymentMapper,
+  PaymentMapper
+} from './domain/mappers/payment.mappers';
+import {
   CreateProductMapper,
   ProductMapper,
   UpdateProductMapper
@@ -62,6 +67,8 @@ import {
   InventoryMapperTypes,
   OrderDtoTypes,
   OrderMapperTypes,
+  PaymentDtoTypes,
+  PaymentMapperTypes,
   ProductDtoTypes,
   ProductMapperTypes,
   VariantDtoTypes,
@@ -283,6 +290,58 @@ const serviceDependencies = runtimeDependencies.chain({
         OtelCollector,
         schemaValidator,
         { OrderMapper, CreateOrderMapper, UpdateOrderMapper }
+      )
+  },
+  /**
+   * BasePaymentService directly for now, matching the CartService/
+   * OrderService/ProductService/VariantService/InventoryService pattern
+   * above — no provider-specific behavior is needed to typecheck/persist a
+   * payment record yet. PaymentService and PaypalPaymentService are
+   * registered as separate tokens (mirroring payment.controller.ts's
+   * provider routing); the provider packages swap these factories to
+   * StripePaymentService/PaypalPaymentService.
+   */
+  PaymentService: {
+    lifetime: Lifetime.Scoped,
+    type: BasePaymentService<SchemaValidator, PaymentMapperTypes, PaymentDtoTypes>,
+    factory: ({ EntityManager, OtelCollector }, context, resolve) =>
+      new BasePaymentService(
+        context?.entityManagerOptions
+          ? resolve('EntityManager', context)
+          : EntityManager,
+        OtelCollector,
+        schemaValidator,
+        // CreatePaymentMapper.toEntity takes a Stripe.PaymentIntent 3rd arg
+        // (payment.mappers.ts is provider-shaped) rather than the generic
+        // BasePaymentService mapper signature (...args: unknown[]) — the
+        // cast bridges the two over one shared runtime mapper object, the
+        // same pattern PaypalPaymentService uses for this pair.
+        { PaymentMapper, CreatePaymentMapper } as unknown as ConstructorParameters<
+          typeof BasePaymentService<
+            SchemaValidator,
+            PaymentMapperTypes,
+            PaymentDtoTypes
+          >
+        >[3]
+      )
+  },
+  PaypalPaymentService: {
+    lifetime: Lifetime.Scoped,
+    type: BasePaymentService<SchemaValidator, PaymentMapperTypes, PaymentDtoTypes>,
+    factory: ({ EntityManager, OtelCollector }, context, resolve) =>
+      new BasePaymentService(
+        context?.entityManagerOptions
+          ? resolve('EntityManager', context)
+          : EntityManager,
+        OtelCollector,
+        schemaValidator,
+        { PaymentMapper, CreatePaymentMapper } as unknown as ConstructorParameters<
+          typeof BasePaymentService<
+            SchemaValidator,
+            PaymentMapperTypes,
+            PaymentDtoTypes
+          >
+        >[3]
       )
   },
   /**

--- a/blueprint/ecommerce-stripe/server.ts
+++ b/blueprint/ecommerce-stripe/server.ts
@@ -9,6 +9,7 @@ import { cartRouter } from './api/routes/cart.routes';
 import { catalogImportRouter } from './api/routes/catalogImport.routes';
 import { inventoryRouter } from './api/routes/inventory.routes';
 import { orderRouter } from './api/routes/order.routes';
+import { paymentRouter } from './api/routes/payment.routes';
 import { productRouter } from './api/routes/product.routes';
 import { variantRouter } from './api/routes/variant.routes';
 import { ci, tokens } from './bootstrapper';
@@ -47,6 +48,7 @@ app.use(inventoryRouter);
 app.use(catalogImportRouter);
 app.use(cartRouter);
 app.use(orderRouter);
+app.use(paymentRouter);
 
 //! starts the server
 app.listen(port, host, () => {

--- a/blueprint/ecommerce-stripe/server.ts
+++ b/blueprint/ecommerce-stripe/server.ts
@@ -9,6 +9,7 @@ import { cartRouter } from './api/routes/cart.routes';
 import { catalogImportRouter } from './api/routes/catalogImport.routes';
 import { inventoryRouter } from './api/routes/inventory.routes';
 import { orderRouter } from './api/routes/order.routes';
+import { paymentRouter } from './api/routes/payment.routes';
 import { productRouter } from './api/routes/product.routes';
 import { variantRouter } from './api/routes/variant.routes';
 import { ci, tokens } from './bootstrapper';
@@ -48,6 +49,7 @@ app.use(inventoryRouter);
 app.use(catalogImportRouter);
 app.use(cartRouter);
 app.use(orderRouter);
+app.use(paymentRouter);
 
 //! starts the server
 app.listen(port, host, () => {

--- a/blueprint/implementations/ecommerce/base/domain/schemas/index.ts
+++ b/blueprint/implementations/ecommerce/base/domain/schemas/index.ts
@@ -1,6 +1,7 @@
 export * from './cart.schema';
 export * from './inventory.schema';
 export * from './order.schema';
+export * from './payment.schema';
 export * from './product.schema';
 export * from './variant.schema';
 // Remaining combined zod/typebox schemas are added incrementally as each entity's PR lands.

--- a/blueprint/implementations/ecommerce/base/domain/schemas/index.ts
+++ b/blueprint/implementations/ecommerce/base/domain/schemas/index.ts
@@ -1,5 +1,6 @@
 export * from './cart.schema';
 export * from './inventory.schema';
 export * from './order.schema';
+export * from './payment.schema';
 export * from './product.schema';
 export * from './variant.schema';

--- a/blueprint/implementations/ecommerce/base/domain/schemas/payment.schema.ts
+++ b/blueprint/implementations/ecommerce/base/domain/schemas/payment.schema.ts
@@ -1,0 +1,8 @@
+import { serviceSchemaResolver } from '@forklaunch/internal';
+import { BasePaymentServiceSchemas as TypeBoxSchemas } from './typebox/payment.schema';
+import { BasePaymentServiceSchemas as ZodSchemas } from './zod/payment.schema';
+
+export const BasePaymentServiceSchemas = serviceSchemaResolver(
+  TypeBoxSchemas,
+  ZodSchemas
+);

--- a/blueprint/implementations/ecommerce/base/domain/schemas/typebox/payment.schema.ts
+++ b/blueprint/implementations/ecommerce/base/domain/schemas/typebox/payment.schema.ts
@@ -1,0 +1,35 @@
+import { enum_, number, optional, string } from '@forklaunch/validator/typebox';
+
+const PaymentStatusEnum = {
+  PENDING: 'pending',
+  SUCCEEDED: 'succeeded',
+  FAILED: 'failed'
+} as const;
+
+export const CreatePaymentSchema = {
+  orderId: string,
+  amountCents: number,
+  currency: string
+};
+
+export const PaymentSchema = {
+  id: string,
+  orderId: string,
+  amountCents: number,
+  currency: string,
+  status: enum_(PaymentStatusEnum),
+  providerRef: optional(string)
+};
+
+export const ConfirmPaymentSchema = {
+  providerRef: string
+};
+
+export const FailPaymentSchema = {
+  providerRef: string
+};
+
+export const BasePaymentServiceSchemas = () => ({
+  CreatePaymentSchema,
+  PaymentSchema
+});

--- a/blueprint/implementations/ecommerce/base/domain/schemas/zod/payment.schema.ts
+++ b/blueprint/implementations/ecommerce/base/domain/schemas/zod/payment.schema.ts
@@ -1,0 +1,35 @@
+import { enum_, number, optional, string } from '@forklaunch/validator/zod';
+
+const PaymentStatusEnum = {
+  PENDING: 'pending',
+  SUCCEEDED: 'succeeded',
+  FAILED: 'failed'
+} as const;
+
+export const CreatePaymentSchema = {
+  orderId: string,
+  amountCents: number,
+  currency: string
+};
+
+export const PaymentSchema = {
+  id: string,
+  orderId: string,
+  amountCents: number,
+  currency: string,
+  status: enum_(PaymentStatusEnum),
+  providerRef: optional(string)
+};
+
+export const ConfirmPaymentSchema = {
+  providerRef: string
+};
+
+export const FailPaymentSchema = {
+  providerRef: string
+};
+
+export const BasePaymentServiceSchemas = () => ({
+  CreatePaymentSchema,
+  PaymentSchema
+});

--- a/blueprint/implementations/ecommerce/base/domain/types/baseEcommerceDto.types.ts
+++ b/blueprint/implementations/ecommerce/base/domain/types/baseEcommerceDto.types.ts
@@ -3,10 +3,12 @@ import {
   CreateCartDto,
   CreateInventoryDto,
   CreateOrderDto,
+  CreatePaymentDto,
   CreateProductDto,
   CreateVariantDto,
   InventoryDto,
   OrderDto,
+  PaymentDto,
   ProductDto,
   UpdateCartDto,
   UpdateInventoryDto,
@@ -51,4 +53,10 @@ export type BaseOrderDtos = {
   OrderMapper: OrderDto;
   CreateOrderMapper: CreateOrderDto;
   UpdateOrderMapper: UpdateOrderDto;
+};
+
+// payment dto types
+export type BasePaymentDtos = {
+  PaymentMapper: PaymentDto;
+  CreatePaymentMapper: CreatePaymentDto;
 };

--- a/blueprint/implementations/ecommerce/base/domain/types/baseEcommerceDto.types.ts
+++ b/blueprint/implementations/ecommerce/base/domain/types/baseEcommerceDto.types.ts
@@ -3,10 +3,12 @@ import {
   CreateCartDto,
   CreateInventoryDto,
   CreateOrderDto,
+  CreatePaymentDto,
   CreateProductDto,
   CreateVariantDto,
   InventoryDto,
   OrderDto,
+  PaymentDto,
   ProductDto,
   UpdateCartDto,
   UpdateInventoryDto,
@@ -50,4 +52,10 @@ export type BaseOrderDtos = {
   OrderMapper: OrderDto;
   CreateOrderMapper: CreateOrderDto;
   UpdateOrderMapper: UpdateOrderDto;
+};
+
+// payment dto types
+export type BasePaymentDtos = {
+  PaymentMapper: PaymentDto;
+  CreatePaymentMapper: CreatePaymentDto;
 };

--- a/blueprint/implementations/ecommerce/base/domain/types/baseEcommerceEntity.types.ts
+++ b/blueprint/implementations/ecommerce/base/domain/types/baseEcommerceEntity.types.ts
@@ -2,6 +2,7 @@ import {
   Cart,
   Inventory,
   Order,
+  Payment,
   Product,
   Variant
 } from '../../persistence/entities';
@@ -41,4 +42,10 @@ export type BaseOrderEntities = {
   OrderMapper: { '~entity': (typeof Order)['~entity'] };
   CreateOrderMapper: { '~entity': (typeof Order)['~entity'] };
   UpdateOrderMapper: { '~entity': (typeof Order)['~entity'] };
+};
+
+// payment entity types
+export type BasePaymentEntities = {
+  PaymentMapper: { '~entity': (typeof Payment)['~entity'] };
+  CreatePaymentMapper: { '~entity': (typeof Payment)['~entity'] };
 };

--- a/blueprint/implementations/ecommerce/base/domain/types/baseEcommerceEntity.types.ts
+++ b/blueprint/implementations/ecommerce/base/domain/types/baseEcommerceEntity.types.ts
@@ -2,6 +2,7 @@ import {
   Cart,
   Inventory,
   Order,
+  Payment,
   Product,
   Variant
 } from '../../persistence/entities';
@@ -40,4 +41,10 @@ export type BaseOrderEntities = {
   OrderMapper: { '~entity': (typeof Order)['~entity'] };
   CreateOrderMapper: { '~entity': (typeof Order)['~entity'] };
   UpdateOrderMapper: { '~entity': (typeof Order)['~entity'] };
+};
+
+// payment entity types
+export type BasePaymentEntities = {
+  PaymentMapper: { '~entity': (typeof Payment)['~entity'] };
+  CreatePaymentMapper: { '~entity': (typeof Payment)['~entity'] };
 };

--- a/blueprint/implementations/ecommerce/base/domain/types/index.ts
+++ b/blueprint/implementations/ecommerce/base/domain/types/index.ts
@@ -3,5 +3,6 @@ export * from './baseEcommerceEntity.types';
 export * from './cart.mapper.types';
 export * from './inventory.mapper.types';
 export * from './order.mapper.types';
+export * from './payment.mapper.types';
 export * from './product.mapper.types';
 export * from './variant.mapper.types';

--- a/blueprint/implementations/ecommerce/base/domain/types/index.ts
+++ b/blueprint/implementations/ecommerce/base/domain/types/index.ts
@@ -3,6 +3,7 @@ export * from './baseEcommerceEntity.types';
 export * from './cart.mapper.types';
 export * from './inventory.mapper.types';
 export * from './order.mapper.types';
+export * from './payment.mapper.types';
 export * from './product.mapper.types';
 export * from './variant.mapper.types';
 // Remaining per-entity mapper.types exports are added incrementally as each PR lands.

--- a/blueprint/implementations/ecommerce/base/domain/types/payment.mapper.types.ts
+++ b/blueprint/implementations/ecommerce/base/domain/types/payment.mapper.types.ts
@@ -1,0 +1,23 @@
+import { EntityManager, InferEntity } from '@mikro-orm/core';
+import { BasePaymentDtos } from './baseEcommerceDto.types';
+import { BasePaymentEntities } from './baseEcommerceEntity.types';
+
+export type PaymentMappers<
+  MapperEntities extends BasePaymentEntities,
+  MapperDomains extends BasePaymentDtos = BasePaymentDtos
+> = {
+  PaymentMapper: {
+    entity: MapperEntities['PaymentMapper'];
+    toDto: (
+      entity: InferEntity<MapperEntities['PaymentMapper']>
+    ) => Promise<MapperDomains['PaymentMapper']>;
+  };
+  CreatePaymentMapper: {
+    entity: MapperEntities['CreatePaymentMapper'];
+    toEntity: (
+      dto: MapperDomains['CreatePaymentMapper'],
+      em: EntityManager,
+      ...args: unknown[]
+    ) => Promise<InferEntity<MapperEntities['CreatePaymentMapper']>>;
+  };
+};

--- a/blueprint/implementations/ecommerce/base/persistence/entities/index.ts
+++ b/blueprint/implementations/ecommerce/base/persistence/entities/index.ts
@@ -90,3 +90,18 @@ export const Order = defineComplianceEntity({
     totalCents: fp.integer().compliance('none')
   }
 });
+
+export const Payment = defineComplianceEntity({
+  name: 'Payment',
+  properties: {
+    id: fp.string().primary().compliance('none'),
+    orderId: fp.string().compliance('none'),
+    amountCents: fp.integer().compliance('none'),
+    currency: fp.string().compliance('none'),
+    status: fp.string().compliance('none'),
+    // Provider payment-intent id — not itself a card/account number, so
+    // compliance('none') is appropriate; raw card data is never stored here
+    // (Stripe/PayPal hold it — see commerce-security convention).
+    providerRef: fp.string().nullable().unique().compliance('none')
+  }
+});

--- a/blueprint/implementations/ecommerce/base/persistence/entities/index.ts
+++ b/blueprint/implementations/ecommerce/base/persistence/entities/index.ts
@@ -89,3 +89,18 @@ export const Order = defineComplianceEntity({
     totalCents: fp.integer().compliance('none')
   }
 });
+
+export const Payment = defineComplianceEntity({
+  name: 'Payment',
+  properties: {
+    id: fp.string().primary().compliance('none'),
+    orderId: fp.string().compliance('none'),
+    amountCents: fp.integer().compliance('none'),
+    currency: fp.string().compliance('none'),
+    status: fp.string().compliance('none'),
+    // Provider payment-intent id — not itself a card/account number, so
+    // compliance('none') is appropriate; raw card data is never stored here
+    // (Stripe/PayPal hold it — see commerce-security convention).
+    providerRef: fp.string().nullable().unique().compliance('none')
+  }
+});

--- a/blueprint/implementations/ecommerce/base/services/index.ts
+++ b/blueprint/implementations/ecommerce/base/services/index.ts
@@ -1,6 +1,7 @@
 export * from './cart.service';
 export * from './inventory.service';
 export * from './order.service';
+export * from './payment.service';
 export * from './product.service';
 export * from './variant.service';
 

--- a/blueprint/implementations/ecommerce/base/services/index.ts
+++ b/blueprint/implementations/ecommerce/base/services/index.ts
@@ -1,6 +1,7 @@
 export * from './cart.service';
 export * from './inventory.service';
 export * from './order.service';
+export * from './payment.service';
 export * from './product.service';
 export * from './variant.service';
 // Remaining per-entity services are added incrementally as each PR lands.

--- a/blueprint/implementations/ecommerce/base/services/payment.service.ts
+++ b/blueprint/implementations/ecommerce/base/services/payment.service.ts
@@ -1,0 +1,145 @@
+import {
+  evaluateTelemetryOptions,
+  MetricsDefinition,
+  OpenTelemetryCollector,
+  TelemetryOptions
+} from '@forklaunch/core/http';
+import { PaymentService } from '@forklaunch/interfaces-ecommerce/interfaces';
+import {
+  ConfirmPaymentDto,
+  CreatePaymentDto,
+  FailPaymentDto,
+  PaymentStatus
+} from '@forklaunch/interfaces-ecommerce/types';
+import { AnySchemaValidator } from '@forklaunch/validator';
+import { EntityManager, InferEntity } from '@mikro-orm/core';
+import { BasePaymentDtos } from '../domain/types/baseEcommerceDto.types';
+import { BasePaymentEntities } from '../domain/types/baseEcommerceEntity.types';
+import { PaymentMappers } from '../domain/types/payment.mapper.types';
+import { Payment } from '../persistence/entities';
+
+/**
+ * Persists payment records and their pending/succeeded/failed lifecycle.
+ * Provider-specific classes (e.g. StripePaymentService) wrap this and add the
+ * actual 3rd-party API calls, delegating persistence back to this base —
+ * same split as BasePlanService/StripePlanService in billing.
+ */
+export class BasePaymentService<
+  SchemaValidator extends AnySchemaValidator,
+  MapperEntities extends BasePaymentEntities,
+  MapperDomains extends BasePaymentDtos = BasePaymentDtos
+> implements PaymentService
+{
+  private evaluatedTelemetryOptions: {
+    logging?: boolean;
+    metrics?: boolean;
+    tracing?: boolean;
+  };
+  public em: EntityManager;
+  protected openTelemetryCollector: OpenTelemetryCollector<MetricsDefinition>;
+  protected schemaValidator: SchemaValidator;
+  protected mappers: PaymentMappers<MapperEntities, MapperDomains>;
+
+  constructor(
+    em: EntityManager,
+    openTelemetryCollector: OpenTelemetryCollector<MetricsDefinition>,
+    schemaValidator: SchemaValidator,
+    mappers: PaymentMappers<MapperEntities, MapperDomains>,
+    options?: {
+      telemetry?: TelemetryOptions;
+    }
+  ) {
+    this.em = em;
+    this.openTelemetryCollector = openTelemetryCollector;
+    this.schemaValidator = schemaValidator;
+    this.mappers = mappers;
+    this.evaluatedTelemetryOptions = options?.telemetry
+      ? evaluateTelemetryOptions(options.telemetry).enabled
+      : {
+          logging: false,
+          metrics: false,
+          tracing: false
+        };
+  }
+
+  /** Persists a pending payment record. Provider wrappers call the 3rd-party API around this. */
+  async createPayment(
+    paymentDto: CreatePaymentDto,
+    em?: EntityManager,
+    ...args: unknown[]
+  ): Promise<MapperDomains['PaymentMapper']> {
+    if (this.evaluatedTelemetryOptions.logging) {
+      this.openTelemetryCollector.info('Creating payment', paymentDto);
+    }
+    const payment = await this.mappers.CreatePaymentMapper.toEntity(
+      paymentDto,
+      em ?? this.em,
+      ...(args[0] instanceof EntityManager ? args.slice(1) : args)
+    );
+    await (em ?? this.em).transactional(async (innerEm) => {
+      await innerEm.persist(payment);
+    });
+    return this.mappers.PaymentMapper.toDto(payment);
+  }
+
+  async getPayment(
+    idDto: { id: string },
+    em?: EntityManager
+  ): Promise<MapperDomains['PaymentMapper']> {
+    if (this.evaluatedTelemetryOptions.logging) {
+      this.openTelemetryCollector.info('Getting payment', idDto);
+    }
+    const payment = await (em ?? this.em).findOneOrFail(
+      this.mappers.PaymentMapper.entity as typeof Payment,
+      idDto
+    );
+    return this.mappers.PaymentMapper.toDto(
+      payment as InferEntity<MapperEntities['PaymentMapper']>
+    );
+  }
+
+  /** Idempotent: re-confirming an already-succeeded payment is a no-op, not an error. */
+  async confirmPayment(
+    confirmDto: ConfirmPaymentDto,
+    em?: EntityManager
+  ): Promise<MapperDomains['PaymentMapper']> {
+    if (this.evaluatedTelemetryOptions.logging) {
+      this.openTelemetryCollector.info('Confirming payment', confirmDto);
+    }
+    const entityManager = em ?? this.em;
+    const payment = await entityManager.findOneOrFail(
+      this.mappers.PaymentMapper.entity as typeof Payment,
+      { providerRef: confirmDto.providerRef }
+    );
+    if (payment.status !== PaymentStatus.SUCCEEDED) {
+      entityManager.assign(payment, { status: PaymentStatus.SUCCEEDED });
+      await entityManager.transactional(async (innerEm) => {
+        await innerEm.persist(payment);
+      });
+    }
+    return this.mappers.PaymentMapper.toDto(
+      payment as InferEntity<MapperEntities['PaymentMapper']>
+    );
+  }
+
+  async failPayment(
+    failDto: FailPaymentDto,
+    em?: EntityManager
+  ): Promise<MapperDomains['PaymentMapper']> {
+    if (this.evaluatedTelemetryOptions.logging) {
+      this.openTelemetryCollector.info('Failing payment', failDto);
+    }
+    const entityManager = em ?? this.em;
+    const payment = await entityManager.findOneOrFail(
+      this.mappers.PaymentMapper.entity as typeof Payment,
+      { providerRef: failDto.providerRef }
+    );
+    entityManager.assign(payment, { status: PaymentStatus.FAILED });
+    await entityManager.transactional(async (innerEm) => {
+      await innerEm.persist(payment);
+    });
+    return this.mappers.PaymentMapper.toDto(
+      payment as InferEntity<MapperEntities['PaymentMapper']>
+    );
+  }
+}

--- a/blueprint/implementations/ecommerce/base/services/payment.service.ts
+++ b/blueprint/implementations/ecommerce/base/services/payment.service.ts
@@ -134,10 +134,18 @@ export class BasePaymentService<
       this.mappers.PaymentMapper.entity as typeof Payment,
       { providerRef: failDto.providerRef }
     );
-    entityManager.assign(payment, { status: PaymentStatus.FAILED });
-    await entityManager.transactional(async (innerEm) => {
-      await innerEm.persist(payment);
-    });
+    // A payment that already succeeded stays succeeded. Stripe does not
+    // guarantee event ordering, so a payment_failed for an earlier attempt can
+    // arrive after the payment_intent.succeeded that settled the charge;
+    // without this guard that late event marks a paid payment FAILED, and the
+    // order is left looking unpaid against money that was actually taken.
+    // confirmPayment guards the same way for the same reason.
+    if (payment.status !== PaymentStatus.SUCCEEDED) {
+      entityManager.assign(payment, { status: PaymentStatus.FAILED });
+      await entityManager.transactional(async (innerEm) => {
+        await innerEm.persist(payment);
+      });
+    }
     return this.mappers.PaymentMapper.toDto(
       payment as InferEntity<MapperEntities['PaymentMapper']>
     );

--- a/blueprint/interfaces/ecommerce/interfaces/index.ts
+++ b/blueprint/interfaces/ecommerce/interfaces/index.ts
@@ -1,5 +1,6 @@
 export * from './cart.service.interface';
 export * from './inventory.service.interface';
 export * from './order.service.interface';
+export * from './payment.service.interface';
 export * from './product.service.interface';
 export * from './variant.service.interface';

--- a/blueprint/interfaces/ecommerce/interfaces/index.ts
+++ b/blueprint/interfaces/ecommerce/interfaces/index.ts
@@ -1,6 +1,7 @@
 export * from './cart.service.interface';
 export * from './inventory.service.interface';
 export * from './order.service.interface';
+export * from './payment.service.interface';
 export * from './product.service.interface';
 export * from './variant.service.interface';
 // Remaining service interfaces are added incrementally as each entity's PR lands.

--- a/blueprint/interfaces/ecommerce/interfaces/payment.service.interface.ts
+++ b/blueprint/interfaces/ecommerce/interfaces/payment.service.interface.ts
@@ -1,0 +1,26 @@
+import { EntityManager } from '@mikro-orm/core';
+import { PaymentServiceParameters } from '../types/payment.service.types';
+
+export interface PaymentService<
+  Params extends PaymentServiceParameters = PaymentServiceParameters
+> {
+  /** Creates a pending payment and initiates it with the provider (ECOM-10). */
+  createPayment: (
+    paymentDto: Params['CreatePaymentDto'],
+    em?: EntityManager
+  ) => Promise<Params['PaymentDto']>;
+  getPayment: (
+    idDto: Params['IdDto'],
+    em?: EntityManager
+  ) => Promise<Params['PaymentDto']>;
+  /** Idempotent — driven by the provider's webhook confirming success. */
+  confirmPayment: (
+    confirmDto: Params['ConfirmPaymentDto'],
+    em?: EntityManager
+  ) => Promise<Params['PaymentDto']>;
+  /** Failed payment — the seam dunning (ECOM-20) hooks into later. */
+  failPayment: (
+    failDto: Params['FailPaymentDto'],
+    em?: EntityManager
+  ) => Promise<Params['PaymentDto']>;
+}

--- a/blueprint/interfaces/ecommerce/interfaces/payment.service.interface.ts
+++ b/blueprint/interfaces/ecommerce/interfaces/payment.service.interface.ts
@@ -4,7 +4,7 @@ import { PaymentServiceParameters } from '../types/payment.service.types';
 export interface PaymentService<
   Params extends PaymentServiceParameters = PaymentServiceParameters
 > {
-  /** Creates a pending payment and initiates it with the provider (ECOM-10). */
+  /** Creates a pending payment and initiates it with the provider. */
   createPayment: (
     paymentDto: Params['CreatePaymentDto'],
     em?: EntityManager
@@ -18,7 +18,7 @@ export interface PaymentService<
     confirmDto: Params['ConfirmPaymentDto'],
     em?: EntityManager
   ) => Promise<Params['PaymentDto']>;
-  /** Failed payment — the seam dunning (ECOM-20) hooks into later. */
+  /** Failed payment — the seam dunning hooks into later. */
   failPayment: (
     failDto: Params['FailPaymentDto'],
     em?: EntityManager

--- a/blueprint/interfaces/ecommerce/types/index.ts
+++ b/blueprint/interfaces/ecommerce/types/index.ts
@@ -1,5 +1,6 @@
 export * from './cart.service.types';
 export * from './inventory.service.types';
 export * from './order.service.types';
+export * from './payment.service.types';
 export * from './product.service.types';
 export * from './variant.service.types';

--- a/blueprint/interfaces/ecommerce/types/index.ts
+++ b/blueprint/interfaces/ecommerce/types/index.ts
@@ -1,6 +1,7 @@
 export * from './cart.service.types';
 export * from './inventory.service.types';
 export * from './order.service.types';
+export * from './payment.service.types';
 export * from './product.service.types';
 export * from './variant.service.types';
 // Remaining DTO types are added incrementally as each entity's PR lands.

--- a/blueprint/interfaces/ecommerce/types/payment.service.types.ts
+++ b/blueprint/interfaces/ecommerce/types/payment.service.types.ts
@@ -1,0 +1,43 @@
+import { IdDto, RecordTimingDto } from '@forklaunch/common';
+
+export const PaymentStatus = {
+  PENDING: 'pending',
+  SUCCEEDED: 'succeeded',
+  FAILED: 'failed'
+} as const;
+
+export type PaymentStatusType = (typeof PaymentStatus)[keyof typeof PaymentStatus];
+
+export type CreatePaymentDto = Partial<IdDto> & {
+  orderId: string;
+  amountCents: number;
+  currency: string;
+};
+
+export type PaymentDto = CreatePaymentDto &
+  IdDto &
+  Partial<RecordTimingDto> & {
+    status: PaymentStatusType;
+    /** Provider-side reference (e.g. Stripe PaymentIntent id). */
+    providerRef?: string;
+  };
+
+/**
+ * Keyed on providerRef, not id — a webhook only ever has the provider's own
+ * reference (e.g. the Stripe PaymentIntent id), never our internal id.
+ */
+export type ConfirmPaymentDto = {
+  providerRef: string;
+};
+
+export type FailPaymentDto = {
+  providerRef: string;
+};
+
+export type PaymentServiceParameters = {
+  CreatePaymentDto: CreatePaymentDto;
+  PaymentDto: PaymentDto;
+  ConfirmPaymentDto: ConfirmPaymentDto;
+  FailPaymentDto: FailPaymentDto;
+  IdDto: IdDto;
+};


### PR DESCRIPTION
Payment core, carved from `feat/ecommerce-module`. Stacks on #237 (order).

Split from the provider implementations so each PR stays inside the ~20 file / ~1000 line review budget — the combined slice was 40 files / 1220 lines.

- `Payment` entity, `BasePaymentService` (create/get/confirm/fail), schemas (typebox + zod), mappers, service interface + types.
- `payment.controller.ts` routes between stripe and paypal by `provider` in the request body.

**One judgment call:** `PaymentService` and `PaypalPaymentService` are registered against `BasePaymentService` here as placeholders, because the provider packages don't exist until the next PR. `tsconfig` includes all `.ts`, so the controller typechecks regardless of routing — both tokens must resolve for this PR to build standalone. The next PR swaps them for the real implementations. This follows the incremental-registration convention already documented in `registrations.ts`.

Applies the `@forklaunch/blueprint-core` import convention. `payment.controller.ts` has no inline schema definitions.

0 typecheck errors.