### PR TITLE
feat(cli): managed mode summary, and the three creation rails on app create

### DIFF
--- a/cli/src/app/create.rs
+++ b/cli/src/app/create.rs
@@ -60,6 +60,39 @@ impl CliCommand for CreateCommand {
                 .help("Application description"),
         )
         .arg(
+            // Placement: where this app's compute lands. Set here so the
+            // first deploy has nothing to ask.
+            Arg::new("cluster_type")
+                .long("cluster-type")
+                .value_parser(["platform-shared", "org-shared", "dedicated"])
+                .help(
+                    "Cluster placement: platform-shared (cheapest, cross-tenant hosts), \
+                     org-shared (your org's hosts), or dedicated (your own cluster)",
+                ),
+        )
+        .arg(
+            // Compliance: what rules the app's DATA is under. A separate rail
+            // from placement — it constrains which placements are allowed,
+            // because compliance-scoped apps cannot run on cross-tenant compute.
+            Arg::new("compliance_framework")
+                .long("compliance-framework")
+                .action(ArgAction::Append)
+                .value_parser(["HIPAA", "PCI-DSS", "SOC 2", "GDPR", "CCPA"])
+                .help(
+                    "Framework this application is scoped to; repeatable. \
+                     Compliance-scoped apps cannot run on cross-tenant compute",
+                ),
+        )
+        .arg(
+            // Managed mode: how MANY of this app run. A third, independent
+            // rail — a managed app still has a placement and still declares
+            // its frameworks.
+            Arg::new("managed")
+                .long("managed")
+                .action(ArgAction::SetTrue)
+                .help("Deploy one instance per customer rather than one shared deployment"),
+        )
+        .arg(
             Arg::new("no_integrate")
                 .long("no-integrate")
                 .action(ArgAction::SetTrue)
@@ -98,6 +131,16 @@ impl CliCommand for CreateCommand {
             .cloned()
             .unwrap_or_else(|| manifest.app_description.clone());
 
+        // Three independent rails, all settled at creation so the first deploy
+        // has nothing to ask: WHERE it runs, what rules its data is under, and
+        // how many of it run.
+        let cluster_type = matches.get_one::<String>("cluster_type").cloned();
+        let compliance_frameworks: Vec<String> = matches
+            .get_many::<String>("compliance_framework")
+            .map(|values| values.cloned().collect())
+            .unwrap_or_default();
+        let managed = matches.get_flag("managed");
+
         let api_url = get_platform_management_api_url();
         let client = Client::new();
 
@@ -117,13 +160,28 @@ impl CliCommand for CreateCommand {
         let create_response = client
             .post(format!("{}/applications/", api_url))
             .bearer_auth(&token)
-            .json(&serde_json::json!({
-                "name": name,
-                "description": description,
-                "userId": me.id,
-                "organizationId": me.organization_id,
-                "isDeleted": false
-            }))
+            .json(&{
+                let mut body = serde_json::json!({
+                    "name": name,
+                    "description": description,
+                    "userId": me.id,
+                    "organizationId": me.organization_id,
+                    "isDeleted": false
+                });
+                // Omitted rather than sent as null: an undeclared app is
+                // unconstrained, which is not the same as declaring "none".
+                if let Some(cluster_type) = &cluster_type {
+                    body["clusterType"] = serde_json::json!(cluster_type);
+                }
+                if !compliance_frameworks.is_empty() {
+                    body["complianceFrameworks"] =
+                        serde_json::json!(compliance_frameworks);
+                }
+                if managed {
+                    body["managedMode"] = serde_json::json!(true);
+                }
+                body
+            })
             .send()
             .with_context(|| ERROR_FAILED_TO_SEND_REQUEST)?;
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -17,6 +17,7 @@ use app::AppCommand;
 use integrate::IntegrateCommand;
 use login::LoginCommand;
 use logout::LogoutCommand;
+use managed::ManagedCommand;
 use observe::ObserveCommand;
 use openapi::OpenApiCommand;
 use release::ReleaseCommand;
@@ -46,6 +47,7 @@ mod init;
 mod integrate;
 mod login;
 mod logout;
+mod managed;
 mod observe;
 mod openapi;
 mod prompt;
@@ -79,6 +81,7 @@ fn main() -> Result<()> {
     let integrate = IntegrateCommand::new();
     let login = LoginCommand::new();
     let logout = LogoutCommand::new();
+    let managed = ManagedCommand::new();
     let observe = ObserveCommand::new();
     let openapi = OpenApiCommand::new();
     let release = ReleaseCommand::new();
@@ -110,6 +113,7 @@ fn main() -> Result<()> {
         .subcommand(release.command())
         .subcommand(login.command())
         .subcommand(logout.command())
+        .subcommand(managed.command())
         .subcommand(observe.command())
         .subcommand(sdk.command())
         .subcommand(whoami.command())
@@ -141,6 +145,7 @@ fn main() -> Result<()> {
         Some(("release", sub_matches)) => release.handler(sub_matches),
         Some(("login", sub_matches)) => login.handler(sub_matches),
         Some(("logout", sub_matches)) => logout.handler(sub_matches),
+        Some(("managed", sub_matches)) => managed.handler(sub_matches),
         Some(("observe", sub_matches)) => observe.handler(sub_matches),
         Some(("sdk", sub_matches)) => sdk.handler(sub_matches),
         Some(("whoami", sub_matches)) => whoami.handler(sub_matches),

--- a/cli/src/managed/mod.rs
+++ b/cli/src/managed/mod.rs
@@ -1,0 +1,39 @@
+use anyhow::Result;
+use clap::{ArgMatches, Command};
+
+use crate::{CliCommand, core::command::command};
+
+mod summary;
+
+use summary::SummaryCommand;
+
+#[derive(Debug)]
+pub(crate) struct ManagedCommand {
+    summary: SummaryCommand,
+}
+
+impl ManagedCommand {
+    pub(crate) fn new() -> Self {
+        Self {
+            summary: SummaryCommand::new(),
+        }
+    }
+}
+
+impl CliCommand for ManagedCommand {
+    fn command(&self) -> Command {
+        command(
+            "managed",
+            "Inspect managed app instances and the OAuth relay that routes their sign-ins",
+        )
+        .subcommand(self.summary.command())
+        .subcommand_required(true)
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        match matches.subcommand() {
+            Some(("summary", sub_matches)) => self.summary.handler(sub_matches),
+            _ => unreachable!(),
+        }
+    }
+}

--- a/cli/src/managed/summary.rs
+++ b/cli/src/managed/summary.rs
@@ -1,0 +1,220 @@
+use std::io::Write;
+
+use anyhow::{Context, Result};
+use clap::{Arg, ArgAction, ArgMatches, Command};
+use serde::{Deserialize, Serialize};
+use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
+
+use crate::{
+    CliCommand,
+    constants::get_platform_management_api_url,
+    core::{command::command, hmac::AuthMode, http_client::get_with_auth},
+};
+
+/// `forklaunch managed summary`
+///
+/// Two questions this answers that nothing else does: which instances are
+/// running and whether sign-in would actually work for them, and the exact
+/// callback URL to register with the OAuth provider. Both come from one
+/// control-plane call, so the output cannot show a half-answer.
+#[derive(Debug)]
+pub(super) struct SummaryCommand;
+
+impl SummaryCommand {
+    pub(super) fn new() -> Self {
+        Self
+    }
+}
+
+impl CliCommand for SummaryCommand {
+    fn command(&self) -> Command {
+        command(
+            "summary",
+            "Managed instances, their sign-in eligibility, and the relay contract per template",
+        )
+        .arg(
+            Arg::new("base_path")
+                .short('p')
+                .long("path")
+                .help("The application path"),
+        )
+        .arg(
+            Arg::new("json")
+                .long("json")
+                .help("Output raw JSON instead of formatted terminal output")
+                .action(ArgAction::SetTrue),
+        )
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        let json_output = matches.get_flag("json");
+        let summary = fetch_summary()?;
+
+        if json_output {
+            println!("{}", serde_json::to_string_pretty(&summary)?);
+        } else {
+            print_summary(&summary)?;
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ManagedInstanceSummary {
+    id: String,
+    template_slug: String,
+    host: String,
+    region: String,
+    state: String,
+    relay_eligible: bool,
+    #[serde(default)]
+    current_version_semver: Option<String>,
+    #[serde(default)]
+    last_error: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RelayConfigSummary {
+    template_slug: String,
+    callback_url: String,
+    state_format: String,
+    host_pattern: String,
+    eligible_states: Vec<String>,
+    state_ttl_seconds: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Counts {
+    total: u64,
+    relay_eligible: u64,
+    failed: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ManagedModeSummary {
+    available: bool,
+    #[serde(default)]
+    unavailable_reason: Option<String>,
+    instances: Vec<ManagedInstanceSummary>,
+    relay_configs: Vec<RelayConfigSummary>,
+    counts: Counts,
+}
+
+fn fetch_summary() -> Result<ManagedModeSummary> {
+    let url = format!("{}/managed-mode/summary", get_platform_management_api_url());
+    let auth_mode = AuthMode::detect();
+    let response =
+        get_with_auth(&auth_mode, &url).with_context(|| "Failed to reach the control plane")?;
+
+    if !response.status().is_success() {
+        let http_status = response.status();
+        let body = response
+            .text()
+            .unwrap_or_else(|_| "unknown error".to_string());
+        anyhow::bail!("Control plane returned {} — {}", http_status, body);
+    }
+
+    response
+        .json()
+        .with_context(|| "Failed to parse managed mode summary")
+}
+
+fn print_summary(summary: &ManagedModeSummary) -> Result<()> {
+    let mut stdout = StandardStream::stdout(ColorChoice::Auto);
+
+    if !summary.available {
+        // Say why, rather than printing an empty list that reads as
+        // "you have no instances".
+        stdout.set_color(ColorSpec::new().set_fg(Some(Color::Yellow)))?;
+        writeln!(stdout, "Managed mode is off")?;
+        stdout.reset()?;
+        if let Some(reason) = &summary.unavailable_reason {
+            writeln!(stdout, "  {}", reason)?;
+        }
+        return Ok(());
+    }
+
+    stdout.set_color(ColorSpec::new().set_bold(true).set_fg(Some(Color::Cyan)))?;
+    writeln!(stdout, "Managed apps")?;
+    stdout.reset()?;
+    writeln!(
+        stdout,
+        "  {} instance(s) · {} sign-in eligible · {} reporting errors",
+        summary.counts.total, summary.counts.relay_eligible, summary.counts.failed
+    )?;
+    writeln!(stdout)?;
+
+    if !summary.relay_configs.is_empty() {
+        stdout.set_color(ColorSpec::new().set_bold(true))?;
+        writeln!(stdout, "  OAuth relay")?;
+        stdout.reset()?;
+        writeln!(
+            stdout,
+            "  Register this as the redirect URI — one per template, shared by all its instances."
+        )?;
+        for cfg in &summary.relay_configs {
+            writeln!(stdout)?;
+            writeln!(stdout, "    {}", cfg.template_slug)?;
+            stdout.set_color(ColorSpec::new().set_fg(Some(Color::Green)))?;
+            writeln!(stdout, "      {}", cfg.callback_url)?;
+            stdout.reset()?;
+            writeln!(stdout, "      state    {}", cfg.state_format)?;
+            writeln!(
+                stdout,
+                "      expires  {} min",
+                cfg.state_ttl_seconds / 60
+            )?;
+            writeln!(
+                stdout,
+                "      routed   while {}",
+                cfg.eligible_states.join(", ")
+            )?;
+        }
+        writeln!(stdout)?;
+    }
+
+    if summary.instances.is_empty() {
+        writeln!(stdout, "  No instances yet.")?;
+        return Ok(());
+    }
+
+    stdout.set_color(ColorSpec::new().set_bold(true))?;
+    writeln!(stdout, "  Instances")?;
+    stdout.reset()?;
+
+    for instance in &summary.instances {
+        // Sign-in eligibility is the same check the relay applies, so an
+        // ineligible instance will have its callback refused.
+        let (marker, color) = if instance.relay_eligible {
+            ("✓", Color::Green)
+        } else {
+            ("✗", Color::Yellow)
+        };
+        stdout.set_color(ColorSpec::new().set_fg(Some(color)))?;
+        write!(stdout, "    {} ", marker)?;
+        stdout.reset()?;
+        write!(stdout, "{}", instance.host)?;
+        writeln!(
+            stdout,
+            "  [{}]{}",
+            instance.state,
+            instance
+                .current_version_semver
+                .as_ref()
+                .map(|v| format!(" v{}", v))
+                .unwrap_or_default()
+        )?;
+        if let Some(err) = &instance.last_error {
+            stdout.set_color(ColorSpec::new().set_fg(Some(Color::Red)))?;
+            writeln!(stdout, "        {}", err)?;
+            stdout.reset()?;
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Consumes the control-plane endpoints added in `forklaunch-platform#400`.

> [!IMPORTANT]
> **Do not release ahead of forklaunch-platform#400 being deployed.** `managed summary` calls `/managed-mode/summary`, and the new creation fields are rejected by the older application schema. Merging is fine; tagging a release before that deploy would ship a CLI that fails against production.

## `forklaunch managed summary`

```
forklaunch managed summary [--json]
```

Renders the fleet, each instance's sign-in eligibility, and the per-template OAuth callback URL to register.

Eligibility is **the same predicate the relay applies**, so an instance shown as refused really will have its callback refused — it isn't a separate heuristic that can drift. When managed mode is off, it says so, rather than printing an empty list that reads as "you have no instances".

## `app create` gains three independent rails

| flag | question |
|---|---|
| `--cluster-type` | **where** compute lands |
| `--compliance-framework` (repeatable) | **what rules** the data is under |
| `--managed` | **how many** run — one per customer, or one shared deployment |

```
forklaunch app create --name health-vault \
  --managed \
  --compliance-framework HIPAA \
  --cluster-type org-shared
```

They're deliberately three flags rather than one mode. A managed app still has a placement and still declares its frameworks; compliance isn't a placement variant, it **constrains** placement, because compliance-scoped apps cannot run on cross-tenant compute.

## Why creation, not deploy

Setting placement here means the deploy-time 428 gate has nothing left to ask — `deploy create --cluster-type` becomes the fallback for apps created before this, rather than the normal path. It also puts compliance where it belongs: it follows from the data an app holds, so it's a property of the app, not of what its org's plan permits.

Unset values are **omitted** from the payload rather than sent as `null` or `[]`. An undeclared app is unconstrained, which is deliberately different from declaring that no frameworks apply.

## Test plan

- [x] `cargo check` clean; no warnings from the new files
- [x] `forklaunch managed --help` / `managed summary --help` render correctly
- [x] `forklaunch app create --help` shows all three flags with their value parsers
- [ ] After forklaunch-platform#400 deploys: run `managed summary` against staging and confirm the callback URL matches what the relay serves
- [ ] Tag `cli-v1.8.0` — new commands and flags are a minor bump, not a patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UDKRm9cMDurLvhvodioUnE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added cluster placement, repeatable compliance framework, and managed-mode options to application creation.
  - Added the `managed summary` command for viewing managed-mode availability, status, aggregate counts, OAuth relay details, and instance information.
  - Supports terminal-friendly output and formatted JSON.
- **Error Handling**
  - Added clear reporting for unavailable managed mode, instance errors, network failures, HTTP errors, and invalid responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->