### PR TITLE
Add Stripe and PayPal payment provider implementations

### DIFF
--- a/blueprint/ecommerce-stripe/domain/types/ecommerceMappers.types.ts
+++ b/blueprint/ecommerce-stripe/domain/types/ecommerceMappers.types.ts
@@ -138,3 +138,10 @@ export type {
   ProductMappers,
   VariantMappers
 } from '@forklaunch/implementation-ecommerce-base/types';
+
+// Same TS2883 anchor requirement as above, but for the two payment-provider
+// packages: their StripePaymentMappers/PaypalPaymentMappers types are what
+// the dependency container infers through StripePaymentService/
+// PaypalPaymentService's constructor generics.
+export type { StripePaymentMappers } from '@forklaunch/implementation-ecommerce-stripe/types';
+export type { PaypalPaymentMappers } from '@forklaunch/implementation-ecommerce-paypal/types';

--- a/blueprint/ecommerce-stripe/domain/types/ecommerceMappers.types.ts
+++ b/blueprint/ecommerce-stripe/domain/types/ecommerceMappers.types.ts
@@ -127,3 +127,10 @@ export type {
   ProductMappers,
   VariantMappers
 } from '@forklaunch/implementation-ecommerce-base/types';
+
+// Same TS2883 anchor requirement as above, but for the two payment-provider
+// packages: their StripePaymentMappers/PaypalPaymentMappers types are what
+// the dependency container infers through StripePaymentService/
+// PaypalPaymentService's constructor generics.
+export type { StripePaymentMappers } from '@forklaunch/implementation-ecommerce-stripe/types';
+export type { PaypalPaymentMappers } from '@forklaunch/implementation-ecommerce-paypal/types';

--- a/blueprint/ecommerce-stripe/package.json
+++ b/blueprint/ecommerce-stripe/package.json
@@ -40,6 +40,8 @@
     "@forklaunch/express": "^1.2.39",
     "@forklaunch/hyper-express": "^1.2.39",
     "@forklaunch/implementation-ecommerce-base": "workspace:^",
+    "@forklaunch/implementation-ecommerce-paypal": "workspace:^",
+    "@forklaunch/implementation-ecommerce-stripe": "workspace:^",
     "@forklaunch/implementation-worker-redis": "workspace:^",
     "@forklaunch/infrastructure-redis": "^1.4.10",
     "@forklaunch/interfaces-ecommerce": "workspace:^",

--- a/blueprint/ecommerce-stripe/registrations.ts
+++ b/blueprint/ecommerce-stripe/registrations.ts
@@ -21,16 +21,21 @@ import {
   BaseCartService,
   BaseInventoryService,
   BaseOrderService,
-  BasePaymentService,
   BaseProductService,
   BaseVariantService
 } from '@forklaunch/implementation-ecommerce-base/services';
+import {
+  PaypalClient,
+  PaypalPaymentService
+} from '@forklaunch/implementation-ecommerce-paypal/services';
+import { StripePaymentService } from '@forklaunch/implementation-ecommerce-stripe/services';
 import { RedisWorkerProducer } from '@forklaunch/implementation-worker-redis/producers';
 import { RedisWorkerSchemas } from '@forklaunch/implementation-worker-redis/schemas';
 import { RedisWorkerOptions } from '@forklaunch/implementation-worker-redis/types';
 import { OrderEventRecord } from './persistence/entities/orderEvent.entity';
 import { ForkOptions } from '@mikro-orm/core';
 import { EntityManager, MikroORM } from '@mikro-orm/postgresql';
