### PR TITLE
Checkout orchestration, tax/shipping services, order-event worker

### DIFF
--- a/blueprint/ecommerce-stripe/__test__/purchaseLoop.test.ts
+++ b/blueprint/ecommerce-stripe/__test__/purchaseLoop.test.ts
@@ -1,0 +1,206 @@
+import { randomUUID } from 'crypto';
+import {
+  cleanupTestDatabase,
+  setupTestDatabase,
+  signTestRequest
+} from './test-utils';
+
+/** Narrows a `{ code, response }` SDK result to its 200 branch, or fails the test with the actual body. */
+function expectOk<T extends { code: number; response: unknown }>(
+  result: T
+): Extract<T, { code: 200 }> {
+  if (result.code !== 200) {
+    throw new Error(`expected 200, got ${result.code}: ${JSON.stringify(result.response)}`);
+  }
+  return result as Extract<T, { code: 200 }>;
+}
+
+/**
+ * Full purchase-loop E2E test: catalog-import -> cart -> order -> full
+ * state-machine transition chain -> illegal transition rejected.
+ *
+ * Requires a container runtime (Docker) for the Postgres testcontainer —
+ * this could not be executed in the sandbox this was authored in (no
+ * container runtime available there; confirmed the repo's existing
+ * billing-stripe e2e tests fail identically in that environment, for the
+ * same environmental reason, unrelated to this test's correctness).
+ *
+ * The flow below was verified live against a real running server + real
+ * Postgres database before being encoded here — see
+ * ecommerce-stripe/purchase-loop-verify.ts for that verification script
+ * and its output.
+ */
+describe('Purchase Loop E2E Test with PostgreSQL Container', () => {
+  beforeAll(async () => {
+    await setupTestDatabase();
+  }, 60000);
+
+  afterAll(async () => {
+    await cleanupTestDatabase();
+  }, 30000);
+
+  it('completes the full purchase loop and rejects an illegal transition', async () => {
+    const { importCatalogRoute } = await import(
+      '../api/routes/catalogImport.routes'
+    );
+    const { getProductByHandleRoute } = await import(
+      '../api/routes/product.routes'
+    );
+    const { listVariantsByProductRoute } = await import(
+      '../api/routes/variant.routes'
+    );
+    const { createCartRoute, addCartItemRoute } = await import(
+      '../api/routes/cart.routes'
+    );
+    const {
+      createOrderRoute,
+      transitionOrderRoute,
+      getOrderRoute
+    } = await import('../api/routes/order.routes');
+
+    const externalId = `e2e-${randomUUID()}`;
+    const handle = `e2e-product-${externalId}`;
+
+    // 1. Catalog import — the same idempotent, batched door Guild's
+    // migration tooling loads through.
+    const importPayload = {
+      products: [
+        {
+          externalId,
+          handle,
+          title: 'E2E Test Product',
+          variants: [
+            {
+              externalId: `${externalId}-v1`,
+              title: 'Default',
+              priceCents: 2500,
+              initialStock: 10
+            }
+          ]
+        }
+      ]
+    };
+    const importResponse = await importCatalogRoute.sdk.importCatalog({
+      body: importPayload,
+      headers: { authorization: signTestRequest('POST', '/', importPayload) }
+    });
+    expect(importResponse.code).toBe(200);
+    expect(importResponse.response).toMatchObject({
+      productsImported: 1,
+      variantsImported: 1
+    });
+
+    // 2. Locate the created product + variant.
+    const productResponse = expectOk(
+      await getProductByHandleRoute.sdk.getProductByHandle({
+        params: { handle },
+        headers: { authorization: signTestRequest('GET', `/handle/${handle}`) }
+      })
+    );
+    const productId = productResponse.response.id;
+
+    const variantsResponse = expectOk(
+      await listVariantsByProductRoute.sdk.listVariantsByProduct({
+        params: { productId },
+        headers: {
+          authorization: signTestRequest('GET', `/product/${productId}`)
+        }
+      })
+    );
+    const variantId = variantsResponse.response[0].id;
+
+    // 3. Cart: create, add item.
+    const cartResponse = expectOk(
+      await createCartRoute.sdk.createCart({
+        body: { customerId: 'e2e-customer-1' },
+        headers: {
+          authorization: signTestRequest('POST', '/', {
+            customerId: 'e2e-customer-1'
+          })
+        }
+      })
+    );
+    const cartId = cartResponse.response.id;
+
+    const addItemBody = { cartId, variantId, quantity: 2 };
+    const addItemResponse = await addCartItemRoute.sdk.addCartItem({
+      body: addItemBody,
+      headers: { authorization: signTestRequest('POST', '/items', addItemBody) }
+    });
+    expect(addItemResponse.code).toBe(200);
+
+    // 4. Order: create from the cart's items.
+    const createOrderBody = {
+      customerId: 'e2e-customer-1',
+      items: [{ variantId, quantity: 2, unitPriceCents: 2500 }],
+      shippingAddress: {
+        name: 'E2E Customer',
+        line1: '123 Test St',
+        city: 'Testville',
+        state: 'CA',
+        postalCode: '90001',
+        country: 'US'
+      },
+      subtotalCents: 5000,
+      discountCents: 0,
+      taxCents: 400,
+      taxBreakdown: [{ jurisdiction: 'CA', taxCents: 400 }],
+      shippingCents: 0,
+      giftCardCents: 0,
+      totalCents: 5400
+    };
+    const orderResponse = expectOk(
+      await createOrderRoute.sdk.createOrder({
+        body: createOrderBody,
+        headers: { authorization: signTestRequest('POST', '/', createOrderBody) }
+      })
+    );
+    expect(orderResponse.response.status).toBe('pending');
+    const orderId = orderResponse.response.id;
+
+    // 5. Full legal transition chain.
+    const transitions = ['paid', 'fulfilled', 'shipped', 'delivered'] as const;
+    for (const to of transitions) {
+      const transitionBody = { to };
+      const transitionResponse = expectOk(
+        await transitionOrderRoute.sdk.transitionOrder({
+          params: { id: orderId },
+          body: transitionBody,
+          headers: {
+            authorization: signTestRequest(
+              'PUT',
+              `/${orderId}/transition`,
+              transitionBody
+            )
+          }
+        })
+      );
+      expect(transitionResponse.response.status).toBe(to);
+    }
+
+    // 6. One illegal transition must be rejected — delivered has no legal
+    // next state.
+    const illegalBody: { to: (typeof transitions)[number] } = { to: 'paid' };
+    const illegalResponse = await transitionOrderRoute.sdk.transitionOrder({
+      params: { id: orderId },
+      body: illegalBody,
+      headers: {
+        authorization: signTestRequest(
+          'PUT',
+          `/${orderId}/transition`,
+          illegalBody
+        )
+      }
+    });
+    expect(illegalResponse.code).toBe(400);
+
+    // 7. Final state confirms the rejected transition had no effect.
+    const finalResponse = expectOk(
+      await getOrderRoute.sdk.getOrder({
+        params: { id: orderId },
+        headers: { authorization: signTestRequest('GET', `/${orderId}`) }
+      })
+    );
+    expect(finalResponse.response.status).toBe('delivered');
+  });
+});

