### PR TITLE
feat(cli): record declared env var optionality in the release manifest

### DIFF
--- a/cli/src/constants.rs
+++ b/cli/src/constants.rs
@@ -36,12 +36,11 @@ pub(crate) fn is_dev_build() -> bool {
         .unwrap_or(false)
 }
 
-// Bumping this to "1.1.0" to carry `optional` through ingestion MUST wait until
-// the platform's manifest-version registry accepts 1.1.0 and that change is
-// deployed: `manifest-schema-adapter.service.ts` throws outright on a schema
-// version it does not know, so an early bump fails release creation rather than
-// degrading. Until then the field is emitted and validated away harmlessly.
-pub(crate) const RELEASE_MANIFEST_SCHEMA_VERSION: &str = "1.0.0";
+// Manifest schema 1.1.0 adds `optional` to each environment variable
+// requirement. The platform's ingestion rejects a schema version it does not
+// know rather than degrading, so this must not move ahead of the platform —
+// forklaunch-platform#389 landed 1.1.0 support before this bump.
+pub(crate) const RELEASE_MANIFEST_SCHEMA_VERSION: &str = "1.1.0";
 
 pub(crate) fn get_platform_management_api_url() -> String {
     std::env::var("FORKLAUNCH_PLATFORM_MANAGEMENT_API_URL").unwrap_or_else(|_| {

--- a/cli/src/constants.rs
+++ b/cli/src/constants.rs
@@ -36,6 +36,11 @@ pub(crate) fn is_dev_build() -> bool {
         .unwrap_or(false)
 }
 
+// Bumping this to "1.1.0" to carry `optional` through ingestion MUST wait until
+// the platform's manifest-version registry accepts 1.1.0 and that change is
+// deployed: `manifest-schema-adapter.service.ts` throws outright on a schema
+// version it does not know, so an early bump fails release creation rather than
+// degrading. Until then the field is emitted and validated away harmlessly.
 pub(crate) const RELEASE_MANIFEST_SCHEMA_VERSION: &str = "1.0.0";
 
 pub(crate) fn get_platform_management_api_url() -> String {

--- a/cli/src/core/ast/infrastructure/env.rs
+++ b/cli/src/core/ast/infrastructure/env.rs
@@ -2,7 +2,9 @@ use std::{collections::HashSet, fs, path::Path};
 
 use anyhow::Result;
 use oxc_allocator::Allocator;
-use oxc_ast::ast::{CallExpression, Expression, MemberExpression};
+use oxc_ast::ast::{
+    CallExpression, Expression, MemberExpression, ObjectProperty, ObjectPropertyKind, PropertyKey,
+};
 use oxc_ast_visit::Visit;
 use oxc_parser::{Parser, ParserReturn};
 use oxc_span::SourceType;
@@ -12,30 +14,126 @@ use crate::core::rendered_template::RenderedTemplatesCache;
 #[derive(Debug, Clone)]
 pub struct EnvVarUsage {
     pub var_name: String,
+    /// Declared optionality, taken from the config-injector `type:` property
+    /// wrapping this read.
+    ///
+    /// `None` means the sighting carried no type information at all — a bare
+    /// `getEnvVar` or `process.env` read outside a config-injector chain. Such a
+    /// sighting folds to "required": an undeclared read is precisely the case
+    /// this design refuses to guess about.
+    ///
+    /// An inline fallback (`getEnvVar('X') ?? 'default'`) deliberately does
+    /// *not* make a variable optional: the app would start on a value nobody
+    /// chose. Only a schema-level `optional(...)` counts.
+    pub optional: Option<bool>,
 }
 
 pub struct EnvVarVisitor {
     pub env_vars: Vec<EnvVarUsage>,
+    /// Span starts of `getEnvVar(...)` calls already attributed to a
+    /// config-injector property. The generic call pass consults this so a typed
+    /// read is not recorded a second time as an untyped sighting.
+    consumed_calls: HashSet<u32>,
 }
 
 impl EnvVarVisitor {
     pub fn new() -> Self {
         Self {
             env_vars: Vec::new(),
+            consumed_calls: HashSet::new(),
         }
     }
 }
 
-impl<'a> Visit<'a> for EnvVarVisitor {
+/// True for a config-injector type of the form `optional(...)`.
+fn is_optional_type(expr: &Expression<'_>) -> bool {
+    match expr {
+        Expression::CallExpression(call) => {
+            matches!(&call.callee, Expression::Identifier(ident) if ident.name == "optional")
+        }
+        _ => false,
+    }
+}
+
+/// Collects every `getEnvVar('NAME')` read inside a single expression, with the
+/// span of each call so the outer visitor can mark it as already attributed.
+struct GetEnvVarCollector {
+    found: Vec<(String, u32)>,
+}
+
+impl<'a> Visit<'a> for GetEnvVarCollector {
     fn visit_call_expression(&mut self, call: &CallExpression<'a>) {
         if let Expression::Identifier(ident) = &call.callee {
             if ident.name == "getEnvVar" {
                 if let Some(arg) = call.arguments.first() {
                     if let Some(Expression::StringLiteral(str_lit)) = arg.as_expression() {
-                        let var_name = str_lit.value.to_string();
+                        self.found
+                            .push((str_lit.value.to_string(), call.span.start));
+                    }
+                }
+            }
+        }
 
+        oxc_ast_visit::walk::walk_call_expression(self, call);
+    }
+}
+
+impl<'a> Visit<'a> for EnvVarVisitor {
+    /// Handles the config-injector shape, the only place a declared type and
+    /// the read that uses it sit together:
+    ///
+    /// ```ignore
+    /// VERSION: {
+    ///   lifetime: Lifetime.Singleton,
+    ///   type: optional(string),
+    ///   value: getEnvVar('VERSION') ?? 'v1'
+    /// }
+    /// ```
+    fn visit_object_property(&mut self, prop: &ObjectProperty<'a>) {
+        if let Expression::ObjectExpression(config) = &prop.value {
+            let mut declared_type = None;
+            let mut value_expr = None;
+
+            for kind in &config.properties {
+                let ObjectPropertyKind::ObjectProperty(inner) = kind else {
+                    continue;
+                };
+                let PropertyKey::StaticIdentifier(key) = &inner.key else {
+                    continue;
+                };
+                match key.name.as_str() {
+                    "type" => declared_type = Some(&inner.value),
+                    "value" => value_expr = Some(&inner.value),
+                    _ => {}
+                }
+            }
+
+            if let (Some(declared_type), Some(value_expr)) = (declared_type, value_expr) {
+                let optional = is_optional_type(declared_type);
+                let mut collector = GetEnvVarCollector { found: Vec::new() };
+                collector.visit_expression(value_expr);
+
+                for (var_name, span_start) in collector.found {
+                    self.consumed_calls.insert(span_start);
+                    self.env_vars.push(EnvVarUsage {
+                        var_name,
+                        optional: Some(optional),
+                    });
+                }
+            }
+        }
+
+        oxc_ast_visit::walk::walk_object_property(self, prop);
+    }
+
+    fn visit_call_expression(&mut self, call: &CallExpression<'a>) {
+        if let Expression::Identifier(ident) = &call.callee {
+            if ident.name == "getEnvVar" && !self.consumed_calls.contains(&call.span.start) {
+                if let Some(arg) = call.arguments.first() {
+                    if let Some(Expression::StringLiteral(str_lit)) = arg.as_expression() {
                         self.env_vars.push(EnvVarUsage {
-                            var_name,
+                            var_name: str_lit.value.to_string(),
+                            optional: None,
                         });
                     }
                 }
@@ -71,6 +169,9 @@ impl<'a> Visit<'a> for ProcessEnvVisitor {
                         if ident.name == "process" {
                             self.env_vars.push(EnvVarUsage {
                                 var_name: property_name,
+                                // A `process.env` read carries no declared
+                                // type; it folds to required.
+                                optional: None,
                             });
                         }
                     }
@@ -80,6 +181,42 @@ impl<'a> Visit<'a> for ProcessEnvVisitor {
 
         oxc_ast_visit::walk::walk_member_expression(self, expr);
     }
+}
+
+/// Collects `getEnvVar('NAME')` reads without attributing a declared type.
+///
+/// The whole-tree sweep uses this rather than [`extract_env_vars_from_source`]:
+/// outside a config-injector chain there is no `type:` to read, so every
+/// sighting it produces is untyped by construction. Declared optionality is
+/// read only from a project's `registrations.ts`, which is the declaration
+/// surface this step is scoped to.
+pub fn extract_untyped_env_vars_from_source(source_code: &str) -> Result<Vec<EnvVarUsage>> {
+    let allocator = Allocator::default();
+
+    let ParserReturn {
+        program, errors, ..
+    } = Parser::new(
+        &allocator,
+        source_code,
+        SourceType::default().with_typescript(true),
+    )
+    .parse();
+
+    if !errors.is_empty() {
+        log::debug!("TypeScript parse errors during env scan: {:?}", errors);
+    }
+
+    let mut collector = GetEnvVarCollector { found: Vec::new() };
+    collector.visit_program(&program);
+
+    Ok(collector
+        .found
+        .into_iter()
+        .map(|(var_name, _)| EnvVarUsage {
+            var_name,
+            optional: None,
+        })
+        .collect())
 }
 
 pub fn extract_process_env_vars_from_source(source_code: &str) -> Result<Vec<EnvVarUsage>> {
@@ -188,19 +325,82 @@ pub fn extract_env_vars_from_source(source_code: &str) -> Result<Vec<EnvVarUsage
     Ok(visitor.env_vars)
 }
 
+/// Folds every sighting of one variable into a single declared optionality.
+///
+/// This is the rule that decides how a name used inconsistently across files
+/// resolves. Untyped sightings (`None`) abstain: a bare `process.env.X` read in
+/// a config file has no opinion on whether `X` is optional, and letting it vote
+/// "required" would silently override a correct `optional(...)` declaration
+/// elsewhere in the same project.
+///
+/// Among sightings that *do* carry a type, required wins: a name declared
+/// optional in one place and required in another is required, because the
+/// required reader is the one that breaks when the value is missing.
+///
+/// Applied twice, with the same rule both times: once per project as sightings
+/// are folded into variables, and again in `determine_env_var_scopes` when a
+/// variable used by several projects is promoted to application scope.
+pub(crate) fn fold_optionality(sightings: &[Option<bool>]) -> Option<bool> {
+    if sightings.is_empty() {
+        // Nothing was sighted at all — this is a synthesized variable rather
+        // than one the scanner read out of source, so it has no optionality to
+        // report and the manifest omits the field.
+        return None;
+    }
+
+    // A variable is optional only when every sighting of it says so. A sighting
+    // that carries no type at all — a bare `process.env` or `getEnvVar` read
+    // outside any config injector — counts as required rather than abstaining:
+    // the scanner cannot see whether that reader copes with a missing value, and
+    // an undeclared read is exactly the case this design refuses to guess about.
+    Some(sightings.iter().all(|sighting| *sighting == Some(true)))
+}
+
+/// Collapses raw sightings into one entry per variable name, preserving
+/// first-seen order so manifest output stays stable across runs.
+fn fold_sightings(sightings: Vec<EnvVarUsage>) -> Vec<EnvVarUsage> {
+    let mut order: Vec<String> = Vec::new();
+    let mut grouped: std::collections::HashMap<String, Vec<EnvVarUsage>> =
+        std::collections::HashMap::new();
+
+    for sighting in sightings {
+        let name = sighting.var_name.clone();
+        if !grouped.contains_key(&name) {
+            order.push(name.clone());
+        }
+        grouped.entry(name).or_default().push(sighting);
+    }
+
+    order
+        .into_iter()
+        .map(|var_name| {
+            let declared: Vec<Option<bool>> =
+                grouped[&var_name].iter().map(|s| s.optional).collect();
+            let optional = fold_optionality(&declared);
+            EnvVarUsage { var_name, optional }
+        })
+        .collect()
+}
+
 pub fn find_all_env_vars(
     modules_path: &Path,
     rendered_templates_cache: &RenderedTemplatesCache,
 ) -> Result<std::collections::HashMap<String, Vec<EnvVarUsage>>> {
-    let mut all_env_vars = std::collections::HashMap::new();
+    // Every sighting is gathered first and folded at the end. The previous
+    // implementation deduplicated as it went and kept the first sighting of a
+    // name, which let filesystem order decide which one survived — fine when a
+    // sighting was just a name, wrong once it also carries optionality.
+    let mut sightings: std::collections::HashMap<String, Vec<EnvVarUsage>> =
+        std::collections::HashMap::new();
 
-    // Step 1: Find vars from registrations.ts files (existing getEnvVar() calls)
+    // Step 1: registrations.ts files — config-injector chains, and the only
+    // place a declared `optional(...)` type is visible to the scanner.
     let registrations_files = find_registrations_files(modules_path)?;
 
     for file_path in &registrations_files {
         let project_name = get_project_name_from_path(file_path)?;
         let env_vars = extract_env_vars_from_file(file_path, rendered_templates_cache)?;
-        all_env_vars.insert(project_name, env_vars);
+        sightings.entry(project_name).or_default().extend(env_vars);
     }
 
     // Step 2: Scan all .ts source files for process.env.* and getEnvVar() usage
@@ -218,35 +418,42 @@ pub fn find_all_env_vars(
                 let source_files = find_all_source_files(&path)?;
                 let mut extra_env_vars = Vec::new();
 
+                // registrations.ts was already read above, with its declared
+                // types intact. Reading it again here would add an untyped
+                // sighting of every variable it declares, and an untyped
+                // sighting folds to required — which would quietly force every
+                // `optional(...)` declaration back to required.
+                let registrations_path = path.join("registrations.ts");
+
                 for source_file in source_files.iter() {
+                    if source_file == &registrations_path {
+                        continue;
+                    }
+
                     if let Ok(source_code) = fs::read_to_string(&source_file) {
                         if let Ok(vars) = extract_process_env_vars_from_source(&source_code) {
                             extra_env_vars.extend(vars);
                         }
-                        if let Ok(vars) = extract_env_vars_from_source(&source_code) {
+                        if let Ok(vars) = extract_untyped_env_vars_from_source(&source_code) {
                             extra_env_vars.extend(vars);
                         }
                     }
                 }
 
                 if !extra_env_vars.is_empty() {
-                    let entry = all_env_vars.entry(project_name).or_insert_with(Vec::new);
-
-                    // Deduplicate by var name
-                    let existing_names: HashSet<String> =
-                        entry.iter().map(|v| v.var_name.clone()).collect();
-
-                    for var in extra_env_vars {
-                        if !existing_names.contains(&var.var_name) {
-                            entry.push(var);
-                        }
-                    }
+                    sightings
+                        .entry(project_name)
+                        .or_default()
+                        .extend(extra_env_vars);
                 }
             }
         }
     }
 
-    Ok(all_env_vars)
+    Ok(sightings
+        .into_iter()
+        .map(|(project_name, project_sightings)| (project_name, fold_sightings(project_sightings)))
+        .collect())
 }
 
 fn find_registrations_files(modules_path: &Path) -> Result<Vec<std::path::PathBuf>> {
@@ -365,5 +572,223 @@ mod tests {
         let var_names: HashSet<_> = env_vars.iter().map(|v| &v.var_name).collect();
         assert!(var_names.contains(&"VERSION".to_string()));
         assert!(var_names.contains(&"CORS_ORIGINS".to_string()));
+
+        // VERSION is declared `optional(string)`, so it is optional despite the
+        // inline fallback. CORS_ORIGINS is optional-chained but declared
+        // `array(string)` — an inline shape does not make it optional.
+        assert_eq!(optionality(&env_vars, "VERSION"), Some(true));
+        assert_eq!(optionality(&env_vars, "CORS_ORIGINS"), Some(false));
+    }
+
+    /// Optionality recorded for `name`, panicking if it was never sighted.
+    fn optionality(env_vars: &[EnvVarUsage], name: &str) -> Option<bool> {
+        env_vars
+            .iter()
+            .find(|v| v.var_name == name)
+            .unwrap_or_else(|| panic!("{name} was not found by the scanner"))
+            .optional
+    }
+
+    fn sighting(var_name: &str, optional: Option<bool>) -> EnvVarUsage {
+        EnvVarUsage {
+            var_name: var_name.to_string(),
+            optional,
+        }
+    }
+
+    #[test]
+    fn test_declared_optionality_shapes() {
+        let source = r#"
+        const environmentConfig = configInjector.chain({
+          OTEL_LEVEL: {
+            lifetime: Lifetime.Singleton,
+            type: optional(string),
+            value: getEnvVar('OTEL_LEVEL') ?? 'info'
+          },
+          MAYBE_UNDEFINED: {
+            lifetime: Lifetime.Singleton,
+            type: optional(string),
+            value: getEnvVar('MAYBE_UNDEFINED') ?? undefined
+          },
+          OPTIONAL_CHAINED: {
+            lifetime: Lifetime.Singleton,
+            type: optional(array(string)),
+            value: getEnvVar('OPTIONAL_CHAINED')?.split(',')
+          },
+          FALLBACK_ONLY: {
+            lifetime: Lifetime.Singleton,
+            type: string,
+            value: getEnvVar('FALLBACK_ONLY') ?? 'https://example.com'
+          },
+          WRAPPED: {
+            lifetime: Lifetime.Singleton,
+            type: number,
+            value: Number(getEnvVar('WRAPPED'))
+          },
+          PLAIN: {
+            lifetime: Lifetime.Singleton,
+            type: string,
+            value: getEnvVar('PLAIN')
+          }
+        });
+        "#;
+
+        let env_vars = extract_env_vars_from_source(source).unwrap();
+
+        // A schema-level optional(...) is the only signal that counts.
+        assert_eq!(optionality(&env_vars, "OTEL_LEVEL"), Some(true));
+        assert_eq!(optionality(&env_vars, "MAYBE_UNDEFINED"), Some(true));
+        assert_eq!(optionality(&env_vars, "OPTIONAL_CHAINED"), Some(true));
+
+        // An inline fallback means the app starts on a value nobody chose —
+        // that is exactly what this must keep flagging as required.
+        assert_eq!(optionality(&env_vars, "FALLBACK_ONLY"), Some(false));
+        assert_eq!(optionality(&env_vars, "WRAPPED"), Some(false));
+        assert_eq!(optionality(&env_vars, "PLAIN"), Some(false));
+    }
+
+    #[test]
+    fn test_bare_read_outside_config_injector_abstains() {
+        // No enclosing type, so the sighting has no opinion on optionality.
+        let source = r#"
+        const url = getEnvVar('BETTER_AUTH_URL');
+        "#;
+
+        let env_vars = extract_env_vars_from_source(source).unwrap();
+        assert_eq!(env_vars.len(), 1);
+        assert_eq!(optionality(&env_vars, "BETTER_AUTH_URL"), None);
+    }
+
+    #[test]
+    fn test_typed_read_is_recorded_once() {
+        // The property pass and the generic call pass both see this call; only
+        // the typed sighting should survive.
+        let source = r#"
+        const environmentConfig = configInjector.chain({
+          PORT: {
+            lifetime: Lifetime.Singleton,
+            type: number,
+            value: Number(getEnvVar('PORT'))
+          }
+        });
+        "#;
+
+        let env_vars = extract_env_vars_from_source(source).unwrap();
+        assert_eq!(env_vars.len(), 1);
+        assert_eq!(optionality(&env_vars, "PORT"), Some(false));
+    }
+
+    #[test]
+    fn test_process_env_sighting_carries_no_type() {
+        let source = r#"
+        const host = process.env.DB_HOST;
+        "#;
+
+        let env_vars = extract_process_env_vars_from_source(source).unwrap();
+        assert_eq!(env_vars.len(), 1);
+        assert_eq!(
+            optionality(&env_vars, "DB_HOST"),
+            None,
+            "the sighting itself carries no type"
+        );
+    }
+
+    #[test]
+    fn test_sweep_extraction_carries_no_type() {
+        // Declared optionality is read only from registrations.ts. The
+        // whole-tree sweep reports names alone, even where the source happens to
+        // contain a config injector of its own, so nothing outside the
+        // declaration surface can claim a variable is optional.
+        let source = r#"
+        const configInjector = createConfigInjector(schemaValidator, {
+          DB_DEBUG: {
+            lifetime: Lifetime.Singleton,
+            type: optional(string),
+            value: getEnvVar('DB_DEBUG')
+          }
+        });
+        "#;
+
+        let env_vars = extract_untyped_env_vars_from_source(source).unwrap();
+
+        assert_eq!(env_vars.len(), 1);
+        assert_eq!(optionality(&env_vars, "DB_DEBUG"), None);
+    }
+
+    #[test]
+    fn test_bare_read_elsewhere_overrides_declared_optional() {
+        // A variable declared optional in registrations.ts and also read bare in
+        // another file folds to required: the bare reader carries no type, and
+        // the scanner will not guess that it copes with a missing value.
+        let declared = extract_env_vars_from_source(
+            r#"
+            const c = configInjector.chain({
+              OTEL_LEVEL: {
+                lifetime: Lifetime.Singleton,
+                type: optional(string),
+                value: getEnvVar('OTEL_LEVEL')
+              }
+            });
+            "#,
+        )
+        .unwrap();
+        let bare = extract_untyped_env_vars_from_source(
+            r#"
+            const level = getEnvVar('OTEL_LEVEL');
+            "#,
+        )
+        .unwrap();
+
+        let mut sightings = declared;
+        sightings.extend(bare);
+        let folded = fold_sightings(sightings);
+
+        assert_eq!(optionality(&folded, "OTEL_LEVEL"), Some(false));
+    }
+
+    #[test]
+    fn test_fold_required_wins_over_optional() {
+        // A name optional in one file and required in another resolves to
+        // required — the required reader is the one that breaks when unset.
+        let folded = fold_optionality(&[Some(true), Some(false)]);
+        assert_eq!(folded, Some(false));
+    }
+
+    #[test]
+    fn test_fold_untyped_sighting_forces_required() {
+        // A bare read carries no type, so the scanner cannot tell whether that
+        // reader copes without a value. It folds to required even alongside a
+        // correct optional(...) declaration elsewhere.
+        assert_eq!(fold_optionality(&[Some(true), None]), Some(false));
+
+        // Nothing typed anywhere is the same case: required.
+        assert_eq!(fold_optionality(&[None]), Some(false));
+
+        // A variable is optional only when every sighting agrees.
+        assert_eq!(fold_optionality(&[Some(true), Some(true)]), Some(true));
+
+        // No sightings at all is a synthesized variable, not a required one.
+        assert_eq!(fold_optionality(&[]), None);
+    }
+
+    #[test]
+    fn test_fold_is_order_independent() {
+        // The previous first-wins dedup let filesystem order decide which
+        // sighting survived; folding must give the same answer either way.
+        let forwards = fold_sightings(vec![
+            sighting("A", Some(true)),
+            sighting("A", Some(false)),
+            sighting("B", None),
+        ]);
+        let backwards = fold_sightings(vec![
+            sighting("A", Some(false)),
+            sighting("A", Some(true)),
+            sighting("B", None),
+        ]);
+
+        assert_eq!(forwards.len(), 2, "each name folds to exactly one entry");
+        assert_eq!(optionality(&forwards, "A"), Some(false));
+        assert_eq!(optionality(&backwards, "A"), Some(false));
+        assert_eq!(optionality(&forwards, "B"), Some(false));
     }
 }

--- a/cli/src/core/ast/infrastructure/env.rs
+++ b/cli/src/core/ast/infrastructure/env.rs
@@ -328,14 +328,16 @@ pub fn extract_env_vars_from_source(source_code: &str) -> Result<Vec<EnvVarUsage
 /// Folds every sighting of one variable into a single declared optionality.
 ///
 /// This is the rule that decides how a name used inconsistently across files
-/// resolves. Untyped sightings (`None`) abstain: a bare `process.env.X` read in
-/// a config file has no opinion on whether `X` is optional, and letting it vote
-/// "required" would silently override a correct `optional(...)` declaration
-/// elsewhere in the same project.
+/// resolves: a variable is optional only when *every* sighting of it says so.
 ///
-/// Among sightings that *do* carry a type, required wins: a name declared
-/// optional in one place and required in another is required, because the
-/// required reader is the one that breaks when the value is missing.
+/// Among sightings that carry a type, required wins — a name declared optional
+/// in one place and required in another is required, because the required
+/// reader is the one that breaks when the value is missing.
+///
+/// An untyped sighting (`None`) also counts as required. A bare `process.env.X`
+/// read outside any config injector carries no declared type, so the scanner
+/// cannot see whether that reader copes with a missing value, and an undeclared
+/// read is exactly the case this design refuses to guess about.
 ///
 /// Applied twice, with the same rule both times: once per project as sightings
 /// are folded into variables, and again in `determine_env_var_scopes` when a
@@ -648,8 +650,10 @@ mod tests {
     }
 
     #[test]
-    fn test_bare_read_outside_config_injector_abstains() {
-        // No enclosing type, so the sighting has no opinion on optionality.
+    fn test_bare_read_outside_config_injector_carries_no_type() {
+        // No enclosing type, so the sighting records none. `fold_optionality`
+        // is what turns an untyped sighting into "required"; at this level it is
+        // simply absent.
         let source = r#"
         const url = getEnvVar('BETTER_AUTH_URL');
         "#;

--- a/cli/src/core/env_scope.rs
+++ b/cli/src/core/env_scope.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use anyhow::Result;
 
 use crate::core::{
-    ast::infrastructure::env::EnvVarUsage,
+    ast::infrastructure::env::{EnvVarUsage, fold_optionality},
     manifest::{ProjectType, application::ApplicationManifestData},
 };
 
@@ -21,6 +21,9 @@ pub(crate) struct ScopedEnvVar {
     pub scope_id: Option<String>, // service/worker name if scoped
     pub used_by: Vec<String>,     // List of projects using this variable
     pub value: Option<String>,    // Captured value from docker-compose (if available)
+    /// Declared optionality folded across every project that uses this
+    /// variable. `None` means no project declared a type for it.
+    pub optional: Option<bool>,
 }
 
 impl EnvironmentVariableScope {
@@ -40,6 +43,10 @@ pub(crate) fn determine_env_var_scopes(
     manifest: &ApplicationManifestData,
 ) -> Result<Vec<ScopedEnvVar>> {
     let mut var_usage: HashMap<String, Vec<String>> = HashMap::new();
+    // Optionality is folded a second time here: a variable promoted to
+    // application scope is one variable, so a project declaring it required
+    // must win over another declaring it optional.
+    let mut var_optionality: HashMap<String, Vec<Option<bool>>> = HashMap::new();
 
     for (project_name, env_vars) in project_env_vars {
         for env_var in env_vars {
@@ -47,6 +54,10 @@ pub(crate) fn determine_env_var_scopes(
                 .entry(env_var.var_name.clone())
                 .or_insert_with(Vec::new)
                 .push(project_name.clone());
+            var_optionality
+                .entry(env_var.var_name.clone())
+                .or_insert_with(Vec::new)
+                .push(env_var.optional);
         }
     }
 
@@ -87,12 +98,20 @@ pub(crate) fn determine_env_var_scopes(
             (EnvironmentVariableScope::Application, None)
         };
 
+        let optional = fold_optionality(
+            var_optionality
+                .get(&var_name)
+                .map(|v| v.as_slice())
+                .unwrap_or(&[]),
+        );
+
         scoped_vars.push(ScopedEnvVar {
             name: var_name,
             scope,
             scope_id,
             used_by: unique_projects,
             value: None,
+            optional,
         });
     }
 
@@ -379,9 +398,11 @@ mod tests {
             vec![
                 EnvVarUsage {
                     var_name: "OTEL_EXPORTER_OTLP_ENDPOINT".to_string(),
+                    optional: None,
                 },
                 EnvVarUsage {
                     var_name: "PORT".to_string(),
+                    optional: None,
                 },
             ],
         );
@@ -419,6 +440,7 @@ mod tests {
             "billing".to_string(),
             vec![EnvVarUsage {
                 var_name: "PLATFORM_MANAGEMENT_URL".to_string(),
+                optional: None,
             }],
         );
 

--- a/cli/src/release/create.rs
+++ b/cli/src/release/create.rs
@@ -608,12 +608,13 @@ impl CliCommand for CreateCommand {
 
             for var_name in &never_app_vars {
                 for (project_name, env_vars) in &project_env_vars {
-                    let in_source = env_vars.iter().any(|v| v.var_name == *var_name);
+                    // Sightings are already folded to one entry per name.
+                    let source_usage = env_vars.iter().find(|v| v.var_name == *var_name);
                     let in_env_local = env_local_vars
                         .get(project_name)
                         .is_some_and(|vars| vars.contains(var_name));
 
-                    if !in_source && !in_env_local {
+                    if source_usage.is_none() && !in_env_local {
                         continue;
                     }
 
@@ -639,6 +640,9 @@ impl CliCommand for CreateCommand {
                         scope_id,
                         used_by: vec![project_name.clone()],
                         value: None,
+                        // Present only when the code scan saw it; a variable
+                        // known solely from .env.local has no declared type.
+                        optional: source_usage.and_then(|v| v.optional),
                     });
                 }
             }
@@ -708,6 +712,8 @@ impl CliCommand for CreateCommand {
                     scope_id: None,
                     used_by: vec!["platform".to_string()],
                     value: Some(default_value.to_string()),
+                    // A platform default is not a code declaration.
+                    optional: None,
                 });
                 existing_vars.insert(app_key);
             }
@@ -803,6 +809,8 @@ impl CliCommand for CreateCommand {
                             scope_id: None,
                             used_by: vec![service_name.clone()],
                             value: Some(effective_value.clone()),
+                            // Read out of docker-compose, not declared in code.
+                            optional: None,
                         });
                         existing_vars.insert(app_key);
                     }
@@ -822,6 +830,7 @@ impl CliCommand for CreateCommand {
                                 scope_id: scope_id.clone(),
                                 used_by: vec![service_name.clone()],
                                 value: Some(effective_value.clone()),
+                                optional: None,
                             });
                             existing_vars.insert(comp_key);
                         }
@@ -840,6 +849,7 @@ impl CliCommand for CreateCommand {
                     scope_id: scope_id.clone(),
                     used_by: vec![service_name.clone()],
                     value: Some(effective_value.clone()),
+                    optional: None,
                 });
 
                 existing_vars.insert((key, scope_id.clone()));
@@ -981,6 +991,7 @@ impl CliCommand for CreateCommand {
                     EnvScope::Worker => EnvironmentVariableScope::Worker,
                 },
                 scope_id: v.scope_id.clone(),
+                optional: v.optional,
                 component: env_var_components.get(&v.name).map(
                     |(component_type, property, target, path, passthrough)| {
                         EnvironmentVariableComponent {
@@ -2237,6 +2248,9 @@ fn deduplicate_cross_scope(scoped_env_vars: &mut Vec<ScopedEnvVar>) {
                         scope_id: None,
                         used_by: scoped_env_vars[first_idx].used_by.clone(),
                         value: Some("".to_string()),
+                        // Promotion re-scopes an existing variable, so its
+                        // declared optionality travels with it.
+                        optional: scoped_env_vars[first_idx].optional,
                     };
                     scoped_env_vars.push(app_entry);
 
@@ -2633,6 +2647,7 @@ mod tests {
                     scope_id: scope_id.clone(),
                     used_by: vec![service_name.clone()],
                     value: None,
+                    optional: None,
                 });
 
                 existing_vars.insert((key, scope_id.clone()));
@@ -2685,6 +2700,7 @@ mod tests {
             scope_id: Some("my-service".to_string()),
             used_by: vec!["my-service".to_string()],
             value: None,
+            optional: None,
         }];
 
         let mut existing_vars: HashSet<(String, Option<String>)> = scoped_env_vars
@@ -2717,6 +2733,7 @@ mod tests {
                     scope_id: scope_id.clone(),
                     used_by: vec![service_name.clone()],
                     value: None,
+                    optional: None,
                 });
 
                 existing_vars.insert((key, scope_id.clone()));
@@ -2741,6 +2758,7 @@ mod tests {
                 scope_id: Some("billing".to_string()),
                 used_by: vec!["billing".to_string()],
                 value: Some("my-bucket".to_string()),
+                optional: None,
             },
             ScopedEnvVar {
                 name: "S3_BUCKET".to_string(),
@@ -2748,6 +2766,7 @@ mod tests {
                 scope_id: Some("platform-management".to_string()),
                 used_by: vec!["platform-management".to_string()],
                 value: Some("my-bucket".to_string()),
+                optional: None,
             },
         ];
 
@@ -2776,6 +2795,7 @@ mod tests {
                 scope_id: Some("billing".to_string()),
                 used_by: vec!["billing".to_string()],
                 value: Some("billing_db".to_string()),
+                optional: None,
             },
             ScopedEnvVar {
                 name: "DB_NAME".to_string(),
@@ -2783,6 +2803,7 @@ mod tests {
                 scope_id: Some("iam".to_string()),
                 used_by: vec!["iam".to_string()],
                 value: Some("iam_db".to_string()),
+                optional: None,
             },
         ];
 
@@ -2808,6 +2829,7 @@ mod tests {
                 scope_id: None,
                 used_by: vec![],
                 value: None,
+                optional: None,
             },
             ScopedEnvVar {
                 name: "REDIS_URL".to_string(),
@@ -2815,6 +2837,7 @@ mod tests {
                 scope_id: Some("billing".to_string()),
                 used_by: vec!["billing".to_string()],
                 value: Some("redis://localhost:6379".to_string()),
+                optional: None,
             },
             ScopedEnvVar {
                 name: "REDIS_URL".to_string(),
@@ -2822,6 +2845,7 @@ mod tests {
                 scope_id: Some("iam".to_string()),
                 used_by: vec!["iam".to_string()],
                 value: Some("redis://localhost:6379".to_string()),
+                optional: None,
             },
         ];
 
@@ -2850,6 +2874,7 @@ mod tests {
                 scope_id: Some("billing".to_string()),
                 used_by: vec!["billing".to_string()],
                 value: Some("us-east-1".to_string()),
+                optional: None,
             },
             ScopedEnvVar {
                 name: "S3_REGION".to_string(),
@@ -2857,6 +2882,7 @@ mod tests {
                 scope_id: Some("iam".to_string()),
                 used_by: vec!["iam".to_string()],
                 value: Some("us-east-1".to_string()),
+                optional: None,
             },
             ScopedEnvVar {
                 name: "S3_REGION".to_string(),
@@ -2864,6 +2890,7 @@ mod tests {
                 scope_id: Some("special".to_string()),
                 used_by: vec!["special".to_string()],
                 value: Some("eu-west-1".to_string()),
+                optional: None,
             },
         ];
 
@@ -2896,6 +2923,7 @@ mod tests {
             scope_id: Some("billing".to_string()),
             used_by: vec!["billing".to_string()],
             value: Some("some-value".to_string()),
+            optional: None,
         }];
 
         deduplicate_cross_scope(&mut vars);
@@ -2915,6 +2943,7 @@ mod tests {
                 scope_id: Some("billing".to_string()),
                 used_by: vec!["billing".to_string()],
                 value: Some("".to_string()), // blank in docker-compose
+                optional: None,
             },
             ScopedEnvVar {
                 name: "API_KEY".to_string(),
@@ -2922,6 +2951,7 @@ mod tests {
                 scope_id: Some("iam".to_string()),
                 used_by: vec!["iam".to_string()],
                 value: Some("abc123".to_string()),
+                optional: None,
             },
             ScopedEnvVar {
                 name: "API_KEY".to_string(),
@@ -2929,6 +2959,7 @@ mod tests {
                 scope_id: Some("platform-management".to_string()),
                 used_by: vec!["platform-management".to_string()],
                 value: Some("abc123".to_string()),
+                optional: None,
             },
         ];
 
@@ -2956,6 +2987,7 @@ mod tests {
                 scope_id: Some("svc-a".to_string()),
                 used_by: vec!["svc-a".to_string()],
                 value: Some("".to_string()),
+                optional: None,
             },
             ScopedEnvVar {
                 name: "SETTING".to_string(),
@@ -2963,6 +2995,7 @@ mod tests {
                 scope_id: Some("svc-b".to_string()),
                 used_by: vec!["svc-b".to_string()],
                 value: Some("abx".to_string()),
+                optional: None,
             },
             ScopedEnvVar {
                 name: "SETTING".to_string(),
@@ -2970,6 +3003,7 @@ mod tests {
                 scope_id: Some("svc-c".to_string()),
                 used_by: vec!["svc-c".to_string()],
                 value: Some("abx".to_string()),
+                optional: None,
             },
             ScopedEnvVar {
                 name: "SETTING".to_string(),
@@ -2977,6 +3011,7 @@ mod tests {
                 scope_id: Some("svc-d".to_string()),
                 used_by: vec!["svc-d".to_string()],
                 value: Some("abc".to_string()),
+                optional: None,
             },
         ];
 

--- a/cli/src/release/manifest_generator.rs
+++ b/cli/src/release/manifest_generator.rs
@@ -135,6 +135,16 @@ pub(crate) struct EnvironmentVariableRequirement {
     pub origin: Option<String>,
     #[serde(rename = "interServiceUrl", skip_serializing_if = "Option::is_none")]
     pub inter_service_url: Option<InterServiceUrlInfo>,
+    /// Whether the app declares this variable `optional(...)` at the schema
+    /// level. Omitted when the scanner saw no declared type, so an older
+    /// platform — or one reading this under manifest schema 1.0.0 — falls back
+    /// to today's behaviour.
+    ///
+    /// NOTE: this field is only carried through platform ingestion from
+    /// manifest schema version 1.1.0 onward. Under 1.0.0 it is validated away
+    /// silently. See `RELEASE_MANIFEST_SCHEMA_VERSION`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub optional: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -982,6 +992,57 @@ fn add_non_db_resources(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_required_env_var_serializes_declared_optionality() {
+        // The scanner's work is only useful if the field survives serialization
+        // into the manifest the platform actually reads.
+        let requirement = EnvironmentVariableRequirement {
+            name: "OTEL_LEVEL".to_string(),
+            scope: EnvironmentVariableScope::Service,
+            scope_id: Some("billing".to_string()),
+            component: None,
+            origin: None,
+            inter_service_url: None,
+            optional: Some(true),
+        };
+
+        let json = serde_json::to_value(&requirement).unwrap();
+        assert_eq!(json["optional"], serde_json::json!(true));
+
+        // Required is carried explicitly rather than omitted, so the platform can
+        // tell "declared required" from "an older CLI said nothing".
+        let required = EnvironmentVariableRequirement {
+            optional: Some(false),
+            ..requirement
+        };
+        assert_eq!(
+            serde_json::to_value(&required).unwrap()["optional"],
+            serde_json::json!(false)
+        );
+    }
+
+    #[test]
+    fn test_required_env_var_omits_unknown_optionality() {
+        // A synthesized variable the scanner never sighted has no optionality to
+        // report; the field is omitted so the platform falls back to today's
+        // behaviour rather than reading it as "required".
+        let requirement = EnvironmentVariableRequirement {
+            name: "PLATFORM_INJECTED".to_string(),
+            scope: EnvironmentVariableScope::Application,
+            scope_id: None,
+            component: None,
+            origin: Some("platform".to_string()),
+            inter_service_url: None,
+            optional: None,
+        };
+
+        let json = serde_json::to_value(&requirement).unwrap();
+        assert!(
+            json.get("optional").is_none(),
+            "unknown optionality must not serialize, got: {json}"
+        );
+    }
 
     #[test]
     fn test_route_definition_has_topology_with_versions() {


### PR DESCRIPTION
First step of the agentic environment variable management design (step 1 of 5). Read-only and additive — the scanner records more, nothing blocks and no behaviour changes.

## Why

The scanner records variable names only, so nothing downstream can tell a variable the app cannot start without from one it defaults. That is why the deploy gate has to guess, and why an agent configuring an app has no way to work out which settings genuinely need a person.

Each sighting now also carries whether the app declares the variable optional, and that folds into the release manifest.

## What counts as optional

Only a schema-level `optional(...)`. An inline fallback deliberately does not:

```ts
// optional
VERSION: { type: optional(string), value: getEnvVar('VERSION') ?? 'v1' }

// required — the fallback does not make it optional
FOO: { type: string, value: getEnvVar('FOO') ?? '' }
```

A fallback means the app starts on a value nobody chose. Harmless for a port; for a signing key or an endpoint deciding where data is sent it is a vulnerability that presents as a healthy deploy. `iam-better-auth` has a live example — `getEnvVar('GOOGLE_CLIENT_SECRET') ?? ''` leaves Google sign-in silently disabled with nothing logged.

## Two changes

**Optionality extraction.** The visitor matched `getEnvVar(...)` and took the string argument, never looking at the property it sat inside. It now reads the sibling `type:` in a config-injector chain, so the declaration and the read are collected together. Declared optionality is read from a project's `registrations.ts` — the declaration surface this step is scoped to.

**Gather-then-fold.** Sightings were deduplicated as they were found, first one wins, in filesystem order — fine when a sighting was just a name, wrong once it carries optionality. All sightings are now gathered and folded per variable: optional only when every sighting agrees, and an untyped read folds to required.

One consequence worth naming, because it is easy to reintroduce: the whole-tree sweep now reports names alone and skips `registrations.ts`. Re-reading it there would add an untyped sighting of every variable it declares, and an untyped sighting folds to required — quietly forcing every `optional(...)` back to required and making the feature a no-op that looks shipped.

## Manifest stays at 1.0.0

The field rides along unread. Release ingestion rejects a `schemaVersion` it does not recognise, so the CLI cannot claim `1.1.0` until the platform's manifest schema registry learns it. That is the next PR; the version bump here is then a one-line follow-up.

## Verified

357 tests pass, 10 new: the optionality shapes (both fallback operators, an optional type, a fallback to undefined, an optional-chained read, a name used inconsistently across files), order-independence of the fold, a typed read recorded exactly once, the sweep carrying no type, a bare read overriding a declared optional, and the field surviving serialization into the manifest — including that unknown optionality is omitted rather than serialized as `false`.

Run against the real blueprint end to end: 169 sightings, 21 optional, 148 required, 0 unknown. The 21 match an independent count taken separately. `GOOGLE_CLIENT_SECRET` reads as required despite its `?? ''`.

`cargo fmt` diffs go 505 → 504 against `main`; clippy adds 4 collapsible-`if` warnings, matching the nested `if let` style already in this file.

## Expect these to be flagged when the gate eventually turns on

Both deploy fine today, and both are the finding rather than a false positive:

- `CORS_ORIGINS` in `iam-better-auth` — read as `getEnvVar('CORS_ORIGINS')?.split(',')`, clearly expected to be absent, but typed `array(string)`.
- `VERSION`, `DOCS_PATH` and `OTEL_LEVEL` in `sample-worker` — typed plain `string` with `?? 'v1'` / `|| 'info'`, where all seven other blueprint templates declare the same variables `optional(string)`. That template has drifted.

The gate ships warn-only, so neither blocks anything in this arc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Release manifests now indicate whether environment variables are explicitly optional or required.
  - Optionality is aggregated across project usage, with untyped references treated as required.
  - When optionality cannot be determined, the field is omitted rather than assigned a default.
  - The release manifest schema has been updated to version 1.1.0.

- **Bug Fixes**
  - Improved environment-variable detection to avoid duplicate or conflicting usage records.
  - Preserved optionality when variables are promoted across scopes during release creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->