### PR TITLE
chore(cli): bump dialoguer + hmac (supersedes #133 and #160)

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -42,11 +42,11 @@ fs_extra = "1.3.0"
 walkdir = "2.5.0"
 regex = "1.11.1"
 lazy_static = "1.5.0"
-dialoguer = { version = "0.11.0", features = ["fuzzy-select"] }
+dialoguer = { version = "0.12.0", features = ["fuzzy-select"] }
 glob = "0.3.2"
 getrandom = { version = "0.2", features = ["js"] }
-hmac = "0.12"
-sha2 = "0.10"
+hmac = "0.13"
+sha2 = "0.11"
 rand = "0.8"
 serde-envfile = "0.3.0"
 tempfile = "3.20.0"

--- a/cli/src/core/hmac.rs
+++ b/cli/src/core/hmac.rs
@@ -1,6 +1,8 @@
 use anyhow::Result;
 use chrono::{SecondsFormat, Utc};
-use hmac::{Hmac, Mac};
+// hmac 0.13 no longer surfaces `new_from_slice` through `Mac`; it comes from
+// `KeyInit`, which must now be imported explicitly.
+use hmac::{Hmac, KeyInit, Mac};
 use serde_json::Value;
 use sha2::Sha256;
 use uuid::Uuid;

--- a/cli/src/prompt.rs
+++ b/cli/src/prompt.rs
@@ -203,8 +203,10 @@ pub(crate) fn prompt_comma_separated_list(
                         .collect::<Vec<&&str>>()
                         .as_slice(),
                 );
+                // dialoguer 0.12 takes the item iterator by value; passing a
+                // reference yields `&(T, bool)` where `(T, bool)` is required.
                 multi_select = multi_select.items_checked(
-                    &active_options
+                    active_options
                         .iter()
                         .map(|v| (*v, true))
                         .collect::<Vec<_>>(),


### PR DESCRIPTION
Replaces dependabot #133 and #160. Neither compiles on its own — I built both against current `main` to check.

## dialoguer 0.11 → 0.12

```
error[E0271]: type mismatch resolving `<&Vec<(&str, bool)> as IntoIterator>::Item == (_, bool)`
  --> src/prompt.rs:207:21
```

`MultiSelect::items_checked` now takes its item iterator **by value**; passing a reference yields `&(T, bool)` where `(T, bool)` is required. One line — drop the borrow.

## hmac 0.12 → 0.13, **with sha2 0.10 → 0.11**

This is why #160 could not work alone. hmac 0.13 moved to a newer `digest` generation, so a `sha2` still on the old one leaves `Sha256` failing every trait bound hmac needs:

```
CoreWrapper<...>: CoreProxy is not satisfied
CoreWrapper<...>: BlockSizeUser is not satisfied
CoreWrapper<...>: FixedOutput is not satisfied
CoreWrapper<...>: HashMarker is not satisfied
```

Bumping the pair together clears all four. The fifth error is separate — `new_from_slice` is no longer reachable through `Mac`, so `KeyInit` is now imported explicitly (the compiler suggests exactly this).

## Verification

On stable rustc 1.98: `cargo check` clean, `cargo test` **449 passed, 0 failed**.

## Not included: the oxc bumps (#161, #162, #163)

Those cannot be done this way and are being closed separately. `main` pins **six** oxc crates at `0.80.0` — `oxc_allocator`, `oxc_ast`, `oxc_codegen`, `oxc_parser`, `oxc_ast_visit`, `oxc_span` — and dependabot opened three PRs each bumping one, with none for the other three. Any mix is incoherent since they share types.

I bumped **all six** together to see whether a proper PR would work. Two blockers: `oxc 0.124` requires **rustc 1.92** (CI uses `dtolnay/rust-toolchain@stable`, so that part is fine), and on stable it produces **27 errors** — `BindingPatternKind` no longer exists in `oxc_ast::ast`, among others. It is a 44-version jump needing a real migration, not a version bump.