--- a/blueprint/ecommerce-stripe/__test__/test-utils.ts
+++ b/blueprint/ecommerce-stripe/__test__/test-utils.ts
@@ -1,0 +1,77 @@
+import { createHmacToken } from '@forklaunch/core/http';
+import {
+  BlueprintTestHarness,
+  DatabaseType,
+  TestSetupResult
+} from '@forklaunch/testing';
+import dotenv from 'dotenv';
+import * as path from 'path';
+
+export { TestSetupResult };
+
+let harness: BlueprintTestHarness;
+
+dotenv.config({ path: path.join(__dirname, '../.env.test') });
+
+export const setupTestDatabase = async (): Promise<TestSetupResult> => {
+  harness = new BlueprintTestHarness({
+    getConfig: async () => {
+      const { default: config } = await import('../mikro-orm.config');
+      return config;
+    },
+    databaseType: (process.env.DATABASE_TYPE ?? 'postgresql') as DatabaseType,
+    useMigrations: false,
+    needsRedis: false,
+    customEnvVars: {
+      STRIPE_API_KEY: process.env.STRIPE_API_KEY ?? '',
+      STRIPE_WEBHOOK_SECRET: process.env.STRIPE_WEBHOOK_SECRET ?? '',
+      HMAC_SECRET_KEY: TEST_HMAC_SECRET
+    }
+  });
+
+  return await harness.setup();
+};
+
+export const cleanupTestDatabase = async (): Promise<void> => {
+  if (harness) {
+    await harness.cleanup();
+  }
+};
+
+/**
+ * The repo's shared TEST_TOKENS.HMAC (from @forklaunch/testing) is a fixed,
+ * fake signature — it will fail real HMAC verification. Use this instead:
+ * a real signature computed the same way the server verifies it. Two
+ * things matter, both found by actually running requests, not by reading
+ * the auth code alone:
+ *
+ * 1. `signedPath` must be the path as the route handler sees it (relative
+ *    to the router's mount point), not the full request URL — e.g. for
+ *    PUT /order/:id/transition, sign '/<id>/transition', not
+ *    '/order/<id>/transition'.
+ * 2. When there is no request body, the framework's own signing code
+ *    embeds the literal string "undefined" in the signed message (a
+ *    template-literal quirk, not a stylistic choice) — passing an empty
+ *    string instead produces a signature that fails with the exact same
+ *    403 as a wrong secret, with no way to tell the two apart from the
+ *    response alone.
+ */
+export const TEST_HMAC_SECRET = 'test-hmac-secret-for-e2e';
+
+export function signTestRequest(
+  method: string,
+  signedPath: string,
+  body?: unknown
+): `HMAC keyId=${string} ts=${string} nonce=${string} signature=${string}` {
+  const timestamp = new Date();
+  const nonce = crypto.randomUUID();
+  const signature = createHmacToken({
+    method,
+    path: signedPath,
+    body,
+    timestamp,
+    nonce,
+    secretKey: TEST_HMAC_SECRET
+  });
+  return `HMAC keyId=default ts=${timestamp.toISOString()} nonce=${nonce} signature=${signature}`;
+}

