### PR TITLE
docs(ecommerce-stripe): merchant setup README and .env.example

### DIFF
--- a/blueprint/ecommerce-stripe/.env.example
+++ b/blueprint/ecommerce-stripe/.env.example
@@ -1,0 +1,82 @@
+# ecommerce-stripe — environment configuration
+#
+# Copy to .env.local and fill in. Every value below is read at startup by
+# registrations.ts / mikro-orm.config.ts; the service exits on the first
+# missing required variable rather than failing later at request time.
+#
+# A scaffolded project (forklaunch init … → ecommerce-stripe) gets most of
+# this generated for you with `replace-with-…` placeholders. This file is the
+# reference for what each one is and where to get it.
+
+# ── Runtime ──────────────────────────────────────────────────────────────
+NODE_ENV=development
+HOST=localhost
+PORT=8000
+VERSION=v1                 # optional, defaults to v1 — URL version prefix
+DOCS_PATH=/docs            # optional, defaults to /docs — OpenAPI UI path
+DOTENV_FILE_PATH=.env.local
+
+# ── Database (Postgres) ──────────────────────────────────────────────────
+# The schema is created by the committed migration: `pnpm migrate:up`.
+DB_NAME=ecommerce
+DB_HOST=localhost
+DB_PORT=5432
+DB_USER=postgres
+DB_PASSWORD=postgres
+
+# ── Redis ────────────────────────────────────────────────────────────────
+# Required, not optional: the cart is a Redis-backed read-through cache and
+# order events are published to a Redis-backed queue that the worker consumes.
+REDIS_URL=redis://localhost:6379
+ORDER_EVENT_QUEUE=order-events
+
+# ── Secrets ──────────────────────────────────────────────────────────────
+# ENCRYPTION_KEY is HKDF input key material for field-level encryption — any
+# non-empty string works, but changing it makes existing encrypted rows
+# unreadable, so treat it as permanent per environment.
+ENCRYPTION_KEY=
+# Signs the /catalog-import endpoint (HMAC). The migration tool must send the
+# same secret.
+HMAC_SECRET_KEY=
+# Public JWKS endpoint used to verify caller JWTs.
+JWKS_PUBLIC_KEY_URL=http://localhost:9000/.well-known/jwks.json
+
+# ── Stripe ───────────────────────────────────────────────────────────────
+# Secret key from https://dashboard.stripe.com/apikeys (sk_test_… while
+# testing, sk_live_… in production).
+STRIPE_API_KEY=
+# Signing secret for the webhook endpoint you register at
+# https://<your-host>/webhook/stripe — Stripe shows it as whsec_…
+# Without it, payment confirmations cannot be verified and orders never
+# reach `paid`.
+STRIPE_WEBHOOK_SECRET=
+
+# ── Stripe Connect (optional — platform mode) ────────────────────────────
+# Leave both unset for the normal case: STRIPE_API_KEY's own account is the
+# merchant of record and receives the funds.
+#
+# Set STRIPE_CONNECTED_ACCOUNT_ID (acct_…) to charge on a connected account
+# instead — a direct charge, so the merchant stays merchant of record and
+# settles their own funds.
+STRIPE_CONNECTED_ACCOUNT_ID=
+# Platform fee in basis points, applied only in Connect mode. Defaults to 0
+# (no fee is attached at all) — no markup is taken on merchant sales.
+STRIPE_PLATFORM_FEE_BPS=
+
+# ── PayPal ───────────────────────────────────────────────────────────────
+# From a Merchant app at https://developer.paypal.com/dashboard/applications/
+# Use the Sandbox tab while testing, Live for production.
+PAYPAL_CLIENT_ID=
+PAYPAL_CLIENT_SECRET=
+# Sandbox: https://api-m.sandbox.paypal.com
+# Live:    https://api-m.paypal.com
+PAYPAL_BASE_URL=https://api-m.sandbox.paypal.com
+# Webhook ID from the same app page, after adding a webhook pointing at
+# https://<your-host>/webhook/paypal. Used to verify inbound event
+# signatures; a missing or wrong value makes every PayPal webhook fail closed.
+PAYPAL_WEBHOOK_ID=
+
+# ── Telemetry ────────────────────────────────────────────────────────────
+OTEL_SERVICE_NAME=ecommerce
+OTEL_LEVEL=info            # optional, defaults to info
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318

