### PR TITLE
fix(analyze): detect defineComplianceEntity + fp-builder entities

### DIFF
--- a/cli/src/core/static_analysis/entity_analyzer.rs
+++ b/cli/src/core/static_analysis/entity_analyzer.rs
@@ -37,7 +37,8 @@ pub struct EntityAnalyzer;
 
 impl EntityAnalyzer {
     /// Parse a TypeScript entity file and extract entity definitions.
-    /// Supports the v7 defineEntity() format:
+    /// Supports the v7 class-free entity factories `defineEntity()` (builder `p`) and
+    /// `defineComplianceEntity()` (builder `fp`, with per-property `.compliance(...)` tags):
     ///
     /// ```typescript
     /// export const User = defineEntity({
@@ -46,6 +47,15 @@ impl EntityAnalyzer {
     ///     ...sqlBaseProperties,
     ///     email: p.string().unique(),
     ///     organization: () => p.manyToOne(Organization).nullable(),
+    ///   },
+    /// });
+    ///
+    /// export const Profile = defineComplianceEntity({
+    ///   name: 'Profile',
+    ///   properties: {
+    ///     ...sqlBaseProperties,
+    ///     displayName: fp.string().compliance('pii'),
+    ///     retryCount: fp.integer().nullable().compliance('none'),
     ///   },
     /// });
     /// ```
@@ -88,11 +98,18 @@ impl EntityAnalyzer {
         Ok(entities)
     }
 
-    /// Check if an expression is a defineEntity() call
+    /// Check if an expression is a defineEntity() / defineComplianceEntity() call.
+    ///
+    /// Both are class-free entity factories with the same `{ name, properties }` shape; the
+    /// compliance variant (from `@forklaunch/core/persistence`) additionally tags each property with
+    /// a `.compliance(...)` classification and uses the `fp` builder instead of `p`. The framework's
+    /// own templates use `defineComplianceEntity` for the large majority of entities, so matching only
+    /// `defineEntity` silently dropped most entities from the analysis.
     fn is_define_entity_call(expr: &Expression) -> bool {
         if let Expression::CallExpression(call) = expr {
             if let Expression::Identifier(id) = &call.callee {
-                return id.name.as_str() == "defineEntity";
+                let name = id.name.as_str();
+                return name == "defineEntity" || name == "defineComplianceEntity";
             }
         }
         false
@@ -241,9 +258,11 @@ impl EntityAnalyzer {
         }
     }
 
-    /// Check if an expression is the `p` identifier (the property builder namespace)
+    /// Check if an expression is the property builder namespace at the base of a chain: `p` (plain
+    /// `defineEntity`) or `fp` (compliance `defineComplianceEntity`). Without accepting `fp`, every
+    /// compliance-entity property resolves to `unknown` because the walk never reaches its base type.
     fn is_p_identifier(expr: &Expression) -> bool {
-        matches!(expr, Expression::Identifier(id) if id.name.as_str() == "p")
+        matches!(expr, Expression::Identifier(id) if matches!(id.name.as_str(), "p" | "fp"))
     }
 
     /// Resolve the base type from a p.xxx() call
@@ -500,5 +519,68 @@ export type IUser = InferEntity<typeof User>;
         assert_eq!(org_prop.relation_type, Some(RelationType::ManyToOne));
         assert!(org_prop.is_nullable);
         assert_eq!(org_prop.type_name, "Organization");
+    }
+
+    #[test]
+    fn test_parse_define_compliance_entity() {
+        let dir = tempdir().unwrap();
+        let entity_path = dir.path().join("profile.entity.ts");
+
+        // Compliance entities use `defineComplianceEntity` + the `fp` builder + `.compliance(...)`
+        // tags. The framework's templates use this form for most entities, so the analyzer must
+        // parse it identically to `defineEntity` (the compliance tags are ignored, like any modifier).
+        write(
+            &entity_path,
+            r#"
+import { defineComplianceEntity, fp } from '@forklaunch/core/persistence';
+import type { InferEntity } from '@mikro-orm/core';
+import { sqlBaseProperties } from '@app/core';
+import { Organization } from './organization.entity';
+
+export const Profile = defineComplianceEntity({
+  name: 'Profile',
+  properties: {
+    ...sqlBaseProperties,
+    displayName: fp.string().compliance('pii'),
+    retryCount: fp.integer().nullable().compliance('none'),
+    organization: () => fp.manyToOne(Organization).nullable().compliance('none'),
+  },
+});
+
+export type Profile = InferEntity<typeof Profile>;
+"#,
+        )
+        .unwrap();
+
+        let entities = EntityAnalyzer::parse_entity_file(&entity_path).unwrap();
+        assert_eq!(entities.len(), 1);
+
+        let profile = &entities[0];
+        assert_eq!(profile.name, "Profile");
+        assert_eq!(profile.properties.len(), 3);
+
+        let display = profile
+            .properties
+            .iter()
+            .find(|p| p.name == "displayName")
+            .unwrap();
+        assert_eq!(display.type_name, "string"); // fp base type resolves (not "unknown")
+
+        let retry = profile
+            .properties
+            .iter()
+            .find(|p| p.name == "retryCount")
+            .unwrap();
+        assert_eq!(retry.type_name, "number");
+        assert!(retry.is_nullable);
+
+        let org = profile
+            .properties
+            .iter()
+            .find(|p| p.name == "organization")
+            .unwrap();
+        assert_eq!(org.relation_type, Some(RelationType::ManyToOne));
+        assert!(org.is_nullable);
+        assert_eq!(org.type_name, "Organization");
     }
 }


### PR DESCRIPTION
## Problem

`fl analyze` only recognized `defineEntity()` with the `p` property builder, so every entity declared with **`defineComplianceEntity()` + the `fp` builder** was silently dropped from the workspace snapshot.

That's the *dominant* pattern — the framework's own templates use `defineComplianceEntity` **28:2** over `defineEntity` (`cli/src/templates`). So most real data models came back empty:

- `observability-api` reported **1 of its 7** entities (only the one `defineEntity` file).
- Across a real `forklaunch-platform` workspace, analyze detected **1** entity instead of **57**.

Root cause, both in `entity_analyzer.rs`:
- `is_define_entity_call` matched only the literal `"defineEntity"`.
- `is_p_identifier` matched only the base builder `"p"`, so even if a compliance call were parsed, its property types would resolve to `"unknown"`.

## Fix

Two minimal broadenings:
- `is_define_entity_call` — also match `defineComplianceEntity` (identical `{ name, properties }` shape).
- `is_p_identifier` — also accept `fp` as the chain-base builder.

The per-property `.compliance(...)` classification tags need no special handling — they're ignored like any other chain modifier (`.unique()`, `.default()`, …).

## Tests

- New unit test `test_parse_define_compliance_entity` covering the `fp` builder, `.compliance(...)` tags, `.nullable()`, and a `manyToOne` relation. All 4 entity-analyzer tests pass.
- Verified end-to-end against `forklaunch-platform`: `observability-api` **1 → 7** entities; workspace total **1 → 57**; compliance-entity property types resolve to real types (not `unknown`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Static analysis now recognizes standard and compliance entity definitions.
  - Compliance entities support property builders, including scalar, nullable, and relational properties.
  - Property chains using supported builders are analyzed consistently, while compliance-specific modifiers are safely ignored.

- **Documentation**
  - Added guidance covering compliance entity property analysis.

- **Tests**
  - Added coverage for scalar, nullable, and relational compliance properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->