### PR TITLE
fix(testing): unblock the generated app E2E harness (fl#270)

### DIFF
--- a/blueprint/billing-base/__test__/test-utils.ts
+++ b/blueprint/billing-base/__test__/test-utils.ts
@@ -21,7 +21,13 @@ export const setupTestDatabase = async (): Promise<TestSetupResult> => {
   harness = new BlueprintTestHarness({
     getConfig: async () => {
       const { default: config } = await import('../mikro-orm.config');
-      return config;
+      // MikroORM.init() mutates options.discovery.skipSyncDiscovery = true on
+      // the object it receives. mikro-orm.config exports a single shared object
+      // that the app's own DI container also builds a MikroORM from, so letting
+      // the harness mutate it leaves the app's `new MikroORM(config)` with an
+      // undefined `.em` (every route then crashes on `Orm.em.fork`). Hand the
+      // harness its own discovery object so the mutation can't leak.
+      return { ...config, discovery: { ...config.discovery } };
     },
     databaseType: getEnvVar('DATABASE_TYPE') as DatabaseType,
     useMigrations: false,

--- a/blueprint/billing-stripe/__test__/test-utils.ts
+++ b/blueprint/billing-stripe/__test__/test-utils.ts
@@ -28,7 +28,13 @@ export const setupTestDatabase = async (): Promise<TestSetupResult> => {
   harness = new BlueprintTestHarness({
     getConfig: async () => {
       const { default: config } = await import('../mikro-orm.config');
-      return config;
+      // MikroORM.init() mutates options.discovery.skipSyncDiscovery = true on
+      // the object it receives. mikro-orm.config exports a single shared object
+      // that the app's own DI container also builds a MikroORM from, so letting
+      // the harness mutate it leaves the app's `new MikroORM(config)` with an
+      // undefined `.em` (every route then crashes on `Orm.em.fork`). Hand the
+      // harness its own discovery object so the mutation can't leak.
+      return { ...config, discovery: { ...config.discovery } };
     },
     databaseType: getEnvVar('DATABASE_TYPE') as DatabaseType,
     useMigrations: false,

--- a/blueprint/iam-base/__test__/test-utils.ts
+++ b/blueprint/iam-base/__test__/test-utils.ts
@@ -20,7 +20,13 @@ export const setupTestDatabase = async (): Promise<TestSetupResult> => {
   harness = new BlueprintTestHarness({
     getConfig: async () => {
       const { default: config } = await import('../mikro-orm.config');
-      return config;
+      // MikroORM.init() mutates options.discovery.skipSyncDiscovery = true on
+      // the object it receives. mikro-orm.config exports a single shared object
+      // that the app's own DI container also builds a MikroORM from, so letting
+      // the harness mutate it leaves the app's `new MikroORM(config)` with an
+      // undefined `.em` (every route then crashes on `Orm.em.fork`). Hand the
+      // harness its own discovery object so the mutation can't leak.
+      return { ...config, discovery: { ...config.discovery } };
     },
     databaseType: getEnvVar('DATABASE_TYPE') as DatabaseType,
     useMigrations: true,

--- a/blueprint/iam-better-auth/__test__/test-utils.ts
+++ b/blueprint/iam-better-auth/__test__/test-utils.ts
@@ -20,7 +20,13 @@ export const setupTestDatabase = async (): Promise<TestSetupResult> => {
   harness = new BlueprintTestHarness({
     getConfig: async () => {
       const { default: config } = await import('../mikro-orm.config');
-      return config;
+      // MikroORM.init() mutates options.discovery.skipSyncDiscovery = true on
+      // the object it receives. mikro-orm.config exports a single shared object
+      // that the app's own DI container also builds a MikroORM from, so letting
+      // the harness mutate it leaves the app's `new MikroORM(config)` with an
+      // undefined `.em` (every route then crashes on `Orm.em.fork`). Hand the
+      // harness its own discovery object so the mutation can't leak.
+      return { ...config, discovery: { ...config.discovery } };
     },
     databaseType: getEnvVar('DATABASE_TYPE') as DatabaseType,
     useMigrations: true,

--- a/blueprint/messaging-base/__test__/test-utils.ts
+++ b/blueprint/messaging-base/__test__/test-utils.ts
@@ -21,7 +21,13 @@ export const setupTestDatabase = async (): Promise<TestSetupResult> => {
   harness = new BlueprintTestHarness({
     getConfig: async () => {
       const { default: config } = await import('../mikro-orm.config');
-      return config;
+      // MikroORM.init() mutates options.discovery.skipSyncDiscovery = true on
+      // the object it receives. mikro-orm.config exports a single shared object
+      // that the app's own DI container also builds a MikroORM from, so letting
+      // the harness mutate it leaves the app's `new MikroORM(config)` with an
+      // undefined `.em` (every route then crashes on `Orm.em.fork`). Hand the
+      // harness its own discovery object so the mutation can't leak.
+      return { ...config, discovery: { ...config.discovery } };
     },
     databaseType: getEnvVar('DATABASE_TYPE') as DatabaseType,
     useMigrations: false,

--- a/blueprint/messaging-twilio/__test__/test-utils.ts
+++ b/blueprint/messaging-twilio/__test__/test-utils.ts
@@ -22,7 +22,13 @@ export const setupTestDatabase = async (): Promise<TestSetupResult> => {
   harness = new BlueprintTestHarness({
     getConfig: async () => {
       const { default: config } = await import('../mikro-orm.config');
-      return config;
+      // MikroORM.init() mutates options.discovery.skipSyncDiscovery = true on
+      // the object it receives. mikro-orm.config exports a single shared object
+      // that the app's own DI container also builds a MikroORM from, so letting
+      // the harness mutate it leaves the app's `new MikroORM(config)` with an
+      // undefined `.em` (every route then crashes on `Orm.em.fork`). Hand the
+      // harness its own discovery object so the mutation can't leak.
+      return { ...config, discovery: { ...config.discovery } };
     },
     databaseType: getEnvVar('DATABASE_TYPE') as DatabaseType,
     useMigrations: false,

--- a/blueprint/sample-worker/__test__/test-utils.ts
+++ b/blueprint/sample-worker/__test__/test-utils.ts
@@ -14,7 +14,13 @@ export const setupTestDatabase = async (): Promise<TestSetupResult> => {
   harness = new BlueprintTestHarness({
     getConfig: async () => {
       const { default: config } = await import('../mikro-orm.config');
-      return config;
+      // MikroORM.init() mutates options.discovery.skipSyncDiscovery = true on
+      // the object it receives. mikro-orm.config exports a single shared object
+      // that the app's own DI container also builds a MikroORM from, so letting
+      // the harness mutate it leaves the app's `new MikroORM(config)` with an
+      // undefined `.em` (every route then crashes on `Orm.em.fork`). Hand the
+      // harness its own discovery object so the mutation can't leak.
+      return { ...config, discovery: { ...config.discovery } };
     },
     databaseType: 'postgres',
     useMigrations: false,

--- a/cli/src/templates/project/service/__test__/test-utils.ts
+++ b/cli/src/templates/project/service/__test__/test-utils.ts
@@ -21,7 +21,13 @@ export const setupTestDatabase = async (): Promise<TestSetupResult> => {
   harness = new BlueprintTestHarness({
     {{#is_database_enabled}}getConfig: async () => {
       const { default: config } = await import('../mikro-orm.config');
-      return config;
+      // MikroORM.init() mutates options.discovery.skipSyncDiscovery = true on
+      // the object it receives. mikro-orm.config exports a single shared object
+      // that the app's own DI container also builds a MikroORM from, so letting
+      // the harness mutate it leaves the app's `new MikroORM(config)` with an
+      // undefined `.em` (every route then crashes on `Orm.em.fork`). Hand the
+      // harness its own discovery object so the mutation can't leak.
+      return { ...config, discovery: { ...config.discovery } };
     },
     databaseType: getEnvVar('DATABASE_TYPE') as DatabaseType,
     useMigrations: true,

--- a/cli/src/templates/project/worker/__test__/test-utils.ts
+++ b/cli/src/templates/project/worker/__test__/test-utils.ts
@@ -21,7 +21,13 @@ export const setupTestDatabase = async (): Promise<TestSetupResult> => {
   harness = new BlueprintTestHarness({
     {{#is_database_enabled}}getConfig: async () => {
       const { default: config } = await import('../mikro-orm.config');
-      return config;
+      // MikroORM.init() mutates options.discovery.skipSyncDiscovery = true on
+      // the object it receives. mikro-orm.config exports a single shared object
+      // that the app's own DI container also builds a MikroORM from, so letting
+      // the harness mutate it leaves the app's `new MikroORM(config)` with an
+      // undefined `.em` (every route then crashes on `Orm.em.fork`). Hand the
+      // harness its own discovery object so the mutation can't leak.
+      return { ...config, discovery: { ...config.discovery } };
     },
     databaseType: getEnvVar('DATABASE_TYPE') as DatabaseType,
     useMigrations: false,

--- a/framework/.changeset/harness-orm-em-clear-fix.md
+++ b/framework/.changeset/harness-orm-em-clear-fix.md
@@ -1,0 +1,14 @@
+---
+"@forklaunch/testing": patch
+---
+
+Fix BlueprintTestHarness so generated app E2E tests can actually run.
+
+`clearTestDatabase` now reads the entity list from `orm.config.get('entities')`
+(MikroORM v7's `getMetadata().getAll()` returns an empty object, so the old
+code cleared nothing and re-seeds hit duplicate-key errors), and clears in a
+foreign-key-safe retry-until-stable order instead of a single reverse pass.
+
+Pairs with the blueprint test-utils change that hands the harness its own
+`discovery` object, so `MikroORM.init()` can't mutate the app's shared config
+and leave the app container's `new MikroORM(config)` with an undefined `.em`.

--- a/framework/testing/src/database.ts
+++ b/framework/testing/src/database.ts
@@ -162,18 +162,45 @@ export async function clearTestDatabase(options?: {
 
   if (orm) {
     const em = orm.em.fork();
-    const entities = Object.values(orm.getMetadata().getAll());
+    // orm.getMetadata().getAll() returns an empty object under MikroORM v7, so
+    // the configured entity list is the reliable source of what to clear.
+    type Deletable = Parameters<typeof em.nativeDelete>[0];
+    let remaining = [...(orm.config.get('entities') as Deletable[])];
 
-    // Delete in reverse order to avoid foreign key constraints
-    for (const entity of entities.reverse()) {
-      try {
-        await em.nativeDelete(entity.class, {});
-      } catch (error) {
-        // Ignore "table does not exist" errors
-        if (!(error as Error).message?.includes('does not exist')) {
+    // The entity list is in declaration order, not FK-dependency order, so a
+    // single reverse pass can still violate foreign keys. Retry the ones that
+    // fail on a constraint until a full pass clears nothing new — that leaves
+    // only genuine errors (a real FK cycle, which would stop making progress).
+    while (remaining.length > 0) {
+      const stillBlocked: Deletable[] = [];
+      let lastConstraintError: Error | undefined;
+      let progressed = false;
+
+      for (const entity of remaining) {
+        try {
+          await em.nativeDelete(entity, {});
+          progressed = true;
+        } catch (error) {
+          const message = (error as Error).message ?? '';
+          if (message.includes('does not exist')) {
+            continue; // table not created — nothing to clear
+          }
+          if (/foreign key|constraint/i.test(message)) {
+            stillBlocked.push(entity);
+            lastConstraintError = error as Error;
+            continue;
+          }
           throw error;
         }
       }
+
+      if (!progressed) {
+        if (lastConstraintError) {
+          throw lastConstraintError; // no progress => unbreakable FK cycle
+        }
+        break;
+      }
+      remaining = stillBlocked;
     }
 
     await em.flush();


### PR DESCRIPTION
Generated app E2E tests have never actually run — they crash on the first request with `Cannot read properties of undefined (reading 'fork')`, which is why every platform module excludes `__test__` from vitest. Two root causes, both fixed here:

## 1. `.em` undefined (the crash — fl#270)
`MikroORM.init()` mutates `options.discovery.skipSyncDiscovery = true` on the object it receives (`@mikro-orm/core` MikroORM.js:93). The blueprint `test-utils.ts` handed the app's **shared** `mikro-orm.config` default straight to the harness, so once the harness called `init()`, the app's own DI container `new MikroORM(config)` skipped `createEntityManager()` and returned with an undefined `.em`. Every route then died on `Orm.em.fork`.

**Fix:** `getConfig` returns `{ ...config, discovery: { ...config.discovery } }` so the mutation lands on a copy, in all 9 blueprint + CLI test-utils templates.

## 2. `clearTestDatabase` clears nothing
It iterated `orm.getMetadata().getAll()`, which returns an **empty object** under MikroORM v7 — so nothing was deleted and fixed-UUID re-seeds hit duplicate-key errors. Now reads `orm.config.get('entities')` and deletes in a **foreign-key-safe retry-until-stable order** (the old single `.reverse()` pass isn't dependency order).

## Verification
On a real `iam-better-auth` scaffold, the previously-crashing surfacing E2E suite goes **24/24 green** (was 100% crashing). Both fixes were confirmed at runtime before committing.

Package fix ships a changeset (`@forklaunch/testing` patch); the template fixes flow to new scaffolds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWR4xL34BHMe2gjvsdLbRk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test database cleanup, including safer handling of foreign-key constraints and retrying blocked deletions.
  * Prevented test setup from altering shared application database configuration.
  * Preserved handling for missing tables while reporting unresolved database errors.

* **Documentation**
  * Added release documentation covering the test harness and database cleanup improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->