--- a/blueprint/ecommerce-stripe/api/controllers/checkout.controller.ts
+++ b/blueprint/ecommerce-stripe/api/controllers/checkout.controller.ts
@@ -13,7 +13,7 @@ const shippingServiceFactory = ci.scopedResolver(tokens.ShippingService);
 const HMAC_SECRET_KEY = ci.resolve(tokens.HMAC_SECRET_KEY);
 
 /**
- * The unified checkout orchestration (ECOM-09): cart -> order in one call,
+ * The unified checkout orchestration: cart -> order in one call,
  * with stock validated up front so a customer never pays for something
  * that's not actually there. Tax (Stripe Tax) and shipping (flat-rate) are
  * both real, not stubs — a shipping address is required because both need

--- a/blueprint/ecommerce-stripe/api/controllers/checkout.controller.ts
+++ b/blueprint/ecommerce-stripe/api/controllers/checkout.controller.ts
@@ -1,0 +1,151 @@
+import { handlers, schemaValidator, string } from '../../schema';
+import { ShippingAddressSchema } from '../../domain/schemas/checkout.schema';
+import { OrderMapper } from '../../domain/mappers/order.mappers';
+import { ci, tokens } from '../../bootstrapper';
+
+const openTelemetryCollector = ci.resolve(tokens.OtelCollector);
+const cartServiceFactory = ci.scopedResolver(tokens.CartService);
+const variantServiceFactory = ci.scopedResolver(tokens.VariantService);
+const inventoryServiceFactory = ci.scopedResolver(tokens.InventoryService);
+const orderServiceFactory = ci.scopedResolver(tokens.OrderService);
+const taxServiceFactory = ci.scopedResolver(tokens.TaxService);
+const shippingServiceFactory = ci.scopedResolver(tokens.ShippingService);
+const HMAC_SECRET_KEY = ci.resolve(tokens.HMAC_SECRET_KEY);
+
+/**
+ * The unified checkout orchestration (ECOM-09): cart -> order in one call,
+ * with stock validated up front so a customer never pays for something
+ * that's not actually there. Tax (Stripe Tax) and shipping (flat-rate) are
+ * both real, not stubs — a shipping address is required because both need
+ * one.
+ *
+ * Promo codes and gift cards are a later phase (order entity already
+ * carries discountCents/giftCardCents from the order slice, so this PR
+ * simply always passes 0 for both — the follow-up promotions PR is what
+ * wires req.body.promoCode/giftCardCode back through to real redemption).
+ */
+export const checkout = handlers.post(
+  schemaValidator,
+  '/',
+  {
+    name: 'Checkout',
+    access: 'internal',
+    summary: 'Convert a cart into an order, validating stock first',
+    auth: { hmac: { secretKeys: { default: HMAC_SECRET_KEY } } },
+    body: {
+      cartId: string,
+      shippingAddress: ShippingAddressSchema
+    },
+    responses: {
+      200: OrderMapper.schema,
+      400: string
+    }
+  },
+  async (req, res) => {
+    const cart = await cartServiceFactory().getCart({ id: req.body.cartId });
+
+    if (!cart.items.length) {
+      res.status(400).send('Cannot checkout an empty cart');
+      return;
+    }
+
+    // Stock check up front, before anything is priced or persisted — a
+    // customer should never be told an order succeeded and then find out
+    // separately that an item was unavailable.
+    const stockChecks = await Promise.all(
+      cart.items.map((item) =>
+        inventoryServiceFactory().checkStock({
+          variantId: item.variantId,
+          requested: item.quantity
+        })
+      )
+    );
+    const outOfStock = stockChecks.filter((check) => !check.available);
+    if (outOfStock.length) {
+      res
+        .status(400)
+        .send(
+          `Insufficient stock for variant(s): ${outOfStock
+            .map((c) => c.variantId)
+            .join(', ')}`
+        );
+      return;
+    }
+
+    // Price each line from the variant's current price — the cart itself
+    // only carries variantId + quantity, never a price (prices can move
+    // between add-to-cart and checkout; checkout always uses the price at
+    // the moment of purchase).
+    const variants = await Promise.all(
+      cart.items.map((item) =>
+        variantServiceFactory().getVariant({ id: item.variantId })
+      )
+    );
+    const orderItems = cart.items.map((item, i) => ({
+      variantId: item.variantId,
+      quantity: item.quantity,
+      unitPriceCents: variants[i].priceCents
+    }));
+
+    const subtotalCents = orderItems.reduce(
+      (sum, item) => sum + item.quantity * item.unitPriceCents,
+      0
+    );
+
+    // No promo code in this slice — discount is always 0 until the
+    // promotions PR lands (see the module-level comment above).
+    const discountCents = 0;
+    const discountedSubtotalCents = Math.max(0, subtotalCents - discountCents);
+
+    const [taxResult, shippingResult] = await Promise.all([
+      taxServiceFactory().calculate({
+        // Taxed on the discounted amount, as one line — not prorated across
+        // the original per-item lines, a reasonable v1 simplification.
+        lineItemCents: [discountedSubtotalCents],
+        shippingAddress: req.body.shippingAddress
+      }),
+      shippingServiceFactory().calculate({
+        shippingAddress: req.body.shippingAddress,
+        subtotalCents: discountedSubtotalCents
+      })
+    ]);
+    if (taxResult.estimated) {
+      openTelemetryCollector.warn(
+        'Order tax is a flat estimate — Stripe Tax was unreachable',
+        { cartId: cart.id }
+      );
+    }
+
+    // No gift card in this slice — applied amount is always 0 until the
+    // promotions PR lands (see the module-level comment above).
+    const giftCardCents = 0;
+    const totalCents = Math.max(
+      0,
+      discountedSubtotalCents +
+        taxResult.taxCents +
+        shippingResult.shippingCents -
+        giftCardCents
+    );
+
+    const order = await orderServiceFactory().createOrder({
+      customerId: cart.customerId,
+      items: orderItems,
+      shippingAddress: req.body.shippingAddress,
+      subtotalCents,
+      discountCents,
+      taxCents: taxResult.taxCents,
+      taxBreakdown: taxResult.breakdown,
+      shippingCents: shippingResult.shippingCents,
+      giftCardCents,
+      totalCents
+    });
+
+    await cartServiceFactory().clearCart({ id: cart.id });
+
+    openTelemetryCollector.info('Checkout completed', {
+      cartId: cart.id,
+      orderId: order.id
+    });
+    res.status(200).json(order);
+  }
+);

--- a/blueprint/ecommerce-stripe/api/controllers/index.ts
+++ b/blueprint/ecommerce-stripe/api/controllers/index.ts
@@ -1,5 +1,6 @@
 export * from './cart.controller';
 export * from './catalogImport.controller';
+export * from './checkout.controller';
 export * from './inventory.controller';
 export * from './order.controller';
 export * from './payment.controller';

--- a/blueprint/ecommerce-stripe/api/routes/checkout.routes.ts
+++ b/blueprint/ecommerce-stripe/api/routes/checkout.routes.ts
@@ -1,0 +1,13 @@
+import { forklaunchRouter, schemaValidator } from '../../schema';
+import { ci, tokens } from '../../bootstrapper';
+import { checkout } from '../controllers/checkout.controller';
+
+const openTelemetryCollector = ci.resolve(tokens.OtelCollector);
+
+export const checkoutRouter = forklaunchRouter(
+  '/checkout',
+  schemaValidator,
+  openTelemetryCollector
+);
+
+export const checkoutRoute = checkoutRouter.post('/', checkout);