--- a/blueprint/ecommerce-stripe/README.md
+++ b/blueprint/ecommerce-stripe/README.md
@@ -1,0 +1,95 @@
+# ecommerce-stripe
+
+The commerce engine: catalog → cart → checkout → payment → order → fulfilment,
+with inventory that can't oversell and payments through Stripe or PayPal.
+
+## What you need running
+
+- **Postgres** — orders, products, inventory, payments
+- **Redis** — the cart cache *and* the order-event queue. Not optional; the
+  service won't start without it.
+- A **Stripe** account, a **PayPal** app, or both
+
+## Setup
+
+```bash
+cp .env.example .env.local   # then fill it in — every variable is explained there
+pnpm install
+pnpm dev                     # runs migrate:up, then serves on http://localhost:8000
+pnpm worker                  # separate process — see below
+```
+
+`pnpm dev` applies the committed migration (8 tables) before starting; run
+`pnpm migrate:up` on its own if you only want the schema.
+
+**The worker is not optional.** Order transitions publish events to Redis, and
+the worker is what consumes them to adjust inventory. Without it running,
+orders will reach `paid` but stock never decrements.
+
+## Getting your payment credentials
+
+**Stripe** — from [dashboard.stripe.com/apikeys](https://dashboard.stripe.com/apikeys):
+the secret key (`sk_test_…` / `sk_live_…`) into `STRIPE_API_KEY`. Then add a
+webhook endpoint pointing at `https://<your-host>/webhook/stripe` and copy its
+signing secret (`whsec_…`) into `STRIPE_WEBHOOK_SECRET`.
+
+**PayPal** — create a *Merchant* app at
+[developer.paypal.com](https://developer.paypal.com/dashboard/applications/)
+(Sandbox tab while testing). Copy the Client ID and Secret. On the same page
+add a webhook pointing at `https://<your-host>/webhook/paypal`, subscribe to
+`PAYMENT.CAPTURE.COMPLETED` and `PAYMENT.CAPTURE.DENIED`, and copy the Webhook
+ID.
+
+> Webhooks need a **publicly reachable HTTPS URL**, so you can only register
+> them once the store is deployed. Until then, use the Stripe CLI
+> (`stripe listen --forward-to localhost:8000/webhook/stripe`) for local
+> testing. **Payments do not complete without webhooks** — the provider
+> confirms the charge asynchronously, and that callback is what moves an order
+> to `paid`.
+
+## How a purchase flows
+
+```
+POST /catalog-import   import products (HMAC-signed — used by the migration tool)
+GET  /product          browse
+POST /cart             create a cart
+POST /cart/items       add items
+POST /checkout         validates stock, creates the order + payment intent
+     ↓ customer pays with the provider
+POST /webhook/stripe   provider confirms → order becomes `paid`
+     ↓ order event → Redis queue
+     worker            decrements inventory
+```
+
+Orders move `pending → paid → fulfilled → shipped → delivered`. `cancelled` is
+reachable from `pending`, `paid` and `fulfilled` — but **not** once an order is
+`shipped`, which can only go on to `delivered`. Illegal transitions are
+rejected. Stock is validated at checkout so a customer never pays for an
+out-of-stock item, and the decrement itself is an atomic conditional update, so
+concurrent orders can't oversell.
+
+## Choosing a payment provider
+
+Checkout takes an optional `provider` (`stripe` by default, or `paypal`). Both
+can be enabled at once — the customer's choice decides which is used per order.
+
+## Bring-your-own vs. platform mode
+
+By default the account behind `STRIPE_API_KEY` is the merchant of record and
+receives the funds — the merchant brings their own Stripe account.
+
+Setting `STRIPE_CONNECTED_ACCOUNT_ID` (an `acct_…` from Stripe Connect)
+switches to a **direct charge on that connected account**: the merchant is
+still merchant of record and still settles their own funds.
+`STRIPE_PLATFORM_FEE_BPS` defaults to `0`, so no application fee is attached
+and no cut is taken from merchant sales.
+
+## Testing
+
+```bash
+pnpm test
+```
+
+The suite uses testcontainers, so **Docker must be running**. It covers the
+full purchase loop (import → cart → order → transitions, including rejecting
+an illegal transition) and the webhook idempotency gate.

--- a/blueprint/ecommerce-stripe/README.md
+++ b/blueprint/ecommerce-stripe/README.md
@@ -16,7 +16,7 @@ with inventory that can't oversell and payments through Stripe or PayPal.
 cp .env.example .env.local   # then fill it in — every variable is explained there
 pnpm install
 pnpm dev                     # runs migrate:up, then serves on http://localhost:8000
-pnpm worker                  # separate process — see below
+pnpm dev:worker              # separate process — see below
 ```
 
 `pnpm dev` applies the committed migration (8 tables) before starting; run
@@ -25,6 +25,10 @@ pnpm worker                  # separate process — see below
 **The worker is not optional.** Order transitions publish events to Redis, and
 the worker is what consumes them to adjust inventory. Without it running,
 orders will reach `paid` but stock never decrements.
+
+It is a second process in production too, not just in development. Deploy
+`pnpm start` and `pnpm start:worker` alongside each other; running only the
+former gives you an API that takes orders and never adjusts stock.
 
 ## Getting your payment credentials
 
@@ -64,9 +68,18 @@ POST /webhook/stripe   provider confirms → order becomes `paid`
 Orders move `pending → paid → fulfilled → shipped → delivered`. `cancelled` is
 reachable from `pending`, `paid` and `fulfilled` — but **not** once an order is
 `shipped`, which can only go on to `delivered`. Illegal transitions are
-rejected. Stock is validated at checkout so a customer never pays for an
-out-of-stock item, and the decrement itself is an atomic conditional update, so
-concurrent orders can't oversell.
+rejected.
+
+Stock is checked at checkout, and the decrement the worker performs on `paid`
+is an atomic conditional update, so stock can never go negative.
+
+**Stock is not reserved at checkout, though.** The check is a read, and the
+decrement happens later, when payment is confirmed. Two orders for the last
+unit will both pass the check and both be charged; the first decrement
+succeeds and the second fails its condition. Nothing oversells the database,
+but a customer can be charged for an order that cannot be fulfilled, and today
+that surfaces only as a worker error in the logs. If you are selling scarce
+stock, reserve at checkout rather than relying on this.
 
 ## Choosing a payment provider
 


### PR DESCRIPTION
Tenth in stack #272, on top of #256.

The module requires **21 environment variables** and shipped with no README and no `.env.example` — a merchant scaffolding a store had no documented way to know what to configure or where to get it.

Adds:
- **`.env.example`** — every variable, what it's for, and where to obtain it (Stripe dashboard, PayPal developer app), including which are optional with defaults
- **`README.md`** — setup steps, the purchase flow, the order state machine, provider selection, and bring-your-own vs Connect platform mode

Two things called out explicitly because both are easy to miss and both look like bugs when missed:
- **Redis is mandatory** (cart cache + order-event queue), not an optional cache
- **The worker must run** — without it orders reach `paid` but inventory never decrements

Claims were checked against the code rather than assumed — which caught one error before it shipped: `cancelled` is reachable from `pending`/`paid`/`fulfilled` but **not** from `shipped`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)