+import Stripe from 'stripe';
 import {
   CartMapper,
   CreateCartMapper,
@@ -132,6 +137,11 @@ const environmentConfig = configInjector.chain({
     type: string,
     value: getEnvVar('OTEL_EXPORTER_OTLP_ENDPOINT')
   },
+  STRIPE_API_KEY: {
+    lifetime: Lifetime.Singleton,
+    type: string,
+    value: getEnvVar('STRIPE_API_KEY')
+  },
   HMAC_SECRET_KEY: {
     lifetime: Lifetime.Singleton,
     type: string,
@@ -146,6 +156,21 @@ const environmentConfig = configInjector.chain({
     lifetime: Lifetime.Singleton,
     type: string,
     value: getEnvVar('ENCRYPTION_KEY')
+  },
+  PAYPAL_CLIENT_ID: {
+    lifetime: Lifetime.Singleton,
+    type: string,
+    value: getEnvVar('PAYPAL_CLIENT_ID')
+  },
+  PAYPAL_CLIENT_SECRET: {
+    lifetime: Lifetime.Singleton,
+    type: string,
+    value: getEnvVar('PAYPAL_CLIENT_SECRET')
+  },
+  PAYPAL_BASE_URL: {
+    lifetime: Lifetime.Singleton,
+    type: string,
+    value: getEnvVar('PAYPAL_BASE_URL')
   },
   REDIS_URL: {
     lifetime: Lifetime.Singleton,
@@ -163,6 +188,21 @@ const environmentConfig = configInjector.chain({
 //! entity-specific services. Same multi-step chain pattern this file uses
 //! above: configInjector -> environmentConfig -> runtimeDependencies.
 const runtimeDependencies = environmentConfig.chain({
+  StripeClient: {
+    lifetime: Lifetime.Singleton,
+    type: Stripe,
+    factory: ({ STRIPE_API_KEY }) => new Stripe(STRIPE_API_KEY)
+  },
+  PaypalClient: {
+    lifetime: Lifetime.Singleton,
+    type: PaypalClient,
+    factory: ({ PAYPAL_CLIENT_ID, PAYPAL_CLIENT_SECRET, PAYPAL_BASE_URL }) =>
+      new PaypalClient({
+        clientId: PAYPAL_CLIENT_ID,
+        clientSecret: PAYPAL_CLIENT_SECRET,
+        baseUrl: PAYPAL_BASE_URL
+      })
+  },
   /**
    * Cart's fast/temporary-state layer: a read-through cache in front of
    * Postgres, which stays the source of truth. 30 minutes matches a typical
@@ -292,62 +332,74 @@ const serviceDependencies = runtimeDependencies.chain({
         { OrderMapper, CreateOrderMapper, UpdateOrderMapper }
       )
   },
-  /**
-   * BasePaymentService directly for now, matching the CartService/
-   * OrderService/ProductService/VariantService/InventoryService pattern
-   * above — no provider-specific behavior is needed to typecheck/persist a
-   * payment record yet. PaymentService and PaypalPaymentService are
-   * registered as separate tokens (mirroring payment.controller.ts's
-   * provider routing); the provider packages swap these factories to
-   * StripePaymentService/PaypalPaymentService.
-   */
   PaymentService: {
     lifetime: Lifetime.Scoped,
-    type: BasePaymentService<SchemaValidator, PaymentMapperTypes, PaymentDtoTypes>,
-    factory: ({ EntityManager, OtelCollector }, context, resolve) =>
-      new BasePaymentService(
+    type: StripePaymentService<
+      SchemaValidator,
+      PaymentMapperTypes,
+      PaymentDtoTypes
+    >,
+    factory: (
+      { StripeClient, EntityManager, OtelCollector },
+      context,
+      resolve
+    ) =>
+      new StripePaymentService(
+        StripeClient,
         context?.entityManagerOptions
           ? resolve('EntityManager', context)
           : EntityManager,
         OtelCollector,
         schemaValidator,
-        // CreatePaymentMapper.toEntity takes a Stripe.PaymentIntent 3rd arg
-        // (payment.mappers.ts is provider-shaped) rather than the generic
-        // BasePaymentService mapper signature (...args: unknown[]) — the
-        // cast bridges the two over one shared runtime mapper object, the
-        // same pattern PaypalPaymentService uses for this pair.
-        { PaymentMapper, CreatePaymentMapper } as unknown as ConstructorParameters<
-          typeof BasePaymentService<
-            SchemaValidator,
-            PaymentMapperTypes,
-            PaymentDtoTypes
-          >
-        >[3]
-      )
-  },
-  PaypalPaymentService: {
-    lifetime: Lifetime.Scoped,
-    type: BasePaymentService<SchemaValidator, PaymentMapperTypes, PaymentDtoTypes>,
-    factory: ({ EntityManager, OtelCollector }, context, resolve) =>
-      new BasePaymentService(
-        context?.entityManagerOptions
-          ? resolve('EntityManager', context)
-          : EntityManager,
-        OtelCollector,
-        schemaValidator,
-        { PaymentMapper, CreatePaymentMapper } as unknown as ConstructorParameters<
-          typeof BasePaymentService<
-            SchemaValidator,
-            PaymentMapperTypes,
-            PaymentDtoTypes
-          >
-        >[3]
+        { PaymentMapper, CreatePaymentMapper }
       )
   },
   /**
-   * The event-emission boundary. Redis transport only, which matches
-   * TtlCache already being registered here, so it needs no infrastructure
-   * beyond what cart caching already requires.
+   * Separate token from PaymentService (Stripe, the default) rather than
+   * replacing it — this is the "one socket, many providers" seam: callers
+   * pick a provider per-request (see payment.controller.ts), neither
+   * provider is removed to add the other.
+   */
+  PaypalPaymentService: {
+    lifetime: Lifetime.Scoped,
+    type: PaypalPaymentService<
+      SchemaValidator,
+      PaymentMapperTypes,
+      PaymentDtoTypes
+    >,
+    factory: (
+      { PaypalClient: paypalClientInstance, EntityManager, OtelCollector },
+      context,
+      resolve
+    ) =>
+      new PaypalPaymentService(
+        paypalClientInstance,
+        context?.entityManagerOptions
+          ? resolve('EntityManager', context)
+          : EntityManager,
+        OtelCollector,
+        schemaValidator,
+        // Same runtime shape as Stripe's mappers (toEntity only reads `.id`
+        // off the 3rd arg) — PaypalPaymentMappers narrows the type to
+        // PaypalOrder; the cast bridges the two provider-specific static
+        // types over one shared runtime mapper object, same as
+        // StripePaymentService does internally for its own 3rd-arg type.
+        { PaymentMapper, CreatePaymentMapper } as unknown as ConstructorParameters<
+          typeof PaypalPaymentService<
+            SchemaValidator,
+            PaymentMapperTypes,
+            PaymentDtoTypes
+          >
+        >[4]
+      )
+  },
+  /**
+   * ECOM-12's event-emission boundary, actually implemented — previously
+   * just a comment. Redis transport only (matches TtlCache already being
+   * registered here; no new infra beyond what cart caching already needs).
+   * Only the producer side is wired here — order.controller.ts is the only
+   * local consumer of a token from this pair; the consumer/worker.ts side
+   * is scoped to a follow-up PR.
    */
   RedisWorkerOptions: {
     lifetime: Lifetime.Singleton,

--- a/blueprint/ecommerce-stripe/registrations.ts
+++ b/blueprint/ecommerce-stripe/registrations.ts
@@ -21,16 +21,21 @@ import {
   BaseCartService,
   BaseInventoryService,
   BaseOrderService,
-  BasePaymentService,
   BaseProductService,
   BaseVariantService
 } from '@forklaunch/implementation-ecommerce-base/services';
+import {
+  PaypalClient,
+  PaypalPaymentService
+} from '@forklaunch/implementation-ecommerce-paypal/services';
+import { StripePaymentService } from '@forklaunch/implementation-ecommerce-stripe/services';
 import { RedisWorkerProducer } from '@forklaunch/implementation-worker-redis/producers';
 import { RedisWorkerSchemas } from '@forklaunch/implementation-worker-redis/schemas';
 import { RedisWorkerOptions } from '@forklaunch/implementation-worker-redis/types';
 import { OrderEventRecord } from './persistence/entities/orderEvent.entity';
 import { ForkOptions } from '@mikro-orm/core';
 import { EntityManager, MikroORM } from '@mikro-orm/postgresql';
+import Stripe from 'stripe';
 import {
   CartMapper,
   CreateCartMapper,
@@ -132,6 +137,11 @@ const environmentConfig = configInjector.chain({
     type: string,
     value: getEnvVar('OTEL_EXPORTER_OTLP_ENDPOINT')
   },
+  STRIPE_API_KEY: {
+    lifetime: Lifetime.Singleton,
+    type: string,
+    value: getEnvVar('STRIPE_API_KEY')
+  },
   HMAC_SECRET_KEY: {
     lifetime: Lifetime.Singleton,
     type: string,
@@ -146,6 +156,21 @@ const environmentConfig = configInjector.chain({
     lifetime: Lifetime.Singleton,
     type: string,
     value: getEnvVar('ENCRYPTION_KEY')
+  },
+  PAYPAL_CLIENT_ID: {
+    lifetime: Lifetime.Singleton,
+    type: string,
+    value: getEnvVar('PAYPAL_CLIENT_ID')
+  },
+  PAYPAL_CLIENT_SECRET: {
+    lifetime: Lifetime.Singleton,
+    type: string,
+    value: getEnvVar('PAYPAL_CLIENT_SECRET')
+  },
+  PAYPAL_BASE_URL: {
+    lifetime: Lifetime.Singleton,
+    type: string,
+    value: getEnvVar('PAYPAL_BASE_URL')
   },
   REDIS_URL: {
     lifetime: Lifetime.Singleton,
@@ -166,6 +191,21 @@ const environmentConfig = configInjector.chain({
 //! -> runtimeDependencies), so every intermediate PR stays independently
 //! buildable rather than referencing services that don't exist yet.
 const runtimeDependencies = environmentConfig.chain({
+  StripeClient: {
+    lifetime: Lifetime.Singleton,
+    type: Stripe,
+    factory: ({ STRIPE_API_KEY }) => new Stripe(STRIPE_API_KEY)
+  },
+  PaypalClient: {
+    lifetime: Lifetime.Singleton,
+    type: PaypalClient,
+    factory: ({ PAYPAL_CLIENT_ID, PAYPAL_CLIENT_SECRET, PAYPAL_BASE_URL }) =>
+      new PaypalClient({
+        clientId: PAYPAL_CLIENT_ID,
+        clientSecret: PAYPAL_CLIENT_SECRET,
+        baseUrl: PAYPAL_BASE_URL
+      })
+  },
   /**
    * Cart's fast/temporary-state layer (ECOM-06's original design) — a
    * read-through cache in front of Postgres, which stays the source of
@@ -287,58 +327,65 @@ const serviceDependencies = runtimeDependencies.chain({
         { OrderMapper, CreateOrderMapper, UpdateOrderMapper }
       )
   },
-  /**
-   * BasePaymentService directly for now, matching the CartService/
-   * OrderService/ProductService/VariantService/InventoryService pattern
-   * above — no provider-specific behavior is needed to typecheck/persist a
-   * payment record yet. PaymentService and PaypalPaymentService are
-   * registered as separate tokens (mirroring payment.controller.ts's
-   * provider routing) but both resolve to the same base implementation
-   * until the stripe/paypal provider packages land in a follow-up PR and
-   * swap these factories to StripePaymentService/PaypalPaymentService.
-   */
   PaymentService: {
     lifetime: Lifetime.Scoped,
-    type: BasePaymentService<SchemaValidator, PaymentMapperTypes, PaymentDtoTypes>,
-    factory: ({ EntityManager, OtelCollector }, context, resolve) =>
-      new BasePaymentService(
+    type: StripePaymentService<
+      SchemaValidator,
+      PaymentMapperTypes,
+      PaymentDtoTypes
+    >,
+    factory: (
+      { StripeClient, EntityManager, OtelCollector },
+      context,
+      resolve
+    ) =>
+      new StripePaymentService(
+        StripeClient,
         context?.entityManagerOptions
           ? resolve('EntityManager', context)
           : EntityManager,
         OtelCollector,
         schemaValidator,
-        // CreatePaymentMapper.toEntity takes a Stripe.PaymentIntent 3rd arg
-        // (payment.mappers.ts is provider-shaped) rather than the generic
-        // BasePaymentService mapper signature (...args: unknown[]) — the
-        // cast bridges the two over one shared runtime mapper object, same
-        // pattern PaypalPaymentService uses for this pair once the stripe/
-        // paypal provider packages land.
-        { PaymentMapper, CreatePaymentMapper } as unknown as ConstructorParameters<
-          typeof BasePaymentService<
-            SchemaValidator,
-            PaymentMapperTypes,
-            PaymentDtoTypes
-          >
-        >[3]
+        { PaymentMapper, CreatePaymentMapper }
       )
   },
+  /**
+   * Separate token from PaymentService (Stripe, the default) rather than
+   * replacing it — this is the "one socket, many providers" seam: callers
+   * pick a provider per-request (see payment.controller.ts), neither
+   * provider is removed to add the other.
+   */
   PaypalPaymentService: {
     lifetime: Lifetime.Scoped,
-    type: BasePaymentService<SchemaValidator, PaymentMapperTypes, PaymentDtoTypes>,
-    factory: ({ EntityManager, OtelCollector }, context, resolve) =>
-      new BasePaymentService(
+    type: PaypalPaymentService<
+      SchemaValidator,
+      PaymentMapperTypes,
+      PaymentDtoTypes
+    >,
+    factory: (
+      { PaypalClient: paypalClientInstance, EntityManager, OtelCollector },
+      context,
+      resolve
+    ) =>
+      new PaypalPaymentService(
+        paypalClientInstance,
         context?.entityManagerOptions
           ? resolve('EntityManager', context)
           : EntityManager,
         OtelCollector,
         schemaValidator,
+        // Same runtime shape as Stripe's mappers (toEntity only reads `.id`
+        // off the 3rd arg) — PaypalPaymentMappers narrows the type to
+        // PaypalOrder; the cast bridges the two provider-specific static
+        // types over one shared runtime mapper object, same as
+        // StripePaymentService does internally for its own 3rd-arg type.
         { PaymentMapper, CreatePaymentMapper } as unknown as ConstructorParameters<
-          typeof BasePaymentService<
+          typeof PaypalPaymentService<
             SchemaValidator,
             PaymentMapperTypes,
             PaymentDtoTypes
           >
-        >[3]
+        >[4]
       )
   },
   /**

--- a/blueprint/ecommerce-stripe/registrations.ts
+++ b/blueprint/ecommerce-stripe/registrations.ts
@@ -384,7 +384,10 @@ const serviceDependencies = runtimeDependencies.chain({
         // PaypalOrder; the cast bridges the two provider-specific static
         // types over one shared runtime mapper object, same as
         // StripePaymentService does internally for its own 3rd-arg type.
-        { PaymentMapper, CreatePaymentMapper } as unknown as ConstructorParameters<
+        {
+          PaymentMapper,
+          CreatePaymentMapper
+        } as unknown as ConstructorParameters<
           typeof PaypalPaymentService<
             SchemaValidator,
             PaymentMapperTypes,
@@ -394,12 +397,9 @@ const serviceDependencies = runtimeDependencies.chain({
       )
   },
   /**
-   * ECOM-12's event-emission boundary, actually implemented — previously
-   * just a comment. Redis transport only (matches TtlCache already being
-   * registered here; no new infra beyond what cart caching already needs).
-   * Only the producer side is wired here — order.controller.ts is the only
-   * local consumer of a token from this pair; the consumer/worker.ts side
-   * is scoped to a follow-up PR.
+   * The event-emission boundary. Redis transport only, which matches
+   * TtlCache already being registered here, so it needs no infrastructure
+   * beyond what cart caching already requires.
    */
   RedisWorkerOptions: {
     lifetime: Lifetime.Singleton,

--- a/blueprint/implementations/ecommerce/paypal/.gitignore
+++ b/blueprint/implementations/ecommerce/paypal/.gitignore
@@ -1,0 +1,14 @@
+node_modules
+.idea
+.DS_Store
+
+lib
+
+.vscode
+
+*dist
+*lib
+
+temp
+
+.env.local

--- a/blueprint/implementations/ecommerce/paypal/.prettierignore
+++ b/blueprint/implementations/ecommerce/paypal/.prettierignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+lib/

--- a/blueprint/implementations/ecommerce/paypal/.prettierrc
+++ b/blueprint/implementations/ecommerce/paypal/.prettierrc
@@ -1,0 +1,7 @@
+{
+    "semi": true,
+    "trailingComma": "none",
+    "singleQuote": true,
+    "printWidth": 80,
+    "tabWidth": 2
+}

--- a/blueprint/implementations/ecommerce/paypal/domain/types/index.ts
+++ b/blueprint/implementations/ecommerce/paypal/domain/types/index.ts
@@ -1,0 +1,1 @@
+export * from './payment.mapper.types';

--- a/blueprint/implementations/ecommerce/paypal/domain/types/payment.mapper.types.ts
+++ b/blueprint/implementations/ecommerce/paypal/domain/types/payment.mapper.types.ts
@@ -1,0 +1,33 @@
+import {
+  BasePaymentDtos,
+  BasePaymentEntities
+} from '@forklaunch/implementation-ecommerce-base/types';
+import { EntityManager, InferEntity } from '@mikro-orm/core';
+import { PaypalOrder } from '../../services/paypal-client';
+
+/**
+ * PayPal-specific override of PaymentMappers — CreatePaymentMapper.toEntity
+ * takes the concrete PaypalOrder (created before persistence). Mirrors the
+ * StripePaymentMappers override; the base's generic ...args: unknown[] is
+ * narrowed here to PaypalOrder.
+ */
+export type PaypalPaymentMappers<
+  Entities extends BasePaymentEntities,
+  Dto extends BasePaymentDtos
+> = {
+  PaymentMapper: {
+    entity: Entities['PaymentMapper'];
+    toDto: (
+      entity: InferEntity<Entities['PaymentMapper']>
+    ) => Promise<Dto['PaymentMapper']>;
+  };
+  CreatePaymentMapper: {
+    entity: Entities['CreatePaymentMapper'];
+    toEntity: (
+      dto: Dto['CreatePaymentMapper'],
+      em: EntityManager,
+      paypalOrder: PaypalOrder,
+      ...args: unknown[]
+    ) => Promise<InferEntity<Entities['CreatePaymentMapper']>>;
+  };
+};

--- a/blueprint/implementations/ecommerce/paypal/eject-package.bash
+++ b/blueprint/implementations/ecommerce/paypal/eject-package.bash
@@ -1,0 +1,39 @@
+rm -rf lib/eject
+mkdir -p lib/eject/domain
+
+if [ -d "domain/schemas" ]; then
+  mkdir -p lib/eject/domain/schemas
+  cp -r domain/schemas/zod lib/eject/domain/schemas
+  cp domain/schemas/index.ts lib/eject/domain/schemas
+  find lib/eject/domain/schemas -type f -name "*.ts" -exec perl -i -pe "s|'\.\.\/\.\.|'\.\.|g" {} \;
+fi
+
+if [ -d "services" ]; then
+  cp -r services lib/eject/services
+fi
+
+if [ -d "domain/types" ]; then
+  cp -r domain/types lib/eject/domain/types
+fi
+
+if [ -d "domain/interfaces" ]; then
+  cp -r domain/interfaces lib/eject/domain/interfaces
+fi
+
+if [ -d "consumers" ]; then
+  cp -r consumers lib/eject/consumers
+fi
+
+if [ -d "producers" ]; then
+  cp -r producers lib/eject/producers
+fi
+
+if [ -d "domain/enum" ]; then
+  cp -r domain/enum lib/eject/domain/enum
+fi
+
+find lib/eject -type f -name '*.ts' -exec sh -c \
+  'for f do \
+    sed "s|@forklaunch/validator/zod|@{{app_name}}/core|g" "$f" > "$f.tmp" && \
+    mv "$f.tmp" "$f"; \
+  done' sh {} +

--- a/blueprint/implementations/ecommerce/paypal/eslint.config.mjs
+++ b/blueprint/implementations/ecommerce/paypal/eslint.config.mjs
@@ -1,0 +1,18 @@
+import pluginJs from '@eslint/js';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
+
+export default [
+  { files: ['**/*.{ts,tsx}'] },
+  {
+    ignores: [
+      '**/*tests/**/*',
+      '**/*dist/**/*',
+      '**/*lib/**/*',
+      '**/*node_modules/**/*'
+    ]
+  },
+  { languageOptions: { globals: globals.browser } },
+  pluginJs.configs.recommended,
+  ...tseslint.configs.recommended
+];

--- a/blueprint/implementations/ecommerce/paypal/jest.config.ts
+++ b/blueprint/implementations/ecommerce/paypal/jest.config.ts
@@ -1,0 +1,22 @@
+import type { JestConfigWithTsJest } from 'ts-jest';
+
+const jestConfig: JestConfigWithTsJest = {
+  preset: 'ts-jest/presets/default-esm', // or other ESM presets
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1'
+  },
+  transform: {
+    // '^.+\\.[tj]sx?$' to process ts,js,tsx,jsx with `ts-jest`
+    // '^.+\\.m?[tj]sx?$' to process ts,js,tsx,jsx,mts,mjs,mtsx,mjsx with `ts-jest`
+    '^.+\\.[tj]sx?$': [
+      'ts-jest',
+      {
+        useESM: true
+      }
+    ],
+    '^.+\\.js$': 'babel-jest'
+  },
+  testPathIgnorePatterns: ['.*dist/', '.*node_modules/']
+};
+
+export default jestConfig;

--- a/blueprint/implementations/ecommerce/paypal/package.json
+++ b/blueprint/implementations/ecommerce/paypal/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@forklaunch/implementation-ecommerce-paypal",
+  "version": "1.0.0",
+  "description": "PayPal (and Venmo) implementation for forklaunch ecommerce",
+  "homepage": "https://github.com/forklaunch/forklaunch-js#readme",
+  "bugs": {
+    "url": "https://github.com/forklaunch/forklaunch-js/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/forklaunch/forklaunch-js.git"
+  },
+  "license": "MIT",
+  "author": "Forklift Technologies, Inc.",
+  "exports": {
+    "./services": {
+      "types": "./lib/services/index.d.ts",
+      "import": "./lib/services/index.mjs",
+      "require": "./lib/services/index.js",
+      "default": "./lib/services/index.js"
+    },
+    "./types": {
+      "types": "./lib/domain/types/index.d.ts",
+      "import": "./lib/domain/types/index.mjs",
+      "require": "./lib/domain/types/index.js",
+      "default": "./lib/domain/types/index.js"
+    }
+  },
+  "files": [
+    "lib/**"
+  ],
+  "scripts": {
+    "build": "tsgo --noEmit && tsup services/index.ts domain/types/index.ts --format cjs,esm --no-splitting --tsconfig tsconfig.json --out-dir lib --clean && tsgo -p tsconfig.build.json --emitDeclarationOnly && if [ -f eject-package.bash ]; then pnpm package:eject; fi",
+    "clean": "rm -rf lib pnpm.lock.yaml node_modules",
+    "docs": "typedoc --out docs *",
+    "format": "prettier --ignore-path=.prettierignore --config .prettierrc '**/*.{ts,tsx,json}' --write",
+    "lint": "eslint . -c eslint.config.mjs",
+    "lint:fix": "eslint . -c eslint.config.mjs --fix",
+    "package:eject": "./eject-package.bash",
+    "prepack": "pnpm run build",
+    "publish:package": "./publish-package.bash",
+    "test": "vitest --passWithNoTests"
+  },
+  "dependencies": {
+    "@forklaunch/common": "^1.2.20",
+    "@forklaunch/core": "^1.5.6",
+    "@forklaunch/implementation-ecommerce-base": "workspace:^",
+    "@forklaunch/interfaces-ecommerce": "workspace:^",
+    "@forklaunch/internal": "^1.2.20",
+    "@forklaunch/validator": "^1.2.20",
+    "@mikro-orm/core": "7.1.8",
+    "@sinclair/typebox": "^0.34.52",
+    "ajv": "^8.20.0",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@typescript/native-preview": "7.0.0-dev.20260707.2",
+    "depcheck": "^1.4.7",
+    "prettier": "^3.9.6",
+    "typedoc": "^0.28.20"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/blueprint/implementations/ecommerce/paypal/package.json
+++ b/blueprint/implementations/ecommerce/paypal/package.json
@@ -42,13 +42,13 @@
     "test": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@forklaunch/common": "^1.2.20",
-    "@forklaunch/core": "^1.5.6",
+    "@forklaunch/common": "^1.2.23",
+    "@forklaunch/core": "^1.5.15",
     "@forklaunch/implementation-ecommerce-base": "workspace:^",
     "@forklaunch/interfaces-ecommerce": "workspace:^",
-    "@forklaunch/internal": "^1.2.20",
-    "@forklaunch/validator": "^1.2.20",
-    "@mikro-orm/core": "7.1.8",
+    "@forklaunch/internal": "^1.2.24",
+    "@forklaunch/validator": "^1.2.24",
+    "@mikro-orm/core": "^7.1.11",
     "@sinclair/typebox": "^0.34.52",
     "ajv": "^8.20.0",
     "zod": "^4.4.3"

--- a/blueprint/implementations/ecommerce/paypal/publish-package.bash
+++ b/blueprint/implementations/ecommerce/paypal/publish-package.bash
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Automatically fetch the package name from package.json
+PACKAGE_NAME=$(node -p "require('./package.json').name")
+
+# Check current version of the package
+CURRENT_VERSION=$(node -p "require('./package.json').version")
+LAST_PUBLISHED_VERSION=$(npm show "$PACKAGE_NAME" version)
+
+# Check if the version has changed
+if [ "$CURRENT_VERSION" != "$LAST_PUBLISHED_VERSION" ]; then
+  echo "Publishing new version of $PACKAGE_NAME..."
+  pnpm publish "$@"
+else
+  echo "Version has not changed for $PACKAGE_NAME, skipping publish."
+fi
+
+

--- a/blueprint/implementations/ecommerce/paypal/services/index.ts
+++ b/blueprint/implementations/ecommerce/paypal/services/index.ts
@@ -1,0 +1,2 @@
+export * from './paypal-client';
+export * from './payment.service';

--- a/blueprint/implementations/ecommerce/paypal/services/payment.service.ts
+++ b/blueprint/implementations/ecommerce/paypal/services/payment.service.ts
@@ -1,0 +1,104 @@
+import {
+  MetricsDefinition,
+  OpenTelemetryCollector,
+  TelemetryOptions
+} from '@forklaunch/core/http';
+import { BasePaymentService } from '@forklaunch/implementation-ecommerce-base/services';
+import {
+  BasePaymentDtos,
+  BasePaymentEntities
+} from '@forklaunch/implementation-ecommerce-base/types';
+import { PaymentService } from '@forklaunch/interfaces-ecommerce/interfaces';
+import {
+  ConfirmPaymentDto,
+  CreatePaymentDto,
+  FailPaymentDto
+} from '@forklaunch/interfaces-ecommerce/types';
+import { AnySchemaValidator } from '@forklaunch/validator';
+import { EntityManager } from '@mikro-orm/core';
+import { PaypalClient } from './paypal-client';
+import { PaypalPaymentMappers } from '../domain/types/payment.mapper.types';
+
+/**
+ * Wraps BasePaymentService with real PayPal Orders API calls — same base/
+ * provider split as the Stripe implementation. PayPal is the one separate
+ * provider build (Venmo rides on it for free). The base does DB persistence;
+ * this class calls PayPal and delegates persistence back to base.
+ */
+export class PaypalPaymentService<
+  SchemaValidator extends AnySchemaValidator,
+  Entities extends BasePaymentEntities,
+  Dto extends BasePaymentDtos = BasePaymentDtos
+> implements PaymentService
+{
+  basePaymentService: BasePaymentService<SchemaValidator, Entities, Dto>;
+  protected readonly paypalClient: PaypalClient;
+  protected readonly em: EntityManager;
+
+  constructor(
+    paypalClient: PaypalClient,
+    em: EntityManager,
+    openTelemetryCollector: OpenTelemetryCollector<MetricsDefinition>,
+    schemaValidator: SchemaValidator,
+    mappers: PaypalPaymentMappers<Entities, Dto>,
+    options?: {
+      telemetry?: TelemetryOptions;
+    }
+  ) {
+    this.paypalClient = paypalClient;
+    this.em = em;
+    this.basePaymentService = new BasePaymentService(
+      em,
+      openTelemetryCollector,
+      schemaValidator,
+      mappers as unknown as ConstructorParameters<
+        typeof BasePaymentService<SchemaValidator, Entities, Dto>
+      >[3],
+      options
+    );
+  }
+
+  /** Creates the PayPal order, then persists the pending record with its id as providerRef. */
+  async createPayment(
+    paymentDto: CreatePaymentDto,
+    em?: EntityManager
+  ): Promise<Dto['PaymentMapper']> {
+    const paypalOrder = await this.paypalClient.createOrder({
+      amountCents: paymentDto.amountCents,
+      currency: paymentDto.currency,
+      referenceId: paymentDto.orderId
+    });
+    return this.basePaymentService.createPayment(
+      paymentDto,
+      em ?? this.em,
+      paypalOrder
+    );
+  }
+
+  async getPayment(
+    idDto: { id: string },
+    em?: EntityManager
+  ): Promise<Dto['PaymentMapper']> {
+    return this.basePaymentService.getPayment(idDto, em);
+  }
+
+  /**
+   * Captures the PayPal order, then marks the payment succeeded. Driven by the
+   * PayPal webhook (verified at the controller layer). Idempotent — PayPal's
+   * capture is safe to re-invoke, and base confirm is a no-op once succeeded.
+   */
+  async confirmPayment(
+    confirmDto: ConfirmPaymentDto,
+    em?: EntityManager
+  ): Promise<Dto['PaymentMapper']> {
+    await this.paypalClient.captureOrder(confirmDto.providerRef);
+    return this.basePaymentService.confirmPayment(confirmDto, em);
+  }
+
+  async failPayment(
+    failDto: FailPaymentDto,
+    em?: EntityManager
+  ): Promise<Dto['PaymentMapper']> {
+    return this.basePaymentService.failPayment(failDto, em);
+  }
+}

--- a/blueprint/implementations/ecommerce/paypal/services/paypal-client.ts
+++ b/blueprint/implementations/ecommerce/paypal/services/paypal-client.ts
@@ -1,0 +1,100 @@
+/**
+ * Minimal PayPal Orders v2 REST client — deliberately no PayPal SDK dependency.
+ * A thin fetch wrapper is enough for the v1 payment seam (create + capture),
+ * keeps the dependency surface clean, and avoids pulling an SDK the rest of the
+ * monorepo doesn't use. Venmo needs no extra code: it rides on PayPal orders as
+ * a funding source (US, mobile) exposed automatically at the PayPal checkout.
+ */
+export interface PaypalOrder {
+  id: string;
+  status: string;
+}
+
+export interface PaypalClientOptions {
+  clientId: string;
+  clientSecret: string;
+  /** e.g. https://api-m.sandbox.paypal.com or https://api-m.paypal.com */
+  baseUrl: string;
+}
+
+export class PaypalClient {
+  private readonly clientId: string;
+  private readonly clientSecret: string;
+  private readonly baseUrl: string;
+
+  constructor(options: PaypalClientOptions) {
+    this.clientId = options.clientId;
+    this.clientSecret = options.clientSecret;
+    this.baseUrl = options.baseUrl.replace(/\/$/, '');
+  }
+
+  private async getAccessToken(): Promise<string> {
+    const credentials = Buffer.from(
+      `${this.clientId}:${this.clientSecret}`
+    ).toString('base64');
+    const res = await fetch(`${this.baseUrl}/v1/oauth2/token`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Basic ${credentials}`,
+        'Content-Type': 'application/x-www-form-urlencoded'
+      },
+      body: 'grant_type=client_credentials'
+    });
+    if (!res.ok) {
+      throw new Error(`PayPal auth failed (status ${res.status})`);
+    }
+    const body = (await res.json()) as { access_token: string };
+    return body.access_token;
+  }
+
+  /** Creates a PayPal order (money in major units + ISO currency). */
+  async createOrder(params: {
+    amountCents: number;
+    currency: string;
+    referenceId: string;
+  }): Promise<PaypalOrder> {
+    const accessToken = await this.getAccessToken();
+    const res = await fetch(`${this.baseUrl}/v2/checkout/orders`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        intent: 'CAPTURE',
+        purchase_units: [
+          {
+            reference_id: params.referenceId,
+            amount: {
+              currency_code: params.currency.toUpperCase(),
+              value: (params.amountCents / 100).toFixed(2)
+            }
+          }
+        ]
+      })
+    });
+    if (!res.ok) {
+      throw new Error(`PayPal create order failed (status ${res.status})`);
+    }
+    return (await res.json()) as PaypalOrder;
+  }
+
+  /** Captures a previously-approved order (idempotent on PayPal's side by order id). */
+  async captureOrder(orderId: string): Promise<PaypalOrder> {
+    const accessToken = await this.getAccessToken();
+    const res = await fetch(
+      `${this.baseUrl}/v2/checkout/orders/${orderId}/capture`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'application/json'
+        }
+      }
+    );
+    if (!res.ok) {
+      throw new Error(`PayPal capture failed (status ${res.status})`);
+    }
+    return (await res.json()) as PaypalOrder;
+  }
+}

--- a/blueprint/implementations/ecommerce/paypal/tsconfig.build.json
+++ b/blueprint/implementations/ecommerce/paypal/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": [
+    "services/index.ts",
+    "domain/types/index.ts"
+  ]
+}

--- a/blueprint/implementations/ecommerce/paypal/tsconfig.json
+++ b/blueprint/implementations/ecommerce/paypal/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "lib"
+  },
+  "include": ["domain/**/*", "services/**/*", "types/**/*", "*.ts"],
+  "exclude": ["node_modules", "lib", "eslint.config.mjs"]
+}

--- a/blueprint/implementations/ecommerce/paypal/vitest.config.ts
+++ b/blueprint/implementations/ecommerce/paypal/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    exclude: ['**/lib/**', '**/dist/**', '**/node_modules/**'],
+    setupFiles: ['__test__/test-utils.ts']
+  }
+});

--- a/blueprint/implementations/ecommerce/stripe/.gitignore
+++ b/blueprint/implementations/ecommerce/stripe/.gitignore
@@ -1,0 +1,14 @@
+node_modules
+.idea
+.DS_Store
+
+lib
+
+.vscode
+
+*dist
+*lib
+
+temp
+
+.env.local

--- a/blueprint/implementations/ecommerce/stripe/.prettierignore
+++ b/blueprint/implementations/ecommerce/stripe/.prettierignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+lib/

--- a/blueprint/implementations/ecommerce/stripe/.prettierrc
+++ b/blueprint/implementations/ecommerce/stripe/.prettierrc
@@ -1,0 +1,7 @@
+{
+    "semi": true,
+    "trailingComma": "none",
+    "singleQuote": true,
+    "printWidth": 80,
+    "tabWidth": 2
+}

--- a/blueprint/implementations/ecommerce/stripe/domain/types/index.ts
+++ b/blueprint/implementations/ecommerce/stripe/domain/types/index.ts
@@ -1,0 +1,1 @@
+export * from './payment.mapper.types';

--- a/blueprint/implementations/ecommerce/stripe/domain/types/payment.mapper.types.ts
+++ b/blueprint/implementations/ecommerce/stripe/domain/types/payment.mapper.types.ts
@@ -1,0 +1,30 @@
+import { BasePaymentDtos, BasePaymentEntities } from '@forklaunch/implementation-ecommerce-base/types';
+import { EntityManager, InferEntity } from '@mikro-orm/core';
+import Stripe from 'stripe';
+
+/**
+ * Stripe-specific override of PaymentMappers — CreatePaymentMapper.toEntity
+ * takes the concrete Stripe.PaymentIntent (created by StripePaymentService
+ * before persistence), not the base's generic ...args: unknown[]. Same
+ * pattern as StripePlanMappers in billing overriding the generic PlanMappers.
+ */
+export type StripePaymentMappers<
+  Entities extends BasePaymentEntities,
+  Dto extends BasePaymentDtos
+> = {
+  PaymentMapper: {
+    entity: Entities['PaymentMapper'];
+    toDto: (
+      entity: InferEntity<Entities['PaymentMapper']>
+    ) => Promise<Dto['PaymentMapper']>;
+  };
+  CreatePaymentMapper: {
+    entity: Entities['CreatePaymentMapper'];
+    toEntity: (
+      dto: Dto['CreatePaymentMapper'],
+      em: EntityManager,
+      paymentIntent: Stripe.PaymentIntent,
+      ...args: unknown[]
+    ) => Promise<InferEntity<Entities['CreatePaymentMapper']>>;
+  };
+};

--- a/blueprint/implementations/ecommerce/stripe/eject-package.bash
+++ b/blueprint/implementations/ecommerce/stripe/eject-package.bash
@@ -1,0 +1,39 @@
+rm -rf lib/eject
+mkdir -p lib/eject/domain
+
+if [ -d "domain/schemas" ]; then
+  mkdir -p lib/eject/domain/schemas
+  cp -r domain/schemas/zod lib/eject/domain/schemas
+  cp domain/schemas/index.ts lib/eject/domain/schemas
+  find lib/eject/domain/schemas -type f -name "*.ts" -exec perl -i -pe "s|'\.\.\/\.\.|'\.\.|g" {} \;
+fi
+
+if [ -d "services" ]; then
+  cp -r services lib/eject/services
+fi
+
+if [ -d "domain/types" ]; then
+  cp -r domain/types lib/eject/domain/types
+fi
+
+if [ -d "domain/interfaces" ]; then
+  cp -r domain/interfaces lib/eject/domain/interfaces
+fi
+
+if [ -d "consumers" ]; then
+  cp -r consumers lib/eject/consumers
+fi
+
+if [ -d "producers" ]; then
+  cp -r producers lib/eject/producers
+fi
+
+if [ -d "domain/enum" ]; then
+  cp -r domain/enum lib/eject/domain/enum
+fi
+
+find lib/eject -type f -name '*.ts' -exec sh -c \
+  'for f do \
+    sed "s|@forklaunch/validator/zod|@{{app_name}}/core|g" "$f" > "$f.tmp" && \
+    mv "$f.tmp" "$f"; \
+  done' sh {} +

--- a/blueprint/implementations/ecommerce/stripe/eslint.config.mjs
+++ b/blueprint/implementations/ecommerce/stripe/eslint.config.mjs
@@ -1,0 +1,18 @@
+import pluginJs from '@eslint/js';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
+
+export default [
+  { files: ['**/*.{ts,tsx}'] },
+  {
+    ignores: [
+      '**/*tests/**/*',
+      '**/*dist/**/*',
+      '**/*lib/**/*',
+      '**/*node_modules/**/*'
+    ]
+  },
+  { languageOptions: { globals: globals.browser } },
+  pluginJs.configs.recommended,
+  ...tseslint.configs.recommended
+];

--- a/blueprint/implementations/ecommerce/stripe/jest.config.ts
+++ b/blueprint/implementations/ecommerce/stripe/jest.config.ts
@@ -1,0 +1,22 @@
+import type { JestConfigWithTsJest } from 'ts-jest';
+
+const jestConfig: JestConfigWithTsJest = {
+  preset: 'ts-jest/presets/default-esm', // or other ESM presets
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1'
+  },
+  transform: {
+    // '^.+\\.[tj]sx?$' to process ts,js,tsx,jsx with `ts-jest`
+    // '^.+\\.m?[tj]sx?$' to process ts,js,tsx,jsx,mts,mjs,mtsx,mjsx with `ts-jest`
+    '^.+\\.[tj]sx?$': [
+      'ts-jest',
+      {
+        useESM: true
+      }
+    ],
+    '^.+\\.js$': 'babel-jest'
+  },
+  testPathIgnorePatterns: ['.*dist/', '.*node_modules/']
+};
+
+export default jestConfig;

--- a/blueprint/implementations/ecommerce/stripe/package.json
+++ b/blueprint/implementations/ecommerce/stripe/package.json
@@ -42,13 +42,13 @@
     "test": "vitest --passWithNoTests"
   },
   "dependencies": {
-    "@forklaunch/common": "^1.2.20",
-    "@forklaunch/core": "^1.5.6",
+    "@forklaunch/common": "^1.2.23",
+    "@forklaunch/core": "^1.5.15",
     "@forklaunch/implementation-ecommerce-base": "workspace:^",
     "@forklaunch/interfaces-ecommerce": "workspace:^",
-    "@forklaunch/internal": "^1.2.20",
-    "@forklaunch/validator": "^1.2.20",
-    "@mikro-orm/core": "7.1.8",
+    "@forklaunch/internal": "^1.2.24",
+    "@forklaunch/validator": "^1.2.24",
+    "@mikro-orm/core": "^7.1.11",
     "@sinclair/typebox": "^0.34.52",
     "ajv": "^8.20.0",
     "stripe": "^22.3.2",

--- a/blueprint/implementations/ecommerce/stripe/package.json
+++ b/blueprint/implementations/ecommerce/stripe/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@forklaunch/implementation-ecommerce-stripe",
+  "version": "1.0.0",
+  "description": "Stripe implementation for forklaunch ecommerce",
+  "homepage": "https://github.com/forklaunch/forklaunch-js#readme",
+  "bugs": {
+    "url": "https://github.com/forklaunch/forklaunch-js/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/forklaunch/forklaunch-js.git"
+  },
+  "license": "MIT",
+  "author": "Forklift Technologies, Inc.",
+  "exports": {
+    "./services": {
+      "types": "./lib/services/index.d.ts",
+      "import": "./lib/services/index.mjs",
+      "require": "./lib/services/index.js",
+      "default": "./lib/services/index.js"
+    },
+    "./types": {
+      "types": "./lib/domain/types/index.d.ts",
+      "import": "./lib/domain/types/index.mjs",
+      "require": "./lib/domain/types/index.js",
+      "default": "./lib/domain/types/index.js"
+    }
+  },
+  "files": [
+    "lib/**"
+  ],
+  "scripts": {
+    "build": "tsgo --noEmit && tsup services/index.ts domain/types/index.ts --format cjs,esm --no-splitting --tsconfig tsconfig.json --out-dir lib --clean && tsgo -p tsconfig.build.json --emitDeclarationOnly && if [ -f eject-package.bash ]; then pnpm package:eject; fi",
+    "clean": "rm -rf lib pnpm.lock.yaml node_modules",
+    "docs": "typedoc --out docs *",
+    "format": "prettier --ignore-path=.prettierignore --config .prettierrc '**/*.{ts,tsx,json}' --write",
+    "lint": "eslint . -c eslint.config.mjs",
+    "lint:fix": "eslint . -c eslint.config.mjs --fix",
+    "package:eject": "./eject-package.bash",
+    "prepack": "pnpm run build",
+    "publish:package": "./publish-package.bash",
+    "test": "vitest --passWithNoTests"
+  },
+  "dependencies": {
+    "@forklaunch/common": "^1.2.20",
+    "@forklaunch/core": "^1.5.6",
+    "@forklaunch/implementation-ecommerce-base": "workspace:^",
+    "@forklaunch/interfaces-ecommerce": "workspace:^",
+    "@forklaunch/internal": "^1.2.20",
+    "@forklaunch/validator": "^1.2.20",
+    "@mikro-orm/core": "7.1.8",
+    "@sinclair/typebox": "^0.34.52",
+    "ajv": "^8.20.0",
+    "stripe": "^22.3.2",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@typescript/native-preview": "7.0.0-dev.20260707.2",
+    "depcheck": "^1.4.7",
+    "prettier": "^3.9.6",
+    "typedoc": "^0.28.20"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/blueprint/implementations/ecommerce/stripe/publish-package.bash
+++ b/blueprint/implementations/ecommerce/stripe/publish-package.bash
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Automatically fetch the package name from package.json
+PACKAGE_NAME=$(node -p "require('./package.json').name")
+
+# Check current version of the package
+CURRENT_VERSION=$(node -p "require('./package.json').version")
+LAST_PUBLISHED_VERSION=$(npm show "$PACKAGE_NAME" version)
+
+# Check if the version has changed
+if [ "$CURRENT_VERSION" != "$LAST_PUBLISHED_VERSION" ]; then
+  echo "Publishing new version of $PACKAGE_NAME..."
+  pnpm publish "$@"
+else
+  echo "Version has not changed for $PACKAGE_NAME, skipping publish."
+fi
+
+

--- a/blueprint/implementations/ecommerce/stripe/services/index.ts
+++ b/blueprint/implementations/ecommerce/stripe/services/index.ts
@@ -1,0 +1,1 @@
+export * from './payment.service';

--- a/blueprint/implementations/ecommerce/stripe/services/payment.service.ts
+++ b/blueprint/implementations/ecommerce/stripe/services/payment.service.ts
@@ -23,7 +23,7 @@ import { StripePaymentMappers } from '../domain/types/payment.mapper.types';
  * Wraps BasePaymentService with real Stripe PaymentIntent calls — the base
  * does DB persistence, this class calls the provider API and delegates
  * persistence back to base (same split as StripePlanService/BasePlanService
- * in billing). Fills the ECOM-10 payment seam: PaymentIntent drives the order
+ * in billing). Fills the payment seam: PaymentIntent drives the order
  * toward paid; confirmation is idempotent and driven by the webhook.
  */
 export class StripePaymentService<
@@ -94,7 +94,7 @@ export class StripePaymentService<
     return this.basePaymentService.confirmPayment(confirmDto, em);
   }
 
-  /** Failed payment emits the event dunning (ECOM-20) hooks into, at the deployable-app layer. */
+  /** Failed payment emits the event dunning hooks into, at the deployable-app layer. */
   async failPayment(
     failDto: FailPaymentDto,
     em?: EntityManager

--- a/blueprint/implementations/ecommerce/stripe/services/payment.service.ts
+++ b/blueprint/implementations/ecommerce/stripe/services/payment.service.ts
@@ -1,0 +1,104 @@
+import {
+  MetricsDefinition,
+  OpenTelemetryCollector,
+  TelemetryOptions
+} from '@forklaunch/core/http';
+import { BasePaymentService } from '@forklaunch/implementation-ecommerce-base/services';
+import {
+  BasePaymentDtos,
+  BasePaymentEntities
+} from '@forklaunch/implementation-ecommerce-base/types';
+import { PaymentService } from '@forklaunch/interfaces-ecommerce/interfaces';
+import {
+  ConfirmPaymentDto,
+  CreatePaymentDto,
+  FailPaymentDto
+} from '@forklaunch/interfaces-ecommerce/types';
+import { AnySchemaValidator } from '@forklaunch/validator';
+import { EntityManager } from '@mikro-orm/core';
+import Stripe from 'stripe';
+import { StripePaymentMappers } from '../domain/types/payment.mapper.types';
+
+/**
+ * Wraps BasePaymentService with real Stripe PaymentIntent calls — the base
+ * does DB persistence, this class calls the provider API and delegates
+ * persistence back to base (same split as StripePlanService/BasePlanService
+ * in billing). Fills the ECOM-10 payment seam: PaymentIntent drives the order
+ * toward paid; confirmation is idempotent and driven by the webhook.
+ */
+export class StripePaymentService<
+  SchemaValidator extends AnySchemaValidator,
+  Entities extends BasePaymentEntities,
+  Dto extends BasePaymentDtos = BasePaymentDtos
+> implements PaymentService
+{
+  basePaymentService: BasePaymentService<SchemaValidator, Entities, Dto>;
+  protected readonly stripeClient: Stripe;
+  protected readonly em: EntityManager;
+
+  constructor(
+    stripeClient: Stripe,
+    em: EntityManager,
+    openTelemetryCollector: OpenTelemetryCollector<MetricsDefinition>,
+    schemaValidator: SchemaValidator,
+    mappers: StripePaymentMappers<Entities, Dto>,
+    options?: {
+      telemetry?: TelemetryOptions;
+    }
+  ) {
+    this.stripeClient = stripeClient;
+    this.em = em;
+    // CreatePaymentMapper.toEntity's 3rd param is concretely Stripe.PaymentIntent
+    // here (narrower than base's generic ...args: unknown[]) — safe at runtime,
+    // this cast just satisfies the base constructor's looser declared type.
+    this.basePaymentService = new BasePaymentService(
+      em,
+      openTelemetryCollector,
+      schemaValidator,
+      mappers as unknown as ConstructorParameters<
+        typeof BasePaymentService<SchemaValidator, Entities, Dto>
+      >[3],
+      options
+    );
+  }
+
+  /** Creates the Stripe PaymentIntent, then persists the pending record with its id as providerRef. */
+  async createPayment(
+    paymentDto: CreatePaymentDto,
+    em?: EntityManager
+  ): Promise<Dto['PaymentMapper']> {
+    const paymentIntent = await this.stripeClient.paymentIntents.create({
+      amount: paymentDto.amountCents,
+      currency: paymentDto.currency,
+      metadata: { orderId: paymentDto.orderId }
+    });
+    return this.basePaymentService.createPayment(
+      paymentDto,
+      em ?? this.em,
+      paymentIntent
+    );
+  }
+
+  async getPayment(
+    idDto: { id: string },
+    em?: EntityManager
+  ): Promise<Dto['PaymentMapper']> {
+    return this.basePaymentService.getPayment(idDto, em);
+  }
+
+  /** Driven by the Stripe webhook (signature-verified at the controller layer) — idempotent. */
+  async confirmPayment(
+    confirmDto: ConfirmPaymentDto,
+    em?: EntityManager
+  ): Promise<Dto['PaymentMapper']> {
+    return this.basePaymentService.confirmPayment(confirmDto, em);
+  }
+
+  /** Failed payment emits the event dunning (ECOM-20) hooks into, at the deployable-app layer. */
+  async failPayment(
+    failDto: FailPaymentDto,
+    em?: EntityManager
+  ): Promise<Dto['PaymentMapper']> {
+    return this.basePaymentService.failPayment(failDto, em);
+  }
+}

--- a/blueprint/implementations/ecommerce/stripe/tsconfig.build.json
+++ b/blueprint/implementations/ecommerce/stripe/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": [
+    "services/index.ts",
+    "domain/types/index.ts"
+  ]
+}

--- a/blueprint/implementations/ecommerce/stripe/tsconfig.json
+++ b/blueprint/implementations/ecommerce/stripe/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "lib"
+  },
+  "include": ["domain/**/*", "services/**/*", "types/**/*", "*.ts"],
+  "exclude": ["node_modules", "lib", "eslint.config.mjs"]
+}

--- a/blueprint/implementations/ecommerce/stripe/vitest.config.ts
+++ b/blueprint/implementations/ecommerce/stripe/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    exclude: ['**/lib/**', '**/dist/**', '**/node_modules/**'],
+    setupFiles: ['__test__/test-utils.ts']
+  }
+});

--- a/blueprint/pnpm-lock.yaml
+++ b/blueprint/pnpm-lock.yaml
@@ -865,7 +865,7 @@ importers:
   implementations/ecommerce/paypal:
     dependencies:
       '@forklaunch/common':
-        specifier: ^1.2.20
+        specifier: ^1.2.23
         version: 1.2.23
       '@forklaunch/core':
         specifier: ^1.5.15
@@ -877,14 +877,14 @@ importers:
         specifier: workspace:^
         version: link:../../../interfaces/ecommerce
       '@forklaunch/internal':
-        specifier: ^1.2.20
+        specifier: ^1.2.24
         version: 1.2.24
       '@forklaunch/validator':
-        specifier: ^1.2.20
+        specifier: ^1.2.24
         version: 1.2.24
       '@mikro-orm/core':
-        specifier: 7.1.8
-        version: 7.1.8
+        specifier: ^7.1.11
+        version: 7.1.11
       '@sinclair/typebox':
         specifier: ^0.34.52
         version: 0.34.52
@@ -911,7 +911,7 @@ importers:
   implementations/ecommerce/stripe:
     dependencies:
       '@forklaunch/common':
-        specifier: ^1.2.20
+        specifier: ^1.2.23
         version: 1.2.23
       '@forklaunch/core':
         specifier: ^1.5.15
@@ -923,14 +923,14 @@ importers:
         specifier: workspace:^
         version: link:../../../interfaces/ecommerce
       '@forklaunch/internal':
-        specifier: ^1.2.20
+        specifier: ^1.2.24
         version: 1.2.24
       '@forklaunch/validator':
-        specifier: ^1.2.20
+        specifier: ^1.2.24
         version: 1.2.24
       '@mikro-orm/core':
-        specifier: 7.1.8
-        version: 7.1.8
+        specifier: ^7.1.11
+        version: 7.1.11
       '@sinclair/typebox':
         specifier: ^0.34.52
         version: 0.34.52
@@ -2933,15 +2933,6 @@ packages:
 
   '@mikro-orm/core@7.1.11':
     resolution: {integrity: sha512-LjxeVx7PYIVqFW4WDwjOYSHa7RygEGK1RJhjUC5ldY1xbvhOgntwrKJSxfJjBxGx6G3CL55jX6xT2HjU1WdyaQ==}
-    engines: {node: '>= 22.17.0'}
-    peerDependencies:
-      dataloader: 2.2.3
-    peerDependenciesMeta:
-      dataloader:
-        optional: true
-
-  '@mikro-orm/core@7.1.8':
-    resolution: {integrity: sha512-hX/869Heo+EEzLEnJsL/c17T4N0qJEn9E6ZQv58nRaV2yIKZGa9FJFnqRXgo5H8wv1ktieQLXcfARs1pcXZofw==}
     engines: {node: '>= 22.17.0'}
     peerDependencies:
       dataloader: 2.2.3
@@ -9869,8 +9860,6 @@ snapshots:
       - dataloader
 
   '@mikro-orm/core@7.1.11': {}
-
-  '@mikro-orm/core@7.1.8': {}
 
   '@mikro-orm/libsql@7.1.11(@mikro-orm/core@7.1.11)':
     dependencies:

--- a/blueprint/pnpm-lock.yaml
+++ b/blueprint/pnpm-lock.yaml
@@ -402,6 +402,12 @@ importers:
       '@forklaunch/implementation-ecommerce-base':
         specifier: workspace:^
         version: link:../implementations/ecommerce/base
+      '@forklaunch/implementation-ecommerce-paypal':
+        specifier: workspace:*
+        version: link:../implementations/ecommerce/paypal
+      '@forklaunch/implementation-ecommerce-stripe':
+        specifier: workspace:*
+        version: link:../implementations/ecommerce/stripe
       '@forklaunch/implementation-worker-redis':
         specifier: workspace:^
         version: link:../implementations/worker/redis
@@ -856,6 +862,99 @@ importers:
         specifier: ^0.28.20
         version: 0.28.20(@typescript/typescript6@6.0.2)
 
+  implementations/ecommerce/paypal:
+    dependencies:
+      '@forklaunch/common':
+        specifier: ^1.2.20
+        version: 1.2.20
+      '@forklaunch/core':
+        specifier: ^1.5.6
+        version: 1.5.6(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
+      '@forklaunch/implementation-ecommerce-base':
+        specifier: workspace:^
+        version: link:../base
+      '@forklaunch/interfaces-ecommerce':
+        specifier: workspace:^
+        version: link:../../../interfaces/ecommerce
+      '@forklaunch/internal':
+        specifier: ^1.2.20
+        version: 1.2.20
+      '@forklaunch/validator':
+        specifier: ^1.2.20
+        version: 1.2.20
+      '@mikro-orm/core':
+        specifier: 7.1.8
+        version: 7.1.8
+      '@sinclair/typebox':
+        specifier: ^0.34.52
+        version: 0.34.52
+      ajv:
+        specifier: ^8.20.0
+        version: 8.20.0
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260707.2
+        version: 7.0.0-dev.20260707.2
+      depcheck:
+        specifier: ^1.4.7
+        version: 1.4.7
+      prettier:
+        specifier: ^3.9.6
+        version: 3.9.6
+      typedoc:
+        specifier: ^0.28.20
+        version: 0.28.20(typescript@6.0.3)
+  implementations/ecommerce/stripe:
+    dependencies:
+      '@forklaunch/common':
+        specifier: ^1.2.20
+        version: 1.2.20
+      '@forklaunch/core':
+        specifier: ^1.5.6
+        version: 1.5.6(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
+      '@forklaunch/implementation-ecommerce-base':
+        specifier: workspace:^
+        version: link:../base
+      '@forklaunch/interfaces-ecommerce':
+        specifier: workspace:^
+        version: link:../../../interfaces/ecommerce
+      '@forklaunch/internal':
+        specifier: ^1.2.20
+        version: 1.2.20
+      '@forklaunch/validator':
+        specifier: ^1.2.20
+        version: 1.2.20
+      '@mikro-orm/core':
+        specifier: 7.1.8
+        version: 7.1.8
+      '@sinclair/typebox':
+        specifier: ^0.34.52
+        version: 0.34.52
+      ajv:
+        specifier: ^8.20.0
+        version: 8.20.0
+      stripe:
+        specifier: ^22.3.2
+        version: 22.3.2(@types/node@26.1.2)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260707.2
+        version: 7.0.0-dev.20260707.2
+      depcheck:
+        specifier: ^1.4.7
+        version: 1.4.7
+      prettier:
+        specifier: ^3.9.6
+        version: 3.9.6
+      typedoc:
+        specifier: ^0.28.20
+        version: 0.28.20(typescript@6.0.3)
   implementations/iam/base:
     dependencies:
       '@forklaunch/common':

--- a/blueprint/pnpm-lock.yaml
+++ b/blueprint/pnpm-lock.yaml
@@ -403,10 +403,10 @@ importers:
         specifier: workspace:^
         version: link:../implementations/ecommerce/base
       '@forklaunch/implementation-ecommerce-paypal':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../implementations/ecommerce/paypal
       '@forklaunch/implementation-ecommerce-stripe':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../implementations/ecommerce/stripe
       '@forklaunch/implementation-worker-redis':
         specifier: workspace:^
@@ -866,10 +866,10 @@ importers:
     dependencies:
       '@forklaunch/common':
         specifier: ^1.2.20
-        version: 1.2.20
+        version: 1.2.23
       '@forklaunch/core':
-        specifier: ^1.5.6
-        version: 1.5.6(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
+        specifier: ^1.5.15
+        version: 1.5.15(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
       '@forklaunch/implementation-ecommerce-base':
         specifier: workspace:^
         version: link:../base
@@ -878,10 +878,10 @@ importers:
         version: link:../../../interfaces/ecommerce
       '@forklaunch/internal':
         specifier: ^1.2.20
-        version: 1.2.20
+        version: 1.2.24
       '@forklaunch/validator':
         specifier: ^1.2.20
-        version: 1.2.20
+        version: 1.2.24
       '@mikro-orm/core':
         specifier: 7.1.8
         version: 7.1.8
@@ -906,15 +906,16 @@ importers:
         version: 3.9.6
       typedoc:
         specifier: ^0.28.20
-        version: 0.28.20(typescript@6.0.3)
+        version: 0.28.20(@typescript/typescript6@6.0.2)
+
   implementations/ecommerce/stripe:
     dependencies:
       '@forklaunch/common':
         specifier: ^1.2.20
-        version: 1.2.20
+        version: 1.2.23
       '@forklaunch/core':
-        specifier: ^1.5.6
-        version: 1.5.6(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
+        specifier: ^1.5.15
+        version: 1.5.15(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
       '@forklaunch/implementation-ecommerce-base':
         specifier: workspace:^
         version: link:../base
@@ -923,10 +924,10 @@ importers:
         version: link:../../../interfaces/ecommerce
       '@forklaunch/internal':
         specifier: ^1.2.20
-        version: 1.2.20
+        version: 1.2.24
       '@forklaunch/validator':
         specifier: ^1.2.20
-        version: 1.2.20
+        version: 1.2.24
       '@mikro-orm/core':
         specifier: 7.1.8
         version: 7.1.8
@@ -938,7 +939,7 @@ importers:
         version: 8.20.0
       stripe:
         specifier: ^22.3.2
-        version: 22.3.2(@types/node@26.1.2)
+        version: 22.4.0(@types/node@26.2.0)
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -954,7 +955,8 @@ importers:
         version: 3.9.6
       typedoc:
         specifier: ^0.28.20
-        version: 0.28.20(typescript@6.0.3)
+        version: 0.28.20(@typescript/typescript6@6.0.2)
+
   implementations/iam/base:
     dependencies:
       '@forklaunch/common':
@@ -2579,6 +2581,15 @@ packages:
 
   '@mikro-orm/core@7.1.11':
     resolution: {integrity: sha512-LjxeVx7PYIVqFW4WDwjOYSHa7RygEGK1RJhjUC5ldY1xbvhOgntwrKJSxfJjBxGx6G3CL55jX6xT2HjU1WdyaQ==}
+    engines: {node: '>= 22.17.0'}
+    peerDependencies:
+      dataloader: 2.2.3
+    peerDependenciesMeta:
+      dataloader:
+        optional: true
+
+  '@mikro-orm/core@7.1.8':
+    resolution: {integrity: sha512-hX/869Heo+EEzLEnJsL/c17T4N0qJEn9E6ZQv58nRaV2yIKZGa9FJFnqRXgo5H8wv1ktieQLXcfARs1pcXZofw==}
     engines: {node: '>= 22.17.0'}
     peerDependencies:
       dataloader: 2.2.3
@@ -9544,6 +9555,8 @@ snapshots:
       - dataloader
 
   '@mikro-orm/core@7.1.11': {}
+
+  '@mikro-orm/core@7.1.8': {}
 
   '@mikro-orm/libsql@7.1.11(@mikro-orm/core@7.1.11)':
     dependencies:

--- a/blueprint/pnpm-lock.yaml
+++ b/blueprint/pnpm-lock.yaml
@@ -906,7 +906,7 @@ importers:
         version: 3.9.6
       typedoc:
         specifier: ^0.28.20
-        version: 0.28.20(@typescript/typescript6@6.0.2)
+        version: 0.28.20(typescript@6.0.3)
 
   implementations/ecommerce/stripe:
     dependencies:
@@ -955,7 +955,7 @@ importers:
         version: 3.9.6
       typedoc:
         specifier: ^0.28.20
-        version: 0.28.20(@typescript/typescript6@6.0.2)
+        version: 0.28.20(typescript@6.0.3)
 
   implementations/iam/base:
     dependencies:

--- a/blueprint/pnpm-lock.yaml
+++ b/blueprint/pnpm-lock.yaml
@@ -403,10 +403,10 @@ importers:
         specifier: workspace:^
         version: link:../implementations/ecommerce/base
       '@forklaunch/implementation-ecommerce-paypal':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../implementations/ecommerce/paypal
       '@forklaunch/implementation-ecommerce-stripe':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../implementations/ecommerce/stripe
       '@forklaunch/implementation-worker-redis':
         specifier: workspace:^
@@ -866,10 +866,10 @@ importers:
     dependencies:
       '@forklaunch/common':
         specifier: ^1.2.20
-        version: 1.2.20
+        version: 1.2.23
       '@forklaunch/core':
-        specifier: ^1.5.6
-        version: 1.5.6(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
+        specifier: ^1.5.15
+        version: 1.5.15(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
       '@forklaunch/implementation-ecommerce-base':
         specifier: workspace:^
         version: link:../base
@@ -878,10 +878,10 @@ importers:
         version: link:../../../interfaces/ecommerce
       '@forklaunch/internal':
         specifier: ^1.2.20
-        version: 1.2.20
+        version: 1.2.24
       '@forklaunch/validator':
         specifier: ^1.2.20
-        version: 1.2.20
+        version: 1.2.24
       '@mikro-orm/core':
         specifier: 7.1.8
         version: 7.1.8
@@ -906,15 +906,16 @@ importers:
         version: 3.9.6
       typedoc:
         specifier: ^0.28.20
-        version: 0.28.20(typescript@6.0.3)
+        version: 0.28.20(@typescript/typescript6@6.0.2)
+
   implementations/ecommerce/stripe:
     dependencies:
       '@forklaunch/common':
         specifier: ^1.2.20
-        version: 1.2.20
+        version: 1.2.23
       '@forklaunch/core':
-        specifier: ^1.5.6
-        version: 1.5.6(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
+        specifier: ^1.5.15
+        version: 1.5.15(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
       '@forklaunch/implementation-ecommerce-base':
         specifier: workspace:^
         version: link:../base
@@ -923,10 +924,10 @@ importers:
         version: link:../../../interfaces/ecommerce
       '@forklaunch/internal':
         specifier: ^1.2.20
-        version: 1.2.20
+        version: 1.2.24
       '@forklaunch/validator':
         specifier: ^1.2.20
-        version: 1.2.20
+        version: 1.2.24
       '@mikro-orm/core':
         specifier: 7.1.8
         version: 7.1.8
@@ -938,7 +939,7 @@ importers:
         version: 8.20.0
       stripe:
         specifier: ^22.3.2
-        version: 22.3.2(@types/node@26.1.2)
+        version: 22.4.0(@types/node@26.2.0)
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -954,7 +955,8 @@ importers:
         version: 3.9.6
       typedoc:
         specifier: ^0.28.20
-        version: 0.28.20(typescript@6.0.3)
+        version: 0.28.20(@typescript/typescript6@6.0.2)
+
   implementations/iam/base:
     dependencies:
       '@forklaunch/common':
@@ -2931,6 +2933,15 @@ packages:
 
   '@mikro-orm/core@7.1.11':
     resolution: {integrity: sha512-LjxeVx7PYIVqFW4WDwjOYSHa7RygEGK1RJhjUC5ldY1xbvhOgntwrKJSxfJjBxGx6G3CL55jX6xT2HjU1WdyaQ==}
+    engines: {node: '>= 22.17.0'}
+    peerDependencies:
+      dataloader: 2.2.3
+    peerDependenciesMeta:
+      dataloader:
+        optional: true
+
+  '@mikro-orm/core@7.1.8':
+    resolution: {integrity: sha512-hX/869Heo+EEzLEnJsL/c17T4N0qJEn9E6ZQv58nRaV2yIKZGa9FJFnqRXgo5H8wv1ktieQLXcfARs1pcXZofw==}
     engines: {node: '>= 22.17.0'}
     peerDependencies:
       dataloader: 2.2.3
@@ -9858,6 +9869,8 @@ snapshots:
       - dataloader
 
   '@mikro-orm/core@7.1.11': {}
+
+  '@mikro-orm/core@7.1.8': {}
 
   '@mikro-orm/libsql@7.1.11(@mikro-orm/core@7.1.11)':
     dependencies:

--- a/blueprint/pnpm-lock.yaml
+++ b/blueprint/pnpm-lock.yaml
@@ -865,7 +865,7 @@ importers:
   implementations/ecommerce/paypal:
     dependencies:
       '@forklaunch/common':
-        specifier: ^1.2.20
+        specifier: ^1.2.23
         version: 1.2.23
       '@forklaunch/core':
         specifier: ^1.5.15
@@ -877,14 +877,14 @@ importers:
         specifier: workspace:^
         version: link:../../../interfaces/ecommerce
       '@forklaunch/internal':
-        specifier: ^1.2.20
+        specifier: ^1.2.24
         version: 1.2.24
       '@forklaunch/validator':
-        specifier: ^1.2.20
+        specifier: ^1.2.24
         version: 1.2.24
       '@mikro-orm/core':
-        specifier: 7.1.8
-        version: 7.1.8
+        specifier: ^7.1.11
+        version: 7.1.11
       '@sinclair/typebox':
         specifier: ^0.34.52
         version: 0.34.52
@@ -911,7 +911,7 @@ importers:
   implementations/ecommerce/stripe:
     dependencies:
       '@forklaunch/common':
-        specifier: ^1.2.20
+        specifier: ^1.2.23
         version: 1.2.23
       '@forklaunch/core':
         specifier: ^1.5.15
@@ -923,14 +923,14 @@ importers:
         specifier: workspace:^
         version: link:../../../interfaces/ecommerce
       '@forklaunch/internal':
-        specifier: ^1.2.20
+        specifier: ^1.2.24
         version: 1.2.24
       '@forklaunch/validator':
-        specifier: ^1.2.20
+        specifier: ^1.2.24
         version: 1.2.24
       '@mikro-orm/core':
-        specifier: 7.1.8
-        version: 7.1.8
+        specifier: ^7.1.11
+        version: 7.1.11
       '@sinclair/typebox':
         specifier: ^0.34.52
         version: 0.34.52
@@ -2581,15 +2581,6 @@ packages:
 
   '@mikro-orm/core@7.1.11':
     resolution: {integrity: sha512-LjxeVx7PYIVqFW4WDwjOYSHa7RygEGK1RJhjUC5ldY1xbvhOgntwrKJSxfJjBxGx6G3CL55jX6xT2HjU1WdyaQ==}
-    engines: {node: '>= 22.17.0'}
-    peerDependencies:
-      dataloader: 2.2.3
-    peerDependenciesMeta:
-      dataloader:
-        optional: true
-
-  '@mikro-orm/core@7.1.8':
-    resolution: {integrity: sha512-hX/869Heo+EEzLEnJsL/c17T4N0qJEn9E6ZQv58nRaV2yIKZGa9FJFnqRXgo5H8wv1ktieQLXcfARs1pcXZofw==}
     engines: {node: '>= 22.17.0'}
     peerDependencies:
       dataloader: 2.2.3
@@ -9555,8 +9546,6 @@ snapshots:
       - dataloader
 
   '@mikro-orm/core@7.1.11': {}
-
-  '@mikro-orm/core@7.1.8': {}
 
   '@mikro-orm/libsql@7.1.11(@mikro-orm/core@7.1.11)':
     dependencies:

--- a/blueprint/pnpm-lock.yaml
+++ b/blueprint/pnpm-lock.yaml
@@ -402,6 +402,12 @@ importers:
       '@forklaunch/implementation-ecommerce-base':
         specifier: workspace:^
         version: link:../implementations/ecommerce/base
+      '@forklaunch/implementation-ecommerce-paypal':
+        specifier: workspace:*
+        version: link:../implementations/ecommerce/paypal
+      '@forklaunch/implementation-ecommerce-stripe':
+        specifier: workspace:*
+        version: link:../implementations/ecommerce/stripe
       '@forklaunch/implementation-worker-redis':
         specifier: workspace:^
         version: link:../implementations/worker/redis
@@ -856,6 +862,99 @@ importers:
         specifier: ^0.28.20
         version: 0.28.20(typescript@6.0.3)
 
+  implementations/ecommerce/paypal:
+    dependencies:
+      '@forklaunch/common':
+        specifier: ^1.2.20
+        version: 1.2.20
+      '@forklaunch/core':
+        specifier: ^1.5.6
+        version: 1.5.6(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
+      '@forklaunch/implementation-ecommerce-base':
+        specifier: workspace:^
+        version: link:../base
+      '@forklaunch/interfaces-ecommerce':
+        specifier: workspace:^
+        version: link:../../../interfaces/ecommerce
+      '@forklaunch/internal':
+        specifier: ^1.2.20
+        version: 1.2.20
+      '@forklaunch/validator':
+        specifier: ^1.2.20
+        version: 1.2.20
+      '@mikro-orm/core':
+        specifier: 7.1.8
+        version: 7.1.8
+      '@sinclair/typebox':
+        specifier: ^0.34.52
+        version: 0.34.52
+      ajv:
+        specifier: ^8.20.0
+        version: 8.20.0
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260707.2
+        version: 7.0.0-dev.20260707.2
+      depcheck:
+        specifier: ^1.4.7
+        version: 1.4.7
+      prettier:
+        specifier: ^3.9.6
+        version: 3.9.6
+      typedoc:
+        specifier: ^0.28.20
+        version: 0.28.20(typescript@6.0.3)
+  implementations/ecommerce/stripe:
+    dependencies:
+      '@forklaunch/common':
+        specifier: ^1.2.20
+        version: 1.2.20
+      '@forklaunch/core':
+        specifier: ^1.5.6
+        version: 1.5.6(ajv-formats@3.0.1(ajv@8.20.0))(ajv@8.20.0)
+      '@forklaunch/implementation-ecommerce-base':
+        specifier: workspace:^
+        version: link:../base
+      '@forklaunch/interfaces-ecommerce':
+        specifier: workspace:^
+        version: link:../../../interfaces/ecommerce
+      '@forklaunch/internal':
+        specifier: ^1.2.20
+        version: 1.2.20
+      '@forklaunch/validator':
+        specifier: ^1.2.20
+        version: 1.2.20
+      '@mikro-orm/core':
+        specifier: 7.1.8
+        version: 7.1.8
+      '@sinclair/typebox':
+        specifier: ^0.34.52
+        version: 0.34.52
+      ajv:
+        specifier: ^8.20.0
+        version: 8.20.0
+      stripe:
+        specifier: ^22.3.2
+        version: 22.3.2(@types/node@26.1.2)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260707.2
+        version: 7.0.0-dev.20260707.2
+      depcheck:
+        specifier: ^1.4.7
+        version: 1.4.7
+      prettier:
+        specifier: ^3.9.6
+        version: 3.9.6
+      typedoc:
+        specifier: ^0.28.20
+        version: 0.28.20(typescript@6.0.3)
   implementations/iam/base:
     dependencies:
       '@forklaunch/common':


### PR DESCRIPTION
The two payment provider packages. Stacks on the payment-core PR.

- `@forklaunch/implementation-ecommerce-stripe` — `StripePaymentService`, real `paymentIntents.create`.
- `@forklaunch/implementation-ecommerce-paypal` — `PaypalPaymentService` over a minimal fetch-based Orders v2 client (no PayPal SDK dependency). Venmo rides on PayPal Orders as a funding source, so no extra code.
- `registrations.ts` — swaps the placeholder `BasePaymentService` registrations for the real provider services, and adds the Stripe/PayPal clients and env config.
- `ecommerceMappers.types.ts` — adds type re-export anchors for the two provider mapper types, same TS2883 declaration-portability issue the file already documents for the base package's types.

0 typecheck errors across all five packages.