### PR TITLE
fix(cli): pin minimumReleaseAge on scaffold so first deploy doesn't fail

### DIFF
--- a/cli/src/change/application.rs
+++ b/cli/src/change/application.rs
@@ -1168,6 +1168,11 @@ fn change_runtime(
     match runtime {
         Runtime::Bun => {
             application_json_to_write.workspaces = Some(existing_workspaces);
+            if let Some(rendered) =
+                crate::core::bunfig::generate_bunfig(&base_path.to_string_lossy())?
+            {
+                rendered_templates_cache.insert("bunfig.toml".to_string(), rendered);
+            }
         }
         Runtime::Node => {
             rendered_templates_cache.insert(

--- a/cli/src/constants.rs
+++ b/cli/src/constants.rs
@@ -512,6 +512,7 @@ pub(crate) const ERROR_FAILED_TO_CREATE_LICENSE: &str =
     "Failed to create license file. Please check your target directory is writable.";
 pub(crate) const ERROR_FAILED_TO_GENERATE_PNPM_WORKSPACE: &str =
     "Failed to generate pnpm-workspace.yaml.";
+pub(crate) const ERROR_FAILED_TO_GENERATE_BUNFIG: &str = "Failed to generate bunfig.toml.";
 pub(crate) const ERROR_FAILED_TO_ADD_PROJECT_METADATA_TO_DOCKER_COMPOSE: &str =
     "Failed to add project metadata to docker compose yaml.";
 pub(crate) const ERROR_FAILED_TO_ADD_PROJECT_METADATA_TO_MANIFEST: &str =

--- a/cli/src/core.rs
+++ b/cli/src/core.rs
@@ -3,6 +3,7 @@ pub(crate) mod log;
 #[macro_use]
 pub(crate) mod ast;
 pub(crate) mod base_path;
+pub(crate) mod bunfig;
 pub(crate) mod choices;
 pub(crate) mod client_sdk;
 pub(crate) mod command;

--- a/cli/src/core/bunfig.rs
+++ b/cli/src/core/bunfig.rs
@@ -1,0 +1,48 @@
+use std::path::Path;
+
+use anyhow::Result;
+
+use super::rendered_template::RenderedTemplate;
+
+/// Bun equivalent of pnpm_workspace.rs's minimumReleaseAge default. Bun's
+/// [install] table takes seconds, not minutes: 86400 = 24h, matching pnpm's
+/// 1440-minute default and forklaunch-platform's own pnpm-workspace.yaml.
+/// Same rationale: pin it explicitly so a scaffold's local `bun install`
+/// resolves under the same age policy the deploy pipeline enforces, rather
+/// than locking in fresh versions the pipeline's bun then rejects.
+const BUNFIG_TOML: &str = "[install]\nminimumReleaseAge = 86400\n";
+
+pub(crate) fn generate_bunfig(application_path: &str) -> Result<Option<RenderedTemplate>> {
+    let bunfig_path = Path::new(application_path).join("bunfig.toml");
+    if bunfig_path.exists() {
+        return Ok(None);
+    }
+
+    Ok(Some(RenderedTemplate {
+        path: bunfig_path,
+        content: BUNFIG_TOML.to_string(),
+        context: None,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generate_bunfig_pins_minimum_release_age() {
+        let dir = tempfile::tempdir().unwrap();
+        let rendered = generate_bunfig(dir.path().to_str().unwrap())
+            .unwrap()
+            .unwrap();
+        assert!(rendered.content.contains("minimumReleaseAge = 86400"));
+    }
+
+    #[test]
+    fn test_generate_bunfig_skips_existing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("bunfig.toml"), "# existing\n").unwrap();
+        let rendered = generate_bunfig(dir.path().to_str().unwrap()).unwrap();
+        assert!(rendered.is_none());
+    }
+}

--- a/cli/src/core/pnpm_workspace.rs
+++ b/cli/src/core/pnpm_workspace.rs
@@ -116,6 +116,16 @@ fn sanitize_minimum_release_age_exclude(pnpm_workspace: &mut PnpmWorkspace) {
     *entries = normalized;
 }
 
+/// Set-if-missing on every rewrite path, not just initial creation, so an
+/// app that already existed before this default was introduced (or had the
+/// key stripped) still gets it back.
+fn ensure_minimum_release_age(pnpm_workspace: &mut PnpmWorkspace) {
+    pnpm_workspace
+        .other
+        .entry("minimumReleaseAge".to_string())
+        .or_insert(Value::Number(1440.into()));
+}
+
 /// Pin explicitly rather than leave unset: pnpm >=11.2 defaults
 /// minimumReleaseAge to 1440 (24h), but a scaffold's local `pnpm install`
 /// may run on an older pnpm with no age gate at all, resolving versions the
@@ -166,12 +176,13 @@ pub(crate) fn render_pnpm_workspace_with_packages(
         PnpmWorkspace {
             packages: Vec::new(),
             allow_builds: None,
-            other: BTreeMap::new(),
+            other: default_other(),
         }
     };
     pnpm_workspace.packages = packages;
     sanitize_allow_builds(&mut pnpm_workspace);
     sanitize_minimum_release_age_exclude(&mut pnpm_workspace);
+    ensure_minimum_release_age(&mut pnpm_workspace);
     Ok(to_string(&pnpm_workspace)
         .with_context(|| ERROR_FAILED_TO_GENERATE_PNPM_WORKSPACE)?)
 }
@@ -193,6 +204,7 @@ pub(crate) fn add_project_definition_to_pnpm_workspace<
     }
     sanitize_allow_builds(&mut pnpm_workspace);
     sanitize_minimum_release_age_exclude(&mut pnpm_workspace);
+    ensure_minimum_release_age(&mut pnpm_workspace);
     Ok(to_string(&pnpm_workspace)
         .with_context(|| ERROR_FAILED_TO_ADD_PROJECT_METADATA_TO_PNPM_WORKSPACE)?)
 }
@@ -216,6 +228,7 @@ pub(crate) fn remove_project_definition_to_pnpm_workspace(
     }
     sanitize_allow_builds(&mut pnpm_workspace);
     sanitize_minimum_release_age_exclude(&mut pnpm_workspace);
+    ensure_minimum_release_age(&mut pnpm_workspace);
 
     Ok(to_string(&pnpm_workspace)
         .with_context(|| ERROR_FAILED_TO_ADD_PROJECT_METADATA_TO_PNPM_WORKSPACE)?)
@@ -254,5 +267,28 @@ mod tests {
             .unwrap()
             .unwrap();
         assert!(rendered.content.contains("minimumReleaseAge: 1440"));
+    }
+
+    #[test]
+    fn test_render_pnpm_workspace_with_packages_pins_minimum_release_age_when_file_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let rendered =
+            render_pnpm_workspace_with_packages(dir.path(), vec!["core".to_string()]).unwrap();
+        assert!(rendered.contains("minimumReleaseAge: 1440"));
+    }
+
+    #[test]
+    fn test_ensure_minimum_release_age_backfills_when_absent() {
+        let mut ws: PnpmWorkspace = from_str("packages:\n- core\n").unwrap();
+        ensure_minimum_release_age(&mut ws);
+        assert!(to_string(&ws).unwrap().contains("minimumReleaseAge: 1440"));
+    }
+
+    #[test]
+    fn test_ensure_minimum_release_age_preserves_existing_value() {
+        let mut ws: PnpmWorkspace =
+            from_str("packages:\n- core\nminimumReleaseAge: 0\n").unwrap();
+        ensure_minimum_release_age(&mut ws);
+        assert!(to_string(&ws).unwrap().contains("minimumReleaseAge: 0"));
     }
 }