--- a/blueprint/ecommerce-stripe/domain/schemas/checkout.schema.ts
+++ b/blueprint/ecommerce-stripe/domain/schemas/checkout.schema.ts
@@ -1,0 +1,18 @@
+import { optional, string } from '../../schema';
+
+/**
+ * Request schema for the checkout endpoint.
+ *
+ * Lives here rather than inline in the controller so the controller stays
+ * HTTP concerns only, matching how billing/iam keep schema definitions out
+ * of their controllers (see catalogImport.schema.ts for the same pattern).
+ */
+export const ShippingAddressSchema = {
+  name: string,
+  line1: string,
+  line2: optional(string),
+  city: string,
+  state: string,
+  postalCode: string,
+  country: string
+};

--- a/blueprint/ecommerce-stripe/domain/services/shipping.service.ts
+++ b/blueprint/ecommerce-stripe/domain/services/shipping.service.ts
@@ -1,0 +1,39 @@
+import { ShippingAddressDto } from '@forklaunch/interfaces-ecommerce/types';
+
+export interface ShippingCalculationResult {
+  shippingCents: number;
+}
+
+export interface ShippingService {
+  calculate(params: {
+    shippingAddress: ShippingAddressDto;
+    subtotalCents: number;
+  }): Promise<ShippingCalculationResult>;
+}
+
+/**
+ * Real flat/table-rate shipping — not a live carrier-rate lookup. This is
+ * deliberately the same shape Guild's own shipping-fulfillment guide
+ * recommends as the fallback path ("never block checkout on a rate call"),
+ * used here as the actual v1 implementation. A live-rate provider (EasyPost/
+ * Shippo) is a second ShippingService implementation behind this same
+ * interface — checkout.controller.ts never needs to change to add one.
+ */
+const FREE_SHIPPING_THRESHOLD_CENTS = 5000;
+const DOMESTIC_RATE_CENTS = 599;
+const INTERNATIONAL_RATE_CENTS = 1999;
+
+export class FlatRateShippingService implements ShippingService {
+  async calculate(params: {
+    shippingAddress: ShippingAddressDto;
+    subtotalCents: number;
+  }): Promise<ShippingCalculationResult> {
+    if (params.subtotalCents >= FREE_SHIPPING_THRESHOLD_CENTS) {
+      return { shippingCents: 0 };
+    }
+    const isDomestic = params.shippingAddress.country.toUpperCase() === 'US';
+    return {
+      shippingCents: isDomestic ? DOMESTIC_RATE_CENTS : INTERNATIONAL_RATE_CENTS
+    };
+  }
+}

--- a/blueprint/ecommerce-stripe/domain/services/tax.service.ts
+++ b/blueprint/ecommerce-stripe/domain/services/tax.service.ts
@@ -1,0 +1,91 @@
+import { TaxLineDto, ShippingAddressDto } from '@forklaunch/interfaces-ecommerce/types';
+import { Metrics } from '@forklaunch/blueprint-monitoring';
+import { OpenTelemetryCollector } from '@forklaunch/core/http';
+import Stripe from 'stripe';
+
+export interface TaxCalculationResult {
+  taxCents: number;
+  breakdown: TaxLineDto[];
+  /** True when the real provider couldn't be reached and this is a
+   *  configured fallback, not a real jurisdiction-calculated amount — per
+   *  Guild's tax-compliance guide: never silently ship $0 tax on a
+   *  provider failure, degrade to a flagged estimate instead. */
+  estimated: boolean;
+}
+
+export interface TaxService {
+  calculate(params: {
+    lineItemCents: number[];
+    shippingAddress: ShippingAddressDto;
+  }): Promise<TaxCalculationResult>;
+}
+
+/** A flat percentage used only when Stripe Tax itself is unreachable —
+ *  deliberately crude (no jurisdiction awareness) because its only job is
+ *  to keep checkout from either hard-failing or silently charging $0 tax
+ *  while the real provider is down. */
+const FALLBACK_TAX_RATE = 0.07;
+
+export class StripeTaxService implements TaxService {
+  constructor(
+    private stripe: Stripe,
+    private openTelemetryCollector: OpenTelemetryCollector<Metrics>
+  ) {}
+
+  async calculate(params: {
+    lineItemCents: number[];
+    shippingAddress: ShippingAddressDto;
+  }): Promise<TaxCalculationResult> {
+    try {
+      const calculation = await this.stripe.tax.calculations.create({
+        currency: 'usd',
+        line_items: params.lineItemCents.map((amount, i) => ({
+          amount,
+          reference: `line-${i}`,
+          tax_behavior: 'exclusive'
+        })),
+        customer_details: {
+          address: {
+            line1: params.shippingAddress.line1,
+            line2: params.shippingAddress.line2,
+            city: params.shippingAddress.city,
+            state: params.shippingAddress.state,
+            postal_code: params.shippingAddress.postalCode,
+            country: params.shippingAddress.country
+          },
+          address_source: 'shipping'
+        }
+      });
+
+      const breakdown: TaxLineDto[] = (calculation.tax_breakdown ?? []).map(
+        (line) => ({
+          jurisdiction:
+            [line.tax_rate_details.state, line.tax_rate_details.country]
+              .filter(Boolean)
+              .join(', ') || 'unknown',
+          taxCents: line.amount
+        })
+      );
+
+      return {
+        taxCents: calculation.tax_amount_exclusive,
+        breakdown,
+        estimated: false
+      };
+    } catch (error) {
+      // Degrade safely: a real order still needs a real (if approximate)
+      // tax line, not $0 — but this must be visible, not silent.
+      this.openTelemetryCollector.warn(
+        'Stripe Tax unreachable — falling back to a flat estimated rate',
+        { error }
+      );
+      const subtotalCents = params.lineItemCents.reduce((a, b) => a + b, 0);
+      const taxCents = Math.round(subtotalCents * FALLBACK_TAX_RATE);
+      return {
+        taxCents,
+        breakdown: [{ jurisdiction: 'estimated-fallback', taxCents }],
+        estimated: true
+      };
+    }
+  }
+}

--- a/blueprint/ecommerce-stripe/package.json
+++ b/blueprint/ecommerce-stripe/package.json
@@ -18,6 +18,7 @@
     "build": "tsgo -b",
     "clean": "rm -rf dist tsconfig.tsbuildinfo pnpm.lock.yaml node_modules",
     "dev": "pnpm run migrate:up && pnpm tsx watch server.ts",
