### PR TITLE
Add Stripe Connect platform mode (direct charges, zero-fee dial)

### DIFF
--- a/blueprint/ecommerce-stripe/__test__/webhookEvent.test.ts
+++ b/blueprint/ecommerce-stripe/__test__/webhookEvent.test.ts
@@ -1,7 +1,11 @@
 import { OpenTelemetryCollector } from '@forklaunch/core/http';
 import { randomUUID } from 'crypto';
 import { EntityManager } from '@mikro-orm/core';
-import { cleanupTestDatabase, setupTestDatabase, TestSetupResult } from './test-utils';
+import {
+  cleanupTestDatabase,
+  setupTestDatabase,
+  TestSetupResult
+} from './test-utils';
 
 /**
  * Regression test for the webhook idempotency gate (ECOM-10).
@@ -35,9 +39,8 @@ describe('WebhookEventService idempotency gate', () => {
   }, 30000);
 
   async function makeService() {
-    const { WebhookEventService } = await import(
-      '../domain/services/webhookEvent.service'
-    );
+    const { WebhookEventService } =
+      await import('../domain/services/webhookEvent.service');
     const em = setup.orm!.em.fork() as unknown as EntityManager;
     return {
       service: new WebhookEventService(

--- a/blueprint/ecommerce-stripe/__test__/webhookEvent.test.ts
+++ b/blueprint/ecommerce-stripe/__test__/webhookEvent.test.ts
@@ -1,5 +1,5 @@
+import { randomUUID } from 'node:crypto';
 import { OpenTelemetryCollector } from '@forklaunch/core/http';
-import { randomUUID } from 'crypto';
 import { EntityManager } from '@mikro-orm/core';
 import {
   cleanupTestDatabase,

--- a/blueprint/ecommerce-stripe/__test__/webhookEvent.test.ts
+++ b/blueprint/ecommerce-stripe/__test__/webhookEvent.test.ts
@@ -1,0 +1,115 @@
+import { OpenTelemetryCollector } from '@forklaunch/core/http';
+import { randomUUID } from 'crypto';
+import { EntityManager } from '@mikro-orm/core';
+import { cleanupTestDatabase, setupTestDatabase, TestSetupResult } from './test-utils';
+
+/**
+ * Regression test for the webhook idempotency gate (ECOM-10).
+ *
+ * The bug this pins: beginProcessing originally claimed events with
+ * `em.insert(WebhookEvent, {...})`. em.insert() is a raw fast-path that
+ * bypasses the unit of work, so sqlBaseProperties' onCreate hooks
+ * (id/createdAt/updatedAt) never ran and the INSERT reached Postgres with a
+ * null id -> NotNullConstraintViolation -> every provider webhook returned
+ * 500 and no order could ever transition to PAID via a real payment. The
+ * purchase-loop E2E never caught it because it drives order transitions
+ * directly and never walks the webhook path.
+ *
+ * The service is constructed directly on the harness's connected ORM (the
+ * same seam the DI factory uses) rather than resolved through the container:
+ * resolving the EntityManager token inside the test harness hits the known
+ * pre-existing Orm.em harness quirk that live servers don't have, and this
+ * test exists to pin insert-vs-create semantics, not container wiring.
+ */
+describe('WebhookEventService idempotency gate', () => {
+  let setup: TestSetupResult;
+
+  // 180s: the Postgres+Redis testcontainers can take well over a minute to
+  // pull/start on a loaded machine; purchaseLoop pays the same cost.
+  beforeAll(async () => {
+    setup = await setupTestDatabase();
+  }, 180000);
+
+  afterAll(async () => {
+    await cleanupTestDatabase();
+  }, 30000);
+
+  async function makeService() {
+    const { WebhookEventService } = await import(
+      '../domain/services/webhookEvent.service'
+    );
+    const em = setup.orm!.em.fork() as unknown as EntityManager;
+    return {
+      service: new WebhookEventService(
+        em,
+        new OpenTelemetryCollector('ecommerce-webhook-test', 'info')
+      ),
+      em
+    };
+  }
+
+  it('claims a new event with a generated id (regression: em.insert sent null id)', async () => {
+    const { WebhookEvent } = await import('../persistence/entities');
+    const { service, em } = await makeService();
+    const providerEventId = `evt_${randomUUID()}`;
+
+    // With the em.insert() bug this line threw NotNullConstraintViolation
+    // (null id) instead of returning 'new'.
+    const outcome = await service.beginProcessing({
+      provider: 'stripe',
+      providerEventId,
+      eventType: 'payment_intent.succeeded'
+    });
+    expect(outcome).toBe('new');
+
+    const row = await em.fork().findOneOrFail(WebhookEvent, {
+      provider: 'stripe',
+      providerEventId
+    });
+    // The heart of the regression: the row must carry a generated id.
+    expect(row.id).toBeTruthy();
+    expect(row.processed).toBe(false);
+  });
+
+  it('keeps redelivery semantics: retry before markProcessed, already-processed after', async () => {
+    const { service } = await makeService();
+    const providerEventId = `evt_${randomUUID()}`;
+    const claim = () =>
+      service.beginProcessing({
+        provider: 'stripe',
+        providerEventId,
+        eventType: 'charge.succeeded'
+      });
+
+    expect(await claim()).toBe('new');
+    // Same event again before processing finished (crash/redelivery window):
+    // safe — and necessary — to process again.
+    expect(await claim()).toBe('retry');
+
+    await service.markProcessed({ provider: 'stripe', providerEventId });
+    // Post-completion redelivery is a no-op.
+    expect(await claim()).toBe('already-processed');
+  });
+
+  it('scopes idempotency per provider: same event id from another provider is new', async () => {
+    const { service } = await makeService();
+    const providerEventId = `evt_${randomUUID()}`;
+
+    expect(
+      await service.beginProcessing({
+        provider: 'stripe',
+        providerEventId,
+        eventType: 'payment_intent.succeeded'
+      })
+    ).toBe('new');
+    // providerEventId alone is only unique per provider (composite
+    // constraint) — PayPal reusing Stripe's id string must not collide.
+    expect(
+      await service.beginProcessing({
+        provider: 'paypal',
+        providerEventId,
+        eventType: 'PAYMENT.CAPTURE.COMPLETED'
+      })
+    ).toBe('new');
+  });
+});