--- a/cli/src/core/pnpm_workspace.rs
+++ b/cli/src/core/pnpm_workspace.rs
@@ -116,6 +116,17 @@ fn sanitize_minimum_release_age_exclude(pnpm_workspace: &mut PnpmWorkspace) {
     *entries = normalized;
 }
 
+/// Pin explicitly rather than leave unset: pnpm >=11.2 defaults
+/// minimumReleaseAge to 1440 (24h), but a scaffold's local `pnpm install`
+/// may run on an older pnpm with no age gate at all, resolving versions the
+/// deploy pipeline's newer pnpm then rejects from an already-locked
+/// lockfile. Setting it explicitly makes local resolution skip too-new
+/// versions the same way deploy does, so the generated lockfile is already
+/// compliant. Same value as forklaunch-platform's own pnpm-workspace.yaml.
+fn default_other() -> BTreeMap<String, Value> {
+    BTreeMap::from([("minimumReleaseAge".to_string(), Value::Number(1440.into()))])
+}
+
 pub(crate) fn generate_pnpm_workspace(
     application_path: &str,
     additional_projects: &Vec<ProjectEntry>,
@@ -130,7 +141,7 @@ pub(crate) fn generate_pnpm_workspace(
         content: to_string(&PnpmWorkspace {
             packages: additional_projects.iter().map(|p| p.name.clone()).collect(),
             allow_builds: Some(default_allow_builds()),
-            other: BTreeMap::new(),
+            other: default_other(),
         })
         .with_context(|| ERROR_FAILED_TO_GENERATE_PNPM_WORKSPACE)?,
         context: None,
@@ -234,5 +245,14 @@ mod tests {
         let mut ws: PnpmWorkspace = from_str("packages:\n- core\n").unwrap();
         sanitize_minimum_release_age_exclude(&mut ws);
         assert!(!to_string(&ws).unwrap().contains("minimumReleaseAgeExclude"));
+    }
+
+    #[test]
+    fn test_generate_pnpm_workspace_pins_minimum_release_age() {
+        let dir = tempfile::tempdir().unwrap();
+        let rendered = generate_pnpm_workspace(dir.path().to_str().unwrap(), &Vec::new())
+            .unwrap()
+            .unwrap();
+        assert!(rendered.content.contains("minimumReleaseAge: 1440"));
     }
 }

--- a/cli/src/init/application.rs
+++ b/cli/src/init/application.rs
@@ -21,7 +21,8 @@ use crate::{
     constants::{
         Database, ERROR_FAILED_TO_CREATE_DATABASE_EXPORT_INDEX_TS,
         ERROR_FAILED_TO_CREATE_GITIGNORE, ERROR_FAILED_TO_CREATE_LICENSE,
-        ERROR_FAILED_TO_GENERATE_PNPM_WORKSPACE, ERROR_FAILED_TO_PARSE_DOCKER_COMPOSE,
+        ERROR_FAILED_TO_GENERATE_BUNFIG, ERROR_FAILED_TO_GENERATE_PNPM_WORKSPACE,
+        ERROR_FAILED_TO_PARSE_DOCKER_COMPOSE,
         Formatter, HttpFramework, License, Linter, Module, ModulesPath,
         Runtime, TestFramework, Validator, get_core_module_description,
         get_monitoring_module_description, get_service_module_cache,
@@ -76,6 +77,7 @@ use crate::{
             },
             project_package_json::{ProjectDependencies, ProjectDevDependencies, ProjectScripts},
         },
+        bunfig::generate_bunfig,
         pnpm_workspace::generate_pnpm_workspace,
         rendered_template::{RenderedTemplate, create_forklaunch_dir, write_rendered_templates},
         symlinks::generate_symlinks,
@@ -1229,6 +1231,11 @@ impl CliCommand for ApplicationCommand {
             rendered_templates.extend(
                 generate_pnpm_workspace(&application_path, &additional_projects)
                     .with_context(|| ERROR_FAILED_TO_GENERATE_PNPM_WORKSPACE)?,
+            );
+        } else if runtime == Runtime::Bun {
+            rendered_templates.extend(
+                generate_bunfig(&application_path)
+                    .with_context(|| ERROR_FAILED_TO_GENERATE_BUNFIG)?,
             );
         }
 


### PR DESCRIPTION
## Bug
A fresh scaffold always resolves the newest available version of every dependency, but pnpm >=11.2 defaults to a 24h minimumReleaseAge supply-chain gate, and CodeBuild always installs the latest pnpm. A locked-in fresh version then gets rejected at deploy time, every time, for any app deployed the same day it's scaffolded.

## Fix
- cli/src/core/pnpm_workspace.rs: pins `minimumReleaseAge: 1440` in scaffolded pnpm-workspace.yaml (node runtime).
- cli/src/core/bunfig.rs (new): pins `minimumReleaseAge = 86400` (seconds, same 24h) in a new bunfig.toml (bun runtime).
- cli/src/init/application.rs: wires the bun path in alongside the existing node path.
- cli/src/constants.rs, cli/src/core.rs: new error string + module registration.

This keeps the actual security policy intact (still 24h everywhere), it just makes local scaffold resolution respect the same window the deploy pipeline enforces, instead of locking in versions that get rejected later.

## Test plan
- [x] Unit tests for both pnpm and bun paths assert the exact pinned value
- [x] Full cargo test suite passes, including init::application
- [ ] Manual: fresh scaffold -> deploy same day succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bun-based applications now automatically generate a `bunfig.toml` configuration file with a 24-hour minimum release age.
  * Existing `bunfig.toml` files are preserved during initialization and runtime changes.
  * Node-based applications now generate and maintain workspaces with an explicitly configured package release-age policy.

* **Bug Fixes**
  * Added clearer error handling when Bun configuration generation fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->