+    "dev:worker": "pnpm tsx watch worker.ts",
     "docs": "typedoc --out docs *",
     "format": "prettier --ignore-path=.prettierignore --config .prettierrc '**/*.{ts,tsx,json}' --write",
     "lint": "eslint . -c eslint.config.mjs",
@@ -28,8 +29,8 @@
     "migrate:up": "NODE_OPTIONS='--import=tsx' mikro-orm migration:up",
     "prepack": "pnpm run build",
     "start": "DOTENV_FILE_PATH=.env.local NODE_OPTIONS='--import=tsx' node dist/server.js",
-    "test": "vitest --passWithNoTests",
-    "worker": "pnpm tsx watch worker.ts"
+    "start:worker": "DOTENV_FILE_PATH=.env.local NODE_OPTIONS='--import=tsx' node dist/worker.js",
+    "test": "vitest --passWithNoTests"
   },
   "dependencies": {
     "@forklaunch/blueprint-core": "workspace:^",

--- a/blueprint/ecommerce-stripe/registrations.ts
+++ b/blueprint/ecommerce-stripe/registrations.ts
@@ -29,10 +29,17 @@ import {
   PaypalPaymentService
 } from '@forklaunch/implementation-ecommerce-paypal/services';
 import { StripePaymentService } from '@forklaunch/implementation-ecommerce-stripe/services';
+import { RedisWorkerConsumer } from '@forklaunch/implementation-worker-redis/consumers';
 import { RedisWorkerProducer } from '@forklaunch/implementation-worker-redis/producers';
 import { RedisWorkerSchemas } from '@forklaunch/implementation-worker-redis/schemas';
 import { RedisWorkerOptions } from '@forklaunch/implementation-worker-redis/types';
+import {
+  WorkerFailureHandler,
+  WorkerProcessFunction
+} from '@forklaunch/interfaces-worker/types';
 import { OrderEventRecord } from './persistence/entities/orderEvent.entity';
+import { StripeTaxService } from './domain/services/tax.service';
+import { FlatRateShippingService } from './domain/services/shipping.service';
 import { ForkOptions } from '@mikro-orm/core';
 import { EntityManager, MikroORM } from '@mikro-orm/postgresql';
 import Stripe from 'stripe';
@@ -202,6 +209,17 @@ const runtimeDependencies = environmentConfig.chain({
         clientSecret: PAYPAL_CLIENT_SECRET,
         baseUrl: PAYPAL_BASE_URL
       })
+  },
+  TaxService: {
+    lifetime: Lifetime.Singleton,
+    type: StripeTaxService,
+    factory: ({ StripeClient, OtelCollector }) =>
+      new StripeTaxService(StripeClient, OtelCollector)
+  },
+  ShippingService: {
+    lifetime: Lifetime.Singleton,
+    type: FlatRateShippingService,
+    factory: () => new FlatRateShippingService()
   },
   /**
    * Cart's fast/temporary-state layer: a read-through cache in front of
@@ -384,10 +402,7 @@ const serviceDependencies = runtimeDependencies.chain({
         // PaypalOrder; the cast bridges the two provider-specific static
         // types over one shared runtime mapper object, same as
         // StripePaymentService does internally for its own 3rd-arg type.
-        {
-          PaymentMapper,
-          CreatePaymentMapper
-        } as unknown as ConstructorParameters<
+        { PaymentMapper, CreatePaymentMapper } as unknown as ConstructorParameters<
           typeof PaypalPaymentService<
             SchemaValidator,
             PaymentMapperTypes,
@@ -397,9 +412,9 @@ const serviceDependencies = runtimeDependencies.chain({
       )
   },
   /**
-   * The event-emission boundary. Redis transport only, which matches
-   * TtlCache already being registered here, so it needs no infrastructure
-   * beyond what cart caching already requires.
+   * ECOM-12's event-emission boundary, actually implemented — previously
+   * just a comment. Redis transport only (matches TtlCache already being
+   * registered here; no new infra beyond what cart caching already needs).
    */
   RedisWorkerOptions: {
     lifetime: Lifetime.Singleton,
@@ -415,6 +430,34 @@ const serviceDependencies = runtimeDependencies.chain({
     type: RedisWorkerProducer<OrderEventRecord, RedisWorkerOptions>,
     factory: ({ TtlCache, ORDER_EVENT_QUEUE, RedisWorkerOptions }) =>
       new RedisWorkerProducer(ORDER_EVENT_QUEUE, TtlCache, RedisWorkerOptions)
+  },
+  OrderEventConsumer: {
+    lifetime: Lifetime.Scoped,
+    // The function_([...], type<...>()) TypeBox-style signature (the exact
+    // pattern sample-worker/registrations.ts uses for its own Redis
+    // consumer) does not type-check here despite being byte-for-byte
+    // identical — a real, unresolved TS-inference discrepancy between the
+    // two files, not a typo. Falling back to an explicit type assertion on
+    // the factory's return so the actual runtime behavior (verified
+    // separately below) isn't blocked by it. Left as a known loose end —
+    // narrowing the real cause needs more time than this pass has.
+    type: null as unknown as (
+      processEventsFunction: WorkerProcessFunction<OrderEventRecord>,
+      failureHandler: WorkerFailureHandler<OrderEventRecord>
+    ) => RedisWorkerConsumer<OrderEventRecord, RedisWorkerOptions>,
+    factory:
+      ({ TtlCache, ORDER_EVENT_QUEUE, RedisWorkerOptions }) =>
+      (
+        processEventsFunction: WorkerProcessFunction<OrderEventRecord>,
+        failureHandler: WorkerFailureHandler<OrderEventRecord>
+      ) =>
+        new RedisWorkerConsumer(
+          ORDER_EVENT_QUEUE,
+          TtlCache,
+          RedisWorkerOptions,
+          processEventsFunction,
+          failureHandler
+        )
   }
 });
 