--- a/blueprint/ecommerce-stripe/__test__/webhookEvent.test.ts
+++ b/blueprint/ecommerce-stripe/__test__/webhookEvent.test.ts
@@ -8,7 +8,7 @@ import {
 } from './test-utils';
 
 /**
- * Regression test for the webhook idempotency gate (ECOM-10).
+ * Regression test for the webhook idempotency gate.
  *
  * The bug this pins: beginProcessing originally claimed events with
  * `em.insert(WebhookEvent, {...})`. em.insert() is a raw fast-path that
@@ -39,8 +39,9 @@ describe('WebhookEventService idempotency gate', () => {
   }, 30000);
 
   async function makeService() {
-    const { WebhookEventService } =
-      await import('../domain/services/webhookEvent.service');
+    const { WebhookEventService } = await import(
+      '../domain/services/webhookEvent.service'
+    );
     const em = setup.orm!.em.fork() as unknown as EntityManager;
     return {
       service: new WebhookEventService(

--- a/blueprint/ecommerce-stripe/registrations.ts
+++ b/blueprint/ecommerce-stripe/registrations.ts
@@ -151,6 +151,25 @@ const environmentConfig = configInjector.chain({
     type: string,
     value: getEnvVar('STRIPE_API_KEY')
   },
+  /** Stripe Connect (platform) mode — optional. When set, this deploy's
+   *  charges are DIRECT charges on the merchant's connected account
+   *  (acct_...): the merchant is merchant-of-record and settles the funds
+   *  themselves. When unset, bring-your-own-key mode is unchanged: the
+   *  STRIPE_API_KEY's own account is the merchant. */
+  STRIPE_CONNECTED_ACCOUNT_ID: {
+    lifetime: Lifetime.Singleton,
+    type: optional(string),
+    value: getEnvVar('STRIPE_CONNECTED_ACCOUNT_ID') ?? undefined
+  },
+  /** Platform fee in basis points, applied only in Connect mode. Defaults
+   *  to 0 — the launch business model takes NO per-transaction markup
+   *  ("payments flat at launch", Guild deck); this is a dial for a future
+   *  deliberate decision, not a revenue assumption. */
+  STRIPE_PLATFORM_FEE_BPS: {
+    lifetime: Lifetime.Singleton,
+    type: optional(string),
+    value: getEnvVar('STRIPE_PLATFORM_FEE_BPS') ?? undefined
+  },
   /** Stripe's webhook signing secret (`whsec_...`) — used by
    *  stripe.webhooks.constructEvent to verify `stripe-signature`, never to
    *  call the Stripe API itself (that's STRIPE_API_KEY). Already
@@ -374,7 +393,13 @@ const serviceDependencies = runtimeDependencies.chain({
       PaymentDtoTypes
     >,
     factory: (
-      { StripeClient, EntityManager, OtelCollector },
+      {
+        StripeClient,
+        EntityManager,
+        OtelCollector,
+        STRIPE_CONNECTED_ACCOUNT_ID,
+        STRIPE_PLATFORM_FEE_BPS
+      },
       context,
       resolve
     ) =>
@@ -385,7 +410,17 @@ const serviceDependencies = runtimeDependencies.chain({
           : EntityManager,
         OtelCollector,
         schemaValidator,
-        { PaymentMapper, CreatePaymentMapper }
+        { PaymentMapper, CreatePaymentMapper },
+        STRIPE_CONNECTED_ACCOUNT_ID
+          ? {
+              connect: {
+                connectedAccountId: STRIPE_CONNECTED_ACCOUNT_ID,
+                platformFeeBps: STRIPE_PLATFORM_FEE_BPS
+                  ? Number(STRIPE_PLATFORM_FEE_BPS)
+                  : 0
+              }
+            }
+          : undefined
       )
   },
   /**

--- a/blueprint/ecommerce-stripe/registrations.ts
+++ b/blueprint/ecommerce-stripe/registrations.ts
@@ -331,7 +331,11 @@ const serviceDependencies = runtimeDependencies.chain({
   },
   ProductService: {
     lifetime: Lifetime.Scoped,
-    type: BaseProductService<SchemaValidator, ProductMapperTypes, ProductDtoTypes>,
+    type: BaseProductService<
+      SchemaValidator,
+      ProductMapperTypes,
+      ProductDtoTypes
+    >,
     factory: ({ EntityManager, OtelCollector }, context, resolve) =>
       new BaseProductService(
         context?.entityManagerOptions
@@ -344,7 +348,11 @@ const serviceDependencies = runtimeDependencies.chain({
   },
   VariantService: {
     lifetime: Lifetime.Scoped,
-    type: BaseVariantService<SchemaValidator, VariantMapperTypes, VariantDtoTypes>,
+    type: BaseVariantService<
+      SchemaValidator,
+      VariantMapperTypes,
+      VariantDtoTypes
+    >,
     factory: ({ EntityManager, OtelCollector }, context, resolve) =>
       new BaseVariantService(
         context?.entityManagerOptions
@@ -453,7 +461,10 @@ const serviceDependencies = runtimeDependencies.chain({
         // PaypalOrder; the cast bridges the two provider-specific static
         // types over one shared runtime mapper object, same as
         // StripePaymentService does internally for its own 3rd-arg type.
-        { PaymentMapper, CreatePaymentMapper } as unknown as ConstructorParameters<
+        {
+          PaymentMapper,
+          CreatePaymentMapper
+        } as unknown as ConstructorParameters<
           typeof PaypalPaymentService<
             SchemaValidator,
             PaymentMapperTypes,

--- a/blueprint/ecommerce-stripe/registrations.ts
+++ b/blueprint/ecommerce-stripe/registrations.ts
@@ -151,6 +151,25 @@ const environmentConfig = configInjector.chain({
     type: string,
     value: getEnvVar('STRIPE_API_KEY')
   },
+  /** Stripe Connect (platform) mode — optional. When set, this deploy's
+   *  charges are DIRECT charges on the merchant's connected account
+   *  (acct_...): the merchant is merchant-of-record and settles the funds
+   *  themselves. When unset, bring-your-own-key mode is unchanged: the
+   *  STRIPE_API_KEY's own account is the merchant. */
+  STRIPE_CONNECTED_ACCOUNT_ID: {
+    lifetime: Lifetime.Singleton,
+    type: optional(string),
+    value: getEnvVar('STRIPE_CONNECTED_ACCOUNT_ID') ?? undefined
+  },
+  /** Platform fee in basis points, applied only in Connect mode. Defaults
+   *  to 0 — the launch business model takes NO per-transaction markup
+   *  ("payments flat at launch", Guild deck); this is a dial for a future
+   *  deliberate decision, not a revenue assumption. */
+  STRIPE_PLATFORM_FEE_BPS: {
+    lifetime: Lifetime.Singleton,
+    type: optional(string),
+    value: getEnvVar('STRIPE_PLATFORM_FEE_BPS') ?? undefined
+  },
   /** Stripe's webhook signing secret (`whsec_...`) — used by
    *  stripe.webhooks.constructEvent to verify `stripe-signature`, never to
    *  call the Stripe API itself (that's STRIPE_API_KEY). Already
@@ -379,7 +398,13 @@ const serviceDependencies = runtimeDependencies.chain({
       PaymentDtoTypes
     >,
     factory: (
-      { StripeClient, EntityManager, OtelCollector },
+      {
+        StripeClient,
+        EntityManager,
+        OtelCollector,
+        STRIPE_CONNECTED_ACCOUNT_ID,
+        STRIPE_PLATFORM_FEE_BPS
+      },
       context,
       resolve
     ) =>
@@ -390,7 +415,17 @@ const serviceDependencies = runtimeDependencies.chain({
           : EntityManager,
         OtelCollector,
         schemaValidator,
-        { PaymentMapper, CreatePaymentMapper }
+        { PaymentMapper, CreatePaymentMapper },
+        STRIPE_CONNECTED_ACCOUNT_ID
+          ? {
+              connect: {
+                connectedAccountId: STRIPE_CONNECTED_ACCOUNT_ID,
+                platformFeeBps: STRIPE_PLATFORM_FEE_BPS
+                  ? Number(STRIPE_PLATFORM_FEE_BPS)
+                  : 0
+              }
+            }
+          : undefined
       )
   },
   /**

--- a/blueprint/implementations/ecommerce/stripe/__test__/connectFee.test.ts
+++ b/blueprint/implementations/ecommerce/stripe/__test__/connectFee.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { StripePaymentService } from '../services/payment.service';
+
+// Stripe requires application_fee_amount to be strictly less than the charge.
+// The fee comes from STRIPE_PLATFORM_FEE_BPS, so a bad value is an operator
+// mistake that would otherwise surface as a rejected PaymentIntent at a
+// customer's checkout rather than at startup.
+const build = (platformFeeBps?: number) =>
+  new StripePaymentService(
+    {} as never,
+    {} as never,
+    { warn: () => undefined } as never,
+    {} as never,
+    {} as never,
+    {
+      connect: { connectedAccountId: 'acct_test', platformFeeBps }
+    }
+  );
+
+describe('Stripe Connect platform fee validation', () => {
+  it('accepts the launch default of no fee', () => {
+    expect(() => build(0)).not.toThrow();
+    expect(() => build(undefined)).not.toThrow();
+  });
+
+  it('accepts a fee below the whole charge', () => {
+    expect(() => build(250)).not.toThrow();
+    expect(() => build(9999)).not.toThrow();
+  });
+
+  it('rejects 10000 bps, which would make the fee equal the charge', () => {
+    expect(() => build(10000)).toThrow(/0 to 9999/);
+  });
+
+  it('rejects a fee above the charge', () => {
+    expect(() => build(10001)).toThrow(/0 to 9999/);
+  });
+
+  it('rejects negative and non-integer values', () => {
+    expect(() => build(-1)).toThrow(/0 to 9999/);
+    expect(() => build(12.5)).toThrow(/0 to 9999/);
+    expect(() => build(Number.NaN)).toThrow(/0 to 9999/);
+  });
+});

--- a/blueprint/implementations/ecommerce/stripe/services/payment.service.ts
+++ b/blueprint/implementations/ecommerce/stripe/services/payment.service.ts
@@ -30,8 +30,7 @@ export class StripePaymentService<
   SchemaValidator extends AnySchemaValidator,
   Entities extends BasePaymentEntities,
   Dto extends BasePaymentDtos = BasePaymentDtos
-> implements PaymentService
-{
+> implements PaymentService {
   basePaymentService: BasePaymentService<SchemaValidator, Entities, Dto>;
   protected readonly stripeClient: Stripe;
   protected readonly em: EntityManager;
@@ -127,7 +126,9 @@ export class StripePaymentService<
     // merchant-of-record and keeps the funds. The platform fee is only
     // attached when non-zero — at launch it always is zero (no markup).
     const feeCents = this.connect
-      ? Math.round((paymentDto.amountCents * this.connect.platformFeeBps) / 10000)
+      ? Math.round(
+          (paymentDto.amountCents * this.connect.platformFeeBps) / 10000
+        )
       : 0;
     const paymentIntent = await this.stripeClient.paymentIntents.create(
       {

--- a/blueprint/implementations/ecommerce/stripe/services/payment.service.ts
+++ b/blueprint/implementations/ecommerce/stripe/services/payment.service.ts
@@ -68,9 +68,27 @@ export class StripePaymentService<
     this.stripeClient = stripeClient;
     this.em = em;
     if (options?.connect) {
+      // Validate the fee dial here rather than trusting the caller: it comes
+      // from an env var, and every bad value fails SILENTLY downstream
+      // otherwise. A non-numeric STRIPE_PLATFORM_FEE_BPS makes Number()
+      // return NaN, `feeCents > 0` is then false, and the application fee is
+      // quietly omitted — an operator who meant to charge a fee would get
+      // none, with nothing logged. A negative value does the same. Failing
+      // at construction turns a silent misconfiguration into a startup error.
+      const platformFeeBps = options.connect.platformFeeBps ?? 0;
+      if (
+        !Number.isInteger(platformFeeBps) ||
+        platformFeeBps < 0 ||
+        platformFeeBps > 10000
+      ) {
+        throw new Error(
+          `Invalid Stripe platform fee: expected an integer between 0 and 10000 basis points, got ${platformFeeBps}. ` +
+            'Check STRIPE_PLATFORM_FEE_BPS.'
+        );
+      }
       this.connect = {
         connectedAccountId: options.connect.connectedAccountId,
-        platformFeeBps: options.connect.platformFeeBps ?? 0
+        platformFeeBps
       };
     }
     // CreatePaymentMapper.toEntity's 3rd param is concretely Stripe.PaymentIntent

--- a/blueprint/implementations/ecommerce/stripe/services/payment.service.ts
+++ b/blueprint/implementations/ecommerce/stripe/services/payment.service.ts
@@ -35,6 +35,10 @@ export class StripePaymentService<
   basePaymentService: BasePaymentService<SchemaValidator, Entities, Dto>;
   protected readonly stripeClient: Stripe;
   protected readonly em: EntityManager;
+  protected readonly connect?: {
+    connectedAccountId: string;
+    platformFeeBps: number;
+  };
 
   constructor(
     stripeClient: Stripe,
@@ -44,10 +48,31 @@ export class StripePaymentService<
     mappers: StripePaymentMappers<Entities, Dto>,
     options?: {
       telemetry?: TelemetryOptions;
+      /**
+       * Stripe Connect (platform) mode. When set, PaymentIntents are created
+       * as DIRECT charges on the merchant's connected account — the merchant
+       * is the merchant of record and settles the funds — with
+       * `application_fee_amount` computed from platformFeeBps. The launch
+       * business model is NO markup (fee 0, see the Guild deck: "payments
+       * flat at launch"), so platformFeeBps defaults to 0 and the fee is
+       * omitted entirely; it exists as a dial, not a revenue assumption.
+       * When absent, behavior is unchanged: the deploy's own STRIPE_API_KEY
+       * account is the merchant (bring-your-own-key mode).
+       */
+      connect?: {
+        connectedAccountId: string;
+        platformFeeBps?: number;
+      };
     }
   ) {
     this.stripeClient = stripeClient;
     this.em = em;
+    if (options?.connect) {
+      this.connect = {
+        connectedAccountId: options.connect.connectedAccountId,
+        platformFeeBps: options.connect.platformFeeBps ?? 0
+      };
+    }
     // CreatePaymentMapper.toEntity's 3rd param is concretely Stripe.PaymentIntent
     // here (narrower than base's generic ...args: unknown[]) — safe at runtime,
     // this cast just satisfies the base constructor's looser declared type.
@@ -79,11 +104,26 @@ export class StripePaymentService<
     paymentDto: CreatePaymentDto,
     em?: EntityManager
   ): Promise<Dto['PaymentMapper'] & { clientSecret?: string }> {
-    const paymentIntent = await this.stripeClient.paymentIntents.create({
-      amount: paymentDto.amountCents,
-      currency: paymentDto.currency,
-      metadata: { orderId: paymentDto.orderId }
-    });
+    // In Connect mode this is a DIRECT charge: created on the merchant's
+    // connected account (stripeAccount request option), so the merchant is
+    // merchant-of-record and keeps the funds. The platform fee is only
+    // attached when non-zero — at launch it always is zero (no markup).
+    const feeCents = this.connect
+      ? Math.round((paymentDto.amountCents * this.connect.platformFeeBps) / 10000)
+      : 0;
+    const paymentIntent = await this.stripeClient.paymentIntents.create(
+      {
+        amount: paymentDto.amountCents,
+        currency: paymentDto.currency,
+        metadata: { orderId: paymentDto.orderId },
+        ...(this.connect && feeCents > 0
+          ? { application_fee_amount: feeCents }
+          : {})
+      },
+      this.connect
+        ? { stripeAccount: this.connect.connectedAccountId }
+        : undefined
+    );
     const payment = await this.basePaymentService.createPayment(
       paymentDto,
       em ?? this.em,

--- a/blueprint/implementations/ecommerce/stripe/services/payment.service.ts
+++ b/blueprint/implementations/ecommerce/stripe/services/payment.service.ts
@@ -30,10 +30,12 @@ export class StripePaymentService<
   SchemaValidator extends AnySchemaValidator,
   Entities extends BasePaymentEntities,
   Dto extends BasePaymentDtos = BasePaymentDtos
-> implements PaymentService {
+> implements PaymentService
+{
   basePaymentService: BasePaymentService<SchemaValidator, Entities, Dto>;
   protected readonly stripeClient: Stripe;
   protected readonly em: EntityManager;
+  protected readonly openTelemetryCollector: OpenTelemetryCollector<MetricsDefinition>;
   protected readonly connect?: {
     connectedAccountId: string;
     platformFeeBps: number;
@@ -66,6 +68,7 @@ export class StripePaymentService<
   ) {
     this.stripeClient = stripeClient;
     this.em = em;
+    this.openTelemetryCollector = openTelemetryCollector;
     if (options?.connect) {
       // Validate the fee dial here rather than trusting the caller: it comes
       // from an env var, and every bad value fails SILENTLY downstream
@@ -75,13 +78,16 @@ export class StripePaymentService<
       // none, with nothing logged. A negative value does the same. Failing
       // at construction turns a silent misconfiguration into a startup error.
       const platformFeeBps = options.connect.platformFeeBps ?? 0;
+      // Upper bound is exclusive: Stripe requires application_fee_amount to be
+      // strictly less than the charge, so 10000 bps (the whole charge) is never
+      // a usable value and is rejected here rather than at the first checkout.
       if (
         !Number.isInteger(platformFeeBps) ||
         platformFeeBps < 0 ||
-        platformFeeBps > 10000
+        platformFeeBps >= 10000
       ) {
         throw new Error(
-          `Invalid Stripe platform fee: expected an integer between 0 and 10000 basis points, got ${platformFeeBps}. ` +
+          `Invalid Stripe platform fee: expected an integer from 0 to 9999 basis points, got ${platformFeeBps}. ` +
             'Check STRIPE_PLATFORM_FEE_BPS.'
         );
       }
@@ -125,11 +131,31 @@ export class StripePaymentService<
     // connected account (stripeAccount request option), so the merchant is
     // merchant-of-record and keeps the funds. The platform fee is only
     // attached when non-zero — at launch it always is zero (no markup).
-    const feeCents = this.connect
+    const requestedFeeCents = this.connect
       ? Math.round(
           (paymentDto.amountCents * this.connect.platformFeeBps) / 10000
         )
       : 0;
+    // application_fee_amount has to stay strictly below the charge. The
+    // constructor already rejects 10000 bps, but rounding can still reach the
+    // full amount on a small enough charge (1 cent at 9999 bps rounds to 1),
+    // and Stripe would reject the PaymentIntent outright. Cap it so a fee
+    // setting cannot fail a customer's checkout, and record it when it bites.
+    const feeCents = Math.min(
+      requestedFeeCents,
+      Math.max(paymentDto.amountCents - 1, 0)
+    );
+    if (feeCents !== requestedFeeCents) {
+      this.openTelemetryCollector.warn(
+        'Stripe platform fee capped below the charge amount',
+        {
+          orderId: paymentDto.orderId,
+          amountCents: paymentDto.amountCents,
+          requestedFeeCents,
+          appliedFeeCents: feeCents
+        }
+      );
+    }
     const paymentIntent = await this.stripeClient.paymentIntents.create(
       {
         amount: paymentDto.amountCents,

--- a/blueprint/implementations/ecommerce/stripe/vitest.config.ts
+++ b/blueprint/implementations/ecommerce/stripe/vitest.config.ts
@@ -3,7 +3,6 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     globals: true,
-    exclude: ['**/lib/**', '**/dist/**', '**/node_modules/**'],
-    setupFiles: ['__test__/test-utils.ts']
+    exclude: ['**/lib/**', '**/dist/**', '**/node_modules/**']
   }
 });


### PR DESCRIPTION
Tops the ecommerce stack (based on #242). Adds an **optional** Stripe Connect platform mode.

## Two models, one env switch (no code fork)
- **Bring-your-own (DEFAULT — env unset):** the deploy's `STRIPE_API_KEY` is the merchant's own account. Their money, their Stripe. Zero platform dependency — ships today.
- **Connect (`STRIPE_CONNECTED_ACCOUNT_ID` set):** merchant onboarded through the platform; checkout becomes a **direct charge on their connected account** (merchant of record, keeps the funds) with `application_fee_amount` from `STRIPE_PLATFORM_FEE_BPS` (**default 0 — no markup**, per the Guild deck 'payments flat at launch'). The fee is a dial for a future decision, not a launch assumption.

**Recommended rollout:** launch bring-your-own (no Rohin/legal dependency), make Connect the default as the platform grows and Connect is enabled on the real account.

**Verified live** against a sandbox connected account: module checkout created the PaymentIntent on the merchant account (provably absent from the platform account), $0 application fee, test-card payment succeeded.

Built on Connect **v1 accounts** (GA, SDK-supported); v2 core accounts is preview — migration when it GAs only touches onboarding, never the charge path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Stripe Connect direct charges on connected merchant accounts.
  * Added optional platform fee configuration using basis points.
  * Payment processing continues to work as before when Connect is not configured.

* **Bug Fixes**
  * Improved webhook handling to prevent duplicate event processing and correctly manage retries.
  * Ensured identical event IDs from different payment providers remain isolated.

* **Validation**
  * Invalid platform fee settings are rejected during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->