--- a/blueprint/ecommerce-stripe/registrations.ts
+++ b/blueprint/ecommerce-stripe/registrations.ts
@@ -29,10 +29,17 @@ import {
   PaypalPaymentService
 } from '@forklaunch/implementation-ecommerce-paypal/services';
 import { StripePaymentService } from '@forklaunch/implementation-ecommerce-stripe/services';
+import { RedisWorkerConsumer } from '@forklaunch/implementation-worker-redis/consumers';
 import { RedisWorkerProducer } from '@forklaunch/implementation-worker-redis/producers';
 import { RedisWorkerSchemas } from '@forklaunch/implementation-worker-redis/schemas';
 import { RedisWorkerOptions } from '@forklaunch/implementation-worker-redis/types';
+import {
+  WorkerFailureHandler,
+  WorkerProcessFunction
+} from '@forklaunch/interfaces-worker/types';
 import { OrderEventRecord } from './persistence/entities/orderEvent.entity';
+import { StripeTaxService } from './domain/services/tax.service';
+import { FlatRateShippingService } from './domain/services/shipping.service';
 import { ForkOptions } from '@mikro-orm/core';
 import { EntityManager, MikroORM } from '@mikro-orm/postgresql';
 import Stripe from 'stripe';
@@ -205,6 +212,17 @@ const runtimeDependencies = environmentConfig.chain({
         clientSecret: PAYPAL_CLIENT_SECRET,
         baseUrl: PAYPAL_BASE_URL
       })
+  },
+  TaxService: {
+    lifetime: Lifetime.Singleton,
+    type: StripeTaxService,
+    factory: ({ StripeClient, OtelCollector }) =>
+      new StripeTaxService(StripeClient, OtelCollector)
+  },
+  ShippingService: {
+    lifetime: Lifetime.Singleton,
+    type: FlatRateShippingService,
+    factory: () => new FlatRateShippingService()
   },
   /**
    * Cart's fast/temporary-state layer (ECOM-06's original design) — a
@@ -392,9 +410,6 @@ const serviceDependencies = runtimeDependencies.chain({
    * ECOM-12's event-emission boundary, actually implemented — previously
    * just a comment. Redis transport only (matches TtlCache already being
    * registered here; no new infra beyond what cart caching already needs).
-   * Only the producer side is wired here — order.controller.ts is the only
-   * local consumer of a token from this pair; the consumer/worker.ts side
-   * is scoped to a follow-up PR.
    */
   RedisWorkerOptions: {
     lifetime: Lifetime.Singleton,
@@ -410,6 +425,34 @@ const serviceDependencies = runtimeDependencies.chain({
     type: RedisWorkerProducer<OrderEventRecord, RedisWorkerOptions>,
     factory: ({ TtlCache, ORDER_EVENT_QUEUE, RedisWorkerOptions }) =>
       new RedisWorkerProducer(ORDER_EVENT_QUEUE, TtlCache, RedisWorkerOptions)
+  },
+  OrderEventConsumer: {
+    lifetime: Lifetime.Scoped,
+    // The function_([...], type<...>()) TypeBox-style signature (the exact
+    // pattern sample-worker/registrations.ts uses for its own Redis
+    // consumer) does not type-check here despite being byte-for-byte
+    // identical — a real, unresolved TS-inference discrepancy between the
+    // two files, not a typo. Falling back to an explicit type assertion on
+    // the factory's return so the actual runtime behavior (verified
+    // separately below) isn't blocked by it. Left as a known loose end —
+    // narrowing the real cause needs more time than this pass has.
+    type: null as unknown as (
+      processEventsFunction: WorkerProcessFunction<OrderEventRecord>,
+      failureHandler: WorkerFailureHandler<OrderEventRecord>
+    ) => RedisWorkerConsumer<OrderEventRecord, RedisWorkerOptions>,
+    factory:
+      ({ TtlCache, ORDER_EVENT_QUEUE, RedisWorkerOptions }) =>
+      (
+        processEventsFunction: WorkerProcessFunction<OrderEventRecord>,
+        failureHandler: WorkerFailureHandler<OrderEventRecord>
+      ) =>
+        new RedisWorkerConsumer(
+          ORDER_EVENT_QUEUE,
+          TtlCache,
+          RedisWorkerOptions,
+          processEventsFunction,
+          failureHandler
+        )
   }
 });
 

--- a/blueprint/ecommerce-stripe/registrations.ts
+++ b/blueprint/ecommerce-stripe/registrations.ts
@@ -402,7 +402,10 @@ const serviceDependencies = runtimeDependencies.chain({
         // PaypalOrder; the cast bridges the two provider-specific static
         // types over one shared runtime mapper object, same as
         // StripePaymentService does internally for its own 3rd-arg type.
-        { PaymentMapper, CreatePaymentMapper } as unknown as ConstructorParameters<
+        {
+          PaymentMapper,
+          CreatePaymentMapper
+        } as unknown as ConstructorParameters<
           typeof PaypalPaymentService<
             SchemaValidator,
             PaymentMapperTypes,
@@ -412,9 +415,9 @@ const serviceDependencies = runtimeDependencies.chain({
       )
   },
   /**
-   * ECOM-12's event-emission boundary, actually implemented — previously
-   * just a comment. Redis transport only (matches TtlCache already being
-   * registered here; no new infra beyond what cart caching already needs).
+   * The event-emission boundary. Redis transport only, which matches
+   * TtlCache already being registered here, so it needs no infrastructure
+   * beyond what cart caching already requires.
    */
   RedisWorkerOptions: {
     lifetime: Lifetime.Singleton,

--- a/blueprint/ecommerce-stripe/server.ts
+++ b/blueprint/ecommerce-stripe/server.ts
@@ -7,6 +7,7 @@ import {
 import { setupRls, setupTenantFilter } from '@forklaunch/core/persistence';
 import { cartRouter } from './api/routes/cart.routes';
 import { catalogImportRouter } from './api/routes/catalogImport.routes';
+import { checkoutRouter } from './api/routes/checkout.routes';
 import { inventoryRouter } from './api/routes/inventory.routes';
 import { orderRouter } from './api/routes/order.routes';
 import { paymentRouter } from './api/routes/payment.routes';
@@ -48,6 +49,7 @@ app.use(variantRouter);
 app.use(inventoryRouter);
 app.use(catalogImportRouter);
 app.use(cartRouter);
+app.use(checkoutRouter);
 app.use(orderRouter);
 app.use(paymentRouter);
 

--- a/blueprint/ecommerce-stripe/server.ts
+++ b/blueprint/ecommerce-stripe/server.ts
@@ -7,6 +7,7 @@ import {
 import { setupRls, setupTenantFilter } from '@forklaunch/core/persistence';
 import { cartRouter } from './api/routes/cart.routes';
 import { catalogImportRouter } from './api/routes/catalogImport.routes';
+import { checkoutRouter } from './api/routes/checkout.routes';
 import { inventoryRouter } from './api/routes/inventory.routes';
 import { orderRouter } from './api/routes/order.routes';
 import { paymentRouter } from './api/routes/payment.routes';
@@ -47,6 +48,7 @@ app.use(variantRouter);
 app.use(inventoryRouter);
 app.use(catalogImportRouter);
 app.use(cartRouter);
+app.use(checkoutRouter);
 app.use(orderRouter);
 app.use(paymentRouter);
 

--- a/blueprint/ecommerce-stripe/worker.ts
+++ b/blueprint/ecommerce-stripe/worker.ts
@@ -10,7 +10,7 @@ const openTelemetryCollector = ci.resolve(tokens.OtelCollector);
 const inventoryServiceFactory = ci.scopedResolver(tokens.InventoryService);
 
 /**
- * ECOM-05/12's inventory side-effect, actually built — the module's real
+ * the inventory side-effect, actually built — the module's real
  * gap this session (search/filter, checkout, PayPal, cart caching) closed
  * but the worker never had. Deliberately scoped to two side effects that
  * are provable against the real database — decrement on paid, restock on
@@ -104,4 +104,6 @@ const orderEventConsumerFactory = ci.resolve(tokens.OrderEventConsumer);
 const consumer = orderEventConsumerFactory(processOrderEvents, processFailures);
 
 consumer.start();
-openTelemetryCollector.info('Ecommerce worker started, consuming order-events queue');
+openTelemetryCollector.info(
+  'Ecommerce worker started, consuming order-events queue'
+);

--- a/blueprint/ecommerce-stripe/worker.ts
+++ b/blueprint/ecommerce-stripe/worker.ts
@@ -1,0 +1,84 @@
+import {
+  WorkerFailureHandler,
+  WorkerProcessFunction
+} from '@forklaunch/interfaces-worker/types';
+import { ci, tokens } from './bootstrapper';
+import { OrderStatus } from '@forklaunch/interfaces-ecommerce/types';
+import type { OrderEventRecord } from './persistence/entities/orderEvent.entity';
+
+const openTelemetryCollector = ci.resolve(tokens.OtelCollector);
+const inventoryServiceFactory = ci.scopedResolver(tokens.InventoryService);
+
+/**
+ * ECOM-05/12's inventory side-effect, actually built — the module's real
+ * gap this session (search/filter, checkout, PayPal, cart caching) closed
+ * but the worker never had. Deliberately scoped to two side effects that
+ * are provable against the real database — decrement on paid, restock on
+ * cancelled — not shipping/invoicing/notifications, which need external
+ * services this environment has no credentials for.
+ */
+const processOrderEvents: WorkerProcessFunction<OrderEventRecord> = async (
+  events
+) => {
+  const failedEvents: { value: OrderEventRecord; error: Error }[] = [];
+
+  for (const event of events) {
+    try {
+      openTelemetryCollector.info(
+        `Processing order event: ${event.orderId} ${event.fromStatus} -> ${event.toStatus}`
+      );
+
+      // A fresh scoped resolution per event, not one shared instance across
+      // the whole batch — same reason the HTTP handlers use ci.scopedResolver
+      // per request rather than a module-level singleton.
+      const inventoryService = inventoryServiceFactory();
+
+      if (event.toStatus === OrderStatus.PAID) {
+        for (const item of event.items) {
+          await inventoryService.adjustStock({
+            variantId: item.variantId,
+            delta: -item.quantity
+          });
+        }
+      } else if (
+        event.toStatus === OrderStatus.CANCELLED &&
+        event.fromStatus === OrderStatus.PAID
+      ) {
+        // Only restock if inventory was actually decremented earlier —
+        // cancelling directly from pending never touched stock (found by
+        // testing: a pending->cancelled order was blindly restocking
+        // anyway, inflating stock for something that was never removed).
+        for (const item of event.items) {
+          await inventoryService.adjustStock({
+            variantId: item.variantId,
+            delta: item.quantity
+          });
+        }
+      }
+
+      event.processed = true;
+    } catch (error) {
+      failedEvents.push({ value: event, error: error as Error });
+    }
+  }
+
+  return failedEvents;
+};
+
+const processFailures: WorkerFailureHandler<OrderEventRecord> = async (
+  events
+) => {
+  events.forEach((event) => {
+    openTelemetryCollector.error(
+      'Order event processing failed',
+      event.error,
+      event.value
+    );
+  });
+};
+
+const orderEventConsumerFactory = ci.resolve(tokens.OrderEventConsumer);
+const consumer = orderEventConsumerFactory(processOrderEvents, processFailures);
+
+consumer.start();
+openTelemetryCollector.info('Ecommerce worker started, consuming order-events queue');

--- a/blueprint/ecommerce-stripe/worker.ts
+++ b/blueprint/ecommerce-stripe/worker.ts
@@ -10,12 +10,10 @@ const openTelemetryCollector = ci.resolve(tokens.OtelCollector);
 const inventoryServiceFactory = ci.scopedResolver(tokens.InventoryService);
 
 /**
- * the inventory side-effect, actually built — the module's real
- * gap this session (search/filter, checkout, PayPal, cart caching) closed
- * but the worker never had. Deliberately scoped to two side effects that
- * are provable against the real database — decrement on paid, restock on
- * cancelled — not shipping/invoicing/notifications, which need external
- * services this environment has no credentials for.
+ * Applies inventory side effects for order transitions: decrement on paid,
+ * restock on cancelled. Deliberately limited to those two, both of which are
+ * provable against the database. Shipping, invoicing and notifications would
+ * consume the same events but depend on external services.
  */
 const processOrderEvents: WorkerProcessFunction<OrderEventRecord> = async (
   events

--- a/blueprint/ecommerce-stripe/worker.ts
+++ b/blueprint/ecommerce-stripe/worker.ts
@@ -58,12 +58,24 @@ const processOrderEvents: WorkerProcessFunction<OrderEventRecord> = async (
         await applyStockDeltas(-1);
       } else if (
         event.toStatus === OrderStatus.CANCELLED &&
-        event.fromStatus === OrderStatus.PAID
+        // Restock only if stock was actually decremented earlier — that
+        // happens exactly once, at PENDING -> PAID. So restock on
+        // cancellation from any state that implies stock was already
+        // taken: PAID (ORDER_TRANSITIONS in order.service.ts allows
+        // PAID -> CANCELLED directly) or FULFILLED (FULFILLED -> CANCELLED
+        // is also legal — this order already passed through PAID to get
+        // there, so stock was decremented then and was never restocked in
+        // between). SHIPPED and DELIVERED are excluded not because stock
+        // wasn't taken (it was), but because ORDER_TRANSITIONS doesn't
+        // allow cancelling from either state — this branch can never
+        // observe fromStatus SHIPPED/DELIVERED in practice. Cancelling
+        // directly from PENDING never touched stock (found by testing: a
+        // pending->cancelled order was blindly restocking anyway,
+        // inflating stock for something that was never removed), so it's
+        // still deliberately excluded here.
+        (event.fromStatus === OrderStatus.PAID ||
+          event.fromStatus === OrderStatus.FULFILLED)
       ) {
-        // Only restock if inventory was actually decremented earlier —
-        // cancelling directly from pending never touched stock (found by
-        // testing: a pending->cancelled order was blindly restocking
-        // anyway, inflating stock for something that was never removed).
         await applyStockDeltas(1);
       }
 

--- a/blueprint/ecommerce-stripe/worker.ts
+++ b/blueprint/ecommerce-stripe/worker.ts
@@ -33,13 +33,29 @@ const processOrderEvents: WorkerProcessFunction<OrderEventRecord> = async (
       // per request rather than a module-level singleton.
       const inventoryService = inventoryServiceFactory();
 
+      // All items in one transaction, so the adjustment is all-or-nothing.
+      // Without this the loop had no per-item checkpoint: if item 2 threw
+      // (oversell guard, transient DB error), item 1's decrement had already
+      // committed, the whole event was requeued unchanged, and the retry
+      // decremented item 1 a second time — stock permanently wrong, then
+      // silently dropped once retryCount exceeded the consumer's limit.
+      // Rolling back on failure means the retry starts from a clean slate.
+      const applyStockDeltas = async (sign: 1 | -1) => {
+        await inventoryService.em.transactional(async (innerEm) => {
+          for (const item of event.items) {
+            await inventoryService.adjustStock(
+              {
+                variantId: item.variantId,
+                delta: sign * item.quantity
+              },
+              innerEm
+            );
+          }
+        });
+      };
+
       if (event.toStatus === OrderStatus.PAID) {
-        for (const item of event.items) {
-          await inventoryService.adjustStock({
-            variantId: item.variantId,
-            delta: -item.quantity
-          });
-        }
+        await applyStockDeltas(-1);
       } else if (
         event.toStatus === OrderStatus.CANCELLED &&
         event.fromStatus === OrderStatus.PAID
@@ -48,12 +64,7 @@ const processOrderEvents: WorkerProcessFunction<OrderEventRecord> = async (
         // cancelling directly from pending never touched stock (found by
         // testing: a pending->cancelled order was blindly restocking
         // anyway, inflating stock for something that was never removed).
-        for (const item of event.items) {
-          await inventoryService.adjustStock({
-            variantId: item.variantId,
-            delta: item.quantity
-          });
-        }
+        await applyStockDeltas(1);
       }
 
       event.processed = true;


### PR DESCRIPTION
Completes the core purchase loop. Stacks on #239 (payment providers).

- `checkout.controller.ts` — cart → order in one call. Stock validated up front so a customer never pays for something unavailable; lines priced from the variant's current price at purchase time, not cart time.
- `StripeTaxService` (real Stripe Tax, with a flagged flat-rate fallback) and `FlatRateShippingService`.
- `worker.ts` — order-event consumer: decrements inventory on PAID, restocks on PAID → CANCELLED.
- `__test__/purchaseLoop.test.ts` — catalog import → cart → order → full legal transition chain → illegal transition rejected. Needs Docker/testcontainers to execute (same constraint as billing-stripe's e2e); typechecks clean here.
- `domain/schemas/checkout.schema.ts` — hoisted the inline `ShippingAddressSchema` out of the controller, per the review feedback on #221.

**Deviation worth review:** the parked `checkout.controller.ts` has hard dependencies on `PromoCodeService` and `GiftCardService`, which are a later phase. Rather than pull those in, this strips the promo/gift-card branches and hardcodes `discountCents`/`giftCardCents` to 0, with the body schema adjusted to match. The order entity already carries those fields, so nothing downstream changes shape. A follow-up promotions PR wires them back in. Flagging explicitly since it changes the checkout request shape vs. the parked version.

**Also still missing from the stack:** `webhook.controller.ts` — so `confirmPayment`/`failPayment` have no caller yet. Worth its own PR.

0 typecheck errors, eslint clean.

---

### Update — worker restock correctness (post-review)

`worker.ts` now restocks inventory on cancellation from **PAID or FULFILLED** (not just PAID). `ORDER_TRANSITIONS` makes `FULFILLED → CANCELLED` legal, and stock is decremented once at PAID — so without this, an order cancelled after fulfillment would never restock (permanent inventory loss). Fixed here where the restock logic lives.