### PR TITLE
feat(cli): `forklaunch managed` command group, with template and instance variables

### DIFF
--- a/cli/src/core/http_client.rs
+++ b/cli/src/core/http_client.rs
@@ -127,6 +127,26 @@ pub fn delete(url: &str) -> Result<Response> {
     make_authenticated_request(Method::DELETE, url, None)
 }
 
+/// POST with NO credentials and NO token lookup.
+///
+/// Every other helper here funnels through `make_authenticated_request`, which calls
+/// `get_token()` and, if that fails, drops the user into an interactive login. That is
+/// the wrong behavior for a route the platform declares `access: 'public'` and that a
+/// person with no ForkLaunch account is expected to call — `managed instance claim` is
+/// the case this exists for, where a one-time token in the body is the credential.
+///
+/// Keeps the `Accept` and `User-Agent` headers so these requests are still identifiable
+/// as CLI-originated in platform logs.
+pub fn post_unauthenticated(url: &str, body: Value) -> Result<Response> {
+    let client = Client::new();
+    Ok(client
+        .post(url)
+        .header("Accept", "application/json")
+        .header("User-Agent", user_agent())
+        .json(&body)
+        .send()?)
+}
+
 /// Extract the path component from a full URL (e.g. "https://host:port/path?q" -> "/path?q")
 fn extract_url_path(url: &str) -> Result<String> {
     // Find the start of the path after scheme://host(:port)

--- a/cli/src/managed/client.rs
+++ b/cli/src/managed/client.rs
@@ -1,0 +1,522 @@
+use anyhow::{Context, Result, bail};
+use reqwest::blocking::Response;
+use serde::Deserialize;
+use serde_json::Value;
+
+use super::types::ManagedInstance;
+use crate::{
+    constants::{ERROR_FAILED_TO_SEND_REQUEST, get_platform_management_api_url},
+    core::{
+        hmac::AuthMode,
+        http_client::{delete, get_with_auth, patch, post_unauthenticated, post_with_auth},
+        validate::resolve_auth,
+    },
+};
+
+/// Every managed-apps command talks to platform-management's `/managed-mode` router and
+/// never to the managed-apps service directly. That service's own design rule is "the
+/// CLI and the dashboard both call platform-management, never managed-apps directly" —
+/// platform-management is the control plane that owns organization scoping, role
+/// checks, and auditing for these operations.
+const MANAGED_MODE_BASE: &str = "/managed-mode";
+
+/// Shown whenever the control plane answers a managed-apps route with 404. A 404 here
+/// means the route is not mounted, which in practice means the platform predates the
+/// managed-apps control-plane API rather than that the user did anything wrong.
+pub(super) const UNSUPPORTED_CONTROL_PLANE: &str = "this control plane does not support managed apps yet — upgrade the platform \
+     (the /managed-mode API this CLI needs is not mounted on the host it is pointed at)";
+
+pub(super) fn managed_url(path: &str) -> String {
+    format!(
+        "{}{}{}",
+        get_platform_management_api_url(),
+        MANAGED_MODE_BASE,
+        path
+    )
+}
+
+/// Managed-apps commands are session-scoped on purpose. Templates and instances hang
+/// off the calling user's organization, and HMAC/CI credentials carry no organization
+/// identity for the control plane to scope them to — so rather than silently acting on
+/// the wrong organization, refuse with an explanation.
+pub(super) fn resolve_managed_auth() -> Result<AuthMode> {
+    let auth_mode = resolve_auth()?;
+    if auth_mode.is_hmac() {
+        bail!(
+            "managed commands require user/session auth — run `forklaunch login` first. \
+             HMAC (CI) credentials carry no organization identity, so the control plane \
+             cannot tell which organization's templates and instances to act on."
+        );
+    }
+    Ok(auth_mode)
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct ManagedModeSummary {
+    #[serde(default)]
+    pub(super) available: Option<bool>,
+    #[serde(default)]
+    pub(super) unavailable_reason: Option<String>,
+    #[serde(default)]
+    pub(super) instances: Vec<ManagedInstance>,
+}
+
+impl ManagedModeSummary {
+    /// Treats a missing `available` field as available. A partial control-plane build
+    /// may omit it, and refusing to run in that case would be a worse failure than
+    /// letting the real request return its own error.
+    fn is_available(&self) -> bool {
+        self.available.unwrap_or(true)
+    }
+}
+
+/// Fetches `/managed-mode/summary`, failing loudly when managed apps is either
+/// unsupported by this control plane or not configured for this deployment.
+///
+/// Every subcommand calls this before its real request. That costs one extra round trip
+/// and buys the difference between "you have no templates" and "managed apps was never
+/// wired up here" — an empty list would otherwise read as the former when it is really
+/// the latter. The parsed summary is returned rather than discarded because it already
+/// carries the instance list, which `managed instance list` reuses.
+pub(super) fn require_managed_mode(auth_mode: &AuthMode) -> Result<ManagedModeSummary> {
+    let url = managed_url("/summary");
+    let response = get_with_auth(auth_mode, &url).with_context(|| ERROR_FAILED_TO_SEND_REQUEST)?;
+    let status = response.status();
+
+    if status.as_u16() == 404 {
+        bail!("{}", UNSUPPORTED_CONTROL_PLANE);
+    }
+    if status.as_u16() == 401 || status.as_u16() == 403 {
+        bail!(
+            "not authorized to use managed apps ({}) — run `forklaunch login`, and check that your organization has managed apps enabled",
+            status
+        );
+    }
+    if !status.is_success() {
+        bail!(
+            "control plane returned {} for {} — {}",
+            status,
+            url,
+            body_snippet(response)
+        );
+    }
+
+    let summary: ManagedModeSummary = response
+        .json()
+        .with_context(|| "Failed to parse the managed mode summary response")?;
+
+    if !summary.is_available() {
+        // The platform returns 200 with available:false for both "MANAGED_APPS_URL is
+        // unset" and "managed-apps is unreachable". Print its reason verbatim — it is
+        // more specific than anything this CLI could infer.
+        let reason = summary
+            .unavailable_reason
+            .as_deref()
+            .unwrap_or("managed apps is not configured for this deployment")
+            .to_string();
+        bail!(
+            "managed apps is not available on this control plane: {}",
+            reason
+        );
+    }
+
+    Ok(summary)
+}
+
+/// What a 404 should mean for a given call.
+pub(super) enum Missing {
+    /// A collection-level route, so a 404 can only mean the endpoint is absent.
+    Endpoint,
+    /// A route addressing one record, so a 404 is ambiguous: either the record does not
+    /// exist, or the endpoint is not implemented on this control plane. Say both.
+    Resource(String),
+    /// A route whose caller has a better account of what a 404 means than "not found"
+    /// does. Used by `instance claim`: the control plane answers one deliberately
+    /// indistinguishable 404 for a bad token, an expired token, an already-claimed
+    /// instance, and an unknown id, so that an attacker cannot probe which links are
+    /// live. The CLI must not invent a distinction the server refused to make — it
+    /// lists the possibilities instead.
+    Custom(String),
+}
+
+pub(super) fn ensure_success(response: Response, missing: Missing) -> Result<Response> {
+    let status = response.status();
+    if status.is_success() {
+        return Ok(response);
+    }
+
+    match status.as_u16() {
+        404 => {
+            let snippet = body_snippet(response);
+            // A 404 from a route that exists carries the platform's own explanation; a
+            // 404 from a route that was never mounted carries the framework's default
+            // ("Cannot POST /managed-mode/templates"). Distinguishing them is what keeps
+            // "you asked for something that isn't there" from being reported as "your
+            // platform is too old", and vice versa.
+            if is_unrouted_404(&snippet) {
+                bail!("{}", UNSUPPORTED_CONTROL_PLANE);
+            }
+            match missing {
+                Missing::Endpoint => bail!("{}", UNSUPPORTED_CONTROL_PLANE),
+                Missing::Resource(what) => bail!("{} not found — {}", what, snippet),
+                Missing::Custom(message) => bail!("{}", message),
+            }
+        }
+        // 503 is the control plane's own "managed-apps is unreachable" signal on the
+        // proxy routes, distinct from a 404 meaning the route is missing.
+        503 => bail!(
+            "managed apps is temporarily unavailable — {}",
+            body_snippet(response)
+        ),
+        401 | 403 => bail!("not authorized ({}) — {}", status, body_snippet(response)),
+        409 => bail!("conflict — {}", body_snippet(response)),
+        // The control plane validates enum-ish fields itself and answers 400 with the
+        // allowed values (for example "status must be one of: draft, published,
+        // retired"). Surface that body verbatim — it is more useful than anything this
+        // CLI would restate, and wrapping it in "control plane returned 400" only pushes
+        // the actionable part further right.
+        400 => bail!("{}", body_snippet(response)),
+        _ => bail!(
+            "control plane returned {} — {}",
+            status,
+            body_snippet(response)
+        ),
+    }
+}
+
+/// Recognizes the "no route matched" 404 that Express-style servers generate, as
+/// opposed to a 404 a real handler chose to return.
+fn is_unrouted_404(snippet: &str) -> bool {
+    let snippet = snippet.trim_start();
+    ["GET", "POST", "PUT", "PATCH", "DELETE"]
+        .iter()
+        .any(|method| snippet.starts_with(&format!("Cannot {} /", method)))
+}
+
+/// Pulls a human-readable message out of a response body. Control-plane errors are
+/// sometimes `{ "message": "..." }` and sometimes a bare string, so try JSON first and
+/// fall back to the raw text, trimmed so a stray HTML error page cannot flood the
+/// terminal.
+pub(super) fn body_snippet(response: Response) -> String {
+    let text = response
+        .text()
+        .unwrap_or_else(|_| "unknown error".to_string());
+    snippet_from_text(&text)
+}
+
+fn snippet_from_text(text: &str) -> String {
+    if let Ok(value) = serde_json::from_str::<Value>(text) {
+        if let Some(string) = value.as_str() {
+            return string.to_string();
+        }
+        for key in ["message", "error", "detail"] {
+            if let Some(message) = value.get(key).and_then(Value::as_str) {
+                return message.to_string();
+            }
+        }
+    }
+
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return "unknown error".to_string();
+    }
+    if trimmed.chars().count() > 400 {
+        let truncated: String = trimmed.chars().take(400).collect();
+        return format!("{}…", truncated);
+    }
+    trimmed.to_string()
+}
+
+/// Pulls the array out of a list response.
+///
+/// The control-plane managed-apps routes are being written in parallel with this CLI,
+/// and list endpoints on platform-management are inconsistent about whether they return
+/// a bare array or wrap it (`{ "templates": [...] }`, `{ "data": [...] }`). Accepting
+/// either shape means a wrapper-key change on the server does not silently turn into
+/// "you have none" here.
+pub(super) fn extract_list<T: serde::de::DeserializeOwned>(
+    value: Value,
+    keys: &[&str],
+) -> Result<Vec<T>> {
+    let array = match value {
+        Value::Array(items) => items,
+        Value::Object(map) => {
+            let found = keys
+                .iter()
+                .chain(["data", "items", "results"].iter())
+                .find_map(|key| map.get(*key));
+            match found {
+                Some(Value::Array(items)) => items.clone(),
+                // An object with no recognizable array key is not an empty list — it is
+                // a response shape we do not understand, and rendering it as empty would
+                // be a lie. Say so instead.
+                _ => bail!(
+                    "unexpected list response shape from the control plane (expected an array, or an object with one of: {})",
+                    keys.join(", ")
+                ),
+            }
+        }
+        other => bail!("unexpected list response from the control plane: {}", other),
+    };
+
+    array
+        .into_iter()
+        .map(|item| serde_json::from_value(item).map_err(anyhow::Error::from))
+        .collect()
+}
+
+pub(super) fn get_value(auth_mode: &AuthMode, path: &str, missing: Missing) -> Result<Value> {
+    let url = managed_url(path);
+    let response = get_with_auth(auth_mode, &url).with_context(|| ERROR_FAILED_TO_SEND_REQUEST)?;
+    let response = ensure_success(response, missing)?;
+    response
+        .json()
+        .with_context(|| format!("Failed to parse the response from {}", url))
+}
+
+/// Like `get_value`, but reports a missing endpoint as `Ok(None)` instead of an error,
+/// so a caller that has a fallback source for the same data can use it.
+pub(super) fn get_value_if_supported(auth_mode: &AuthMode, path: &str) -> Result<Option<Value>> {
+    let url = managed_url(path);
+    let response = get_with_auth(auth_mode, &url).with_context(|| ERROR_FAILED_TO_SEND_REQUEST)?;
+    if response.status().as_u16() == 404 {
+        return Ok(None);
+    }
+    let response = ensure_success(response, Missing::Endpoint)?;
+    let value = response
+        .json()
+        .with_context(|| format!("Failed to parse the response from {}", url))?;
+    Ok(Some(value))
+}
+
+pub(super) fn post_json<T: serde::de::DeserializeOwned>(
+    auth_mode: &AuthMode,
+    path: &str,
+    body: Value,
+    missing: Missing,
+) -> Result<T> {
+    let url = managed_url(path);
+    let response =
+        post_with_auth(auth_mode, &url, body).with_context(|| ERROR_FAILED_TO_SEND_REQUEST)?;
+    let response = ensure_success(response, missing)?;
+    response
+        .json()
+        .with_context(|| format!("Failed to parse the response from {}", url))
+}
+
+/// PATCH.
+///
+/// Unlike `get_value` / `post_json` this takes no `&AuthMode`, and the asymmetry is
+/// deliberate. `get_with_auth` and `post_with_auth` already existed and are shared with
+/// commands that really do support HMAC. Nothing here does: `resolve_managed_auth`
+/// refuses HMAC before any of these run, so a `patch_with_auth` would carry an
+/// unreachable HMAC arm — precisely the dead dispatch that main removed from
+/// `http_client` in 817afe8d6. `patch` still attaches the session token and keeps the
+/// refresh-and-retry behavior; it just does not branch on a mode that cannot occur.
+pub(super) fn patch_json<T: serde::de::DeserializeOwned>(
+    path: &str,
+    body: Value,
+    missing: Missing,
+) -> Result<T> {
+    let url = managed_url(path);
+    let response = patch(&url, body).with_context(|| ERROR_FAILED_TO_SEND_REQUEST)?;
+    let response = ensure_success(response, missing)?;
+    response
+        .json()
+        .with_context(|| format!("Failed to parse the response from {}", url))
+}
+
+/// POST with NO credentials attached.
+///
+/// Used only by `instance claim`. That endpoint is declared `access: 'public'` on the
+/// control plane because the person claiming an instance is the end customer, who has
+/// no ForkLaunch account and never will — the one-time token in the body *is* the
+/// credential. Sending an operator's session token here would be wrong in both
+/// directions: it is not required, and it would make a customer-facing command silently
+/// depend on whoever happened to be logged in on that machine.
+pub(super) fn post_json_public<T: serde::de::DeserializeOwned>(
+    path: &str,
+    body: Value,
+    missing: Missing,
+) -> Result<T> {
+    let url = managed_url(path);
+    let response =
+        post_unauthenticated(&url, body).with_context(|| ERROR_FAILED_TO_SEND_REQUEST)?;
+    let response = ensure_success(response, missing)?;
+    response
+        .json()
+        .with_context(|| format!("Failed to parse the response from {}", url))
+}
+
+/// DELETE where the control plane answers `202` with a bare status string rather than
+/// JSON, so the body is returned as text instead of being parsed.
+/// Takes no `&AuthMode` for the same reason as `patch_json` — see its note.
+pub(super) fn delete_text(path: &str, missing: Missing) -> Result<String> {
+    let url = managed_url(path);
+    let response = delete(&url).with_context(|| ERROR_FAILED_TO_SEND_REQUEST)?;
+    let response = ensure_success(response, missing)?;
+    Ok(body_snippet(response))
+}
+
+/// Prints the request a `--dryrun` invocation would have made, instead of making it.
+pub(super) fn print_dryrun(method: &str, path: &str, body: Option<&Value>) -> Result<()> {
+    println!("[DRYRUN] {} {}", method, managed_url(path));
+    if let Some(body) = body {
+        println!("{}", serde_json::to_string_pretty(body)?);
+    }
+    println!("[DRYRUN] no request was sent.");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::managed::types::AppTemplate;
+
+    #[test]
+    fn managed_url_is_rooted_at_the_managed_mode_router() {
+        unsafe {
+            std::env::set_var(
+                "FORKLAUNCH_PLATFORM_MANAGEMENT_API_URL",
+                "https://platform.example.com",
+            );
+        }
+        assert_eq!(
+            managed_url("/templates"),
+            "https://platform.example.com/managed-mode/templates"
+        );
+        assert_eq!(
+            managed_url("/instances/abc/claim-link"),
+            "https://platform.example.com/managed-mode/instances/abc/claim-link"
+        );
+        // `claim` and `claim-link` are different endpoints with different audiences —
+        // a path typo here would silently point the customer-facing command at the
+        // operator-facing one.
+        assert_eq!(
+            managed_url("/instances/abc/claim"),
+            "https://platform.example.com/managed-mode/instances/abc/claim"
+        );
+        assert_eq!(
+            managed_url("/templates/clinic"),
+            "https://platform.example.com/managed-mode/templates/clinic"
+        );
+        unsafe {
+            std::env::remove_var("FORKLAUNCH_PLATFORM_MANAGEMENT_API_URL");
+        }
+    }
+
+    #[test]
+    fn summary_without_available_field_is_treated_as_available() {
+        let summary: ManagedModeSummary = serde_json::from_str("{}").unwrap();
+        assert!(summary.is_available());
+    }
+
+    #[test]
+    fn summary_reports_unavailable_with_reason() {
+        let summary: ManagedModeSummary = serde_json::from_str(
+            r#"{"available":false,"unavailableReason":"Managed apps is not configured for this deployment (MANAGED_APPS_URL is unset).","instances":[],"counts":{"total":0}}"#,
+        )
+        .unwrap();
+        assert!(!summary.is_available());
+        assert_eq!(
+            summary.unavailable_reason.as_deref(),
+            Some("Managed apps is not configured for this deployment (MANAGED_APPS_URL is unset).")
+        );
+    }
+
+    #[test]
+    fn summary_parses_embedded_instances() {
+        let summary: ManagedModeSummary = serde_json::from_str(
+            r#"{"available":true,"instances":[{"id":"i1","templateSlug":"clinic","host":"a.example.com","region":"us-west-2","state":"active","relayEligible":true}],"relayConfigs":[],"counts":{"total":1,"relayEligible":1,"failed":0}}"#,
+        )
+        .unwrap();
+        assert_eq!(summary.instances.len(), 1);
+        assert_eq!(
+            summary.instances[0].template_slug.as_deref(),
+            Some("clinic")
+        );
+        assert_eq!(summary.instances[0].state.as_deref(), Some("active"));
+    }
+
+    #[test]
+    fn extract_list_accepts_a_bare_array() {
+        let templates: Vec<AppTemplate> =
+            extract_list(serde_json::json!([{"slug":"a","name":"A"}]), &["templates"]).unwrap();
+        assert_eq!(templates.len(), 1);
+        assert_eq!(templates[0].slug.as_deref(), Some("a"));
+    }
+
+    #[test]
+    fn extract_list_accepts_a_wrapped_array() {
+        let templates: Vec<AppTemplate> = extract_list(
+            serde_json::json!({"templates":[{"slug":"a"},{"slug":"b"}]}),
+            &["templates"],
+        )
+        .unwrap();
+        assert_eq!(templates.len(), 2);
+    }
+
+    #[test]
+    fn extract_list_accepts_generic_envelope_keys() {
+        let templates: Vec<AppTemplate> =
+            extract_list(serde_json::json!({"data":[{"slug":"a"}]}), &["templates"]).unwrap();
+        assert_eq!(templates.len(), 1);
+    }
+
+    #[test]
+    fn extract_list_refuses_to_pretend_an_unknown_shape_is_empty() {
+        let result: Result<Vec<AppTemplate>> =
+            extract_list(serde_json::json!({"unexpected": 1}), &["templates"]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn snippet_prefers_a_json_message_field() {
+        assert_eq!(
+            snippet_from_text(r#"{"message":"No published template 'clinic'"}"#),
+            "No published template 'clinic'"
+        );
+    }
+
+    #[test]
+    fn snippet_unwraps_a_bare_json_string_body() {
+        assert_eq!(
+            snippet_from_text(r#""Destroy requested""#),
+            "Destroy requested"
+        );
+    }
+
+    #[test]
+    fn snippet_falls_back_to_trimmed_text() {
+        assert_eq!(
+            snippet_from_text("  Cannot POST /managed-mode/templates  "),
+            "Cannot POST /managed-mode/templates"
+        );
+    }
+
+    #[test]
+    fn unrouted_404_bodies_are_recognized() {
+        assert!(is_unrouted_404("Cannot POST /managed-mode/templates"));
+        assert!(is_unrouted_404("Cannot GET /managed-mode/instances"));
+        assert!(is_unrouted_404("Cannot DELETE /managed-mode/instances/abc"));
+    }
+
+    #[test]
+    fn handler_authored_404_bodies_are_not_mistaken_for_missing_routes() {
+        assert!(!is_unrouted_404(
+            "No claim link available — it was already revealed, expired, or the instance is claimed"
+        ));
+        assert!(!is_unrouted_404("No published template 'clinic'"));
+        // A resource whose name happens to start with the word "Cannot" must not trip it.
+        assert!(!is_unrouted_404("Cannot find that instance"));
+    }
+
+    #[test]
+    fn snippet_truncates_a_flood_of_html() {
+        let flood = "x".repeat(5000);
+        let snippet = snippet_from_text(&flood);
+        assert_eq!(snippet.chars().count(), 401);
+        assert!(snippet.ends_with('…'));
+    }
+}

--- a/cli/src/managed/client.rs
+++ b/cli/src/managed/client.rs
@@ -332,11 +332,10 @@ pub(super) fn patch_json<T: serde::de::DeserializeOwned>(
 /// Takes no `&AuthMode` for the same reason as `patch_json` — see its note.
 ///
 /// Returns `Option<Value>` rather than deserializing into a type because the variable
-/// upsert routes are being written in parallel with this CLI and it is not yet settled
-/// whether they answer `200` with the stored record or `204` with nothing. Both are
-/// reasonable for an upsert, and a CLI that failed with "expected value at line 1
-/// column 1" against the second would be reporting a parse error for a request that
-/// completely succeeded.
+/// upsert routes answer `200` with a bare string (`'Variable set'`), not JSON — and a
+/// CLI that failed with "expected value at line 1 column 1" would be reporting a parse
+/// error for a request that completely succeeded. Staying tolerant also covers a server
+/// that later returns the stored record, or `204` with nothing.
 pub(super) fn put_json_optional(
     path: &str,
     body: Value,

--- a/cli/src/managed/client.rs
+++ b/cli/src/managed/client.rs
@@ -8,7 +8,7 @@ use crate::{
     constants::{ERROR_FAILED_TO_SEND_REQUEST, get_platform_management_api_url},
     core::{
         hmac::AuthMode,
-        http_client::{delete, get_with_auth, patch, post_unauthenticated, post_with_auth},
+        http_client::{delete, get_with_auth, patch, post_unauthenticated, post_with_auth, put},
         validate::resolve_auth,
     },
 };
@@ -325,6 +325,33 @@ pub(super) fn patch_json<T: serde::de::DeserializeOwned>(
     response
         .json()
         .with_context(|| format!("Failed to parse the response from {}", url))
+}
+
+/// PUT, tolerating a response with no body.
+///
+/// Takes no `&AuthMode` for the same reason as `patch_json` — see its note.
+///
+/// Returns `Option<Value>` rather than deserializing into a type because the variable
+/// upsert routes are being written in parallel with this CLI and it is not yet settled
+/// whether they answer `200` with the stored record or `204` with nothing. Both are
+/// reasonable for an upsert, and a CLI that failed with "expected value at line 1
+/// column 1" against the second would be reporting a parse error for a request that
+/// completely succeeded.
+pub(super) fn put_json_optional(
+    path: &str,
+    body: Value,
+    missing: Missing,
+) -> Result<Option<Value>> {
+    let url = managed_url(path);
+    let response = put(&url, body).with_context(|| ERROR_FAILED_TO_SEND_REQUEST)?;
+    let response = ensure_success(response, missing)?;
+    let text = response
+        .text()
+        .with_context(|| format!("Failed to read the response from {}", url))?;
+    if text.trim().is_empty() {
+        return Ok(None);
+    }
+    Ok(serde_json::from_str(&text).ok())
 }
 
 /// POST with NO credentials attached.

--- a/cli/src/managed/instance/claim.rs
+++ b/cli/src/managed/instance/claim.rs
@@ -1,0 +1,178 @@
+use std::io::Write;
+
+use anyhow::{Context, Result};
+use clap::{Arg, ArgAction, ArgMatches, Command};
+use serde_json::json;
+use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
+
+use crate::{
+    CliCommand,
+    core::command::command,
+    managed::{
+        client::{Missing, post_json_public, print_dryrun},
+        types::{ManagedInstance, dash},
+    },
+};
+
+/// `forklaunch managed instance claim`
+///
+/// The customer-side half of the claim handshake, and the only command in this group
+/// that is not operator-facing.
+///
+/// It is deliberately unauthenticated. The control plane declares this route
+/// `access: 'public'` because the person running it is the end customer, who has no
+/// ForkLaunch account and never will — the one-time token *is* the credential. Do not
+/// add a login requirement here.
+#[derive(Debug)]
+pub(super) struct ClaimCommand;
+
+impl ClaimCommand {
+    pub(super) fn new() -> Self {
+        Self
+    }
+}
+
+impl CliCommand for ClaimCommand {
+    fn command(&self) -> Command {
+        command(
+            "claim",
+            "CONSUME a one-time claim link to take ownership of an instance (customer-side, no login)",
+        )
+        .long_about(
+            "Take ownership of a managed instance using the one-time claim link you were given.\n\n\
+             THIS IS THE CUSTOMER-SIDE COMMAND, AND IT NEEDS NO FORKLAUNCH ACCOUNT.\n\
+             Do not confuse it with `instance claim-link`:\n\
+             \x20 `instance claim-link`  REVEALS the link. Operator-side, requires login. Run by\n\
+             \x20                        the organization that launched the instance.\n\
+             \x20 `instance claim`       CONSUMES the link. Customer-side, requires no login. Run\n\
+             \x20                        by the person taking ownership.\n\n\
+             ─────────────────────────────────────────────────────────────────────────────\n\
+             READ THIS BEFORE YOU RUN IT — YOUR BACKUP PASSPHRASE CANNOT BE RECOVERED\n\
+             ─────────────────────────────────────────────────────────────────────────────\n\
+             --backup-public-key is an age recipient (a public key) that you derive from a\n\
+             passphrase you choose. Your instance's backups are encrypted to it.\n\n\
+             The platform stores ONLY THE PUBLIC HALF. It cannot decrypt your backups, and\n\
+             neither can ForkLaunch support, now or ever. That is the point of the design —\n\
+             but it means the consequence is absolute:\n\n\
+             \x20   IF YOU LOSE THE PASSPHRASE, YOUR BACKUPS ARE UNREADABLE. PERMANENTLY.\n\
+             \x20   NOBODY CAN RECOVER THEM FOR YOU. THE DATA IS GONE.\n\n\
+             Store the passphrase somewhere durable — a password manager, not a terminal\n\
+             scrollback — BEFORE running this command. Claiming can only be done once.\n\n\
+             The claim also fails as a single indistinguishable error whether the token is\n\
+             wrong, expired, already used, or the instance id is unknown. That is deliberate\n\
+             on the platform's side, so that the error cannot be used to probe which links\n\
+             are still live.",
+        )
+        .arg(
+            Arg::new("id")
+                .long("id")
+                .required(true)
+                .help("Id of the instance being claimed (from the claim link you were given)"),
+        )
+        .arg(
+            Arg::new("token")
+                .long("token")
+                .required(true)
+                .help("The one-time claim token (from the claim link you were given)"),
+        )
+        .arg(
+            Arg::new("backup_public_key")
+                .long("backup-public-key")
+                .required(true)
+                .help(
+                    "Your age recipient (public key) for backup encryption — derived from a \
+                     passphrase only you hold; a lost passphrase means unrecoverable backups",
+                ),
+        )
+        .arg(
+            Arg::new("dryrun")
+                .long("dryrun")
+                .help("Print the request that would be sent without sending it — does NOT consume the claim")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("json")
+                .long("json")
+                .help("Output raw JSON instead of formatted terminal output")
+                .action(ArgAction::SetTrue),
+        )
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        let mut stdout = StandardStream::stdout(ColorChoice::Always);
+
+        let id = matches
+            .get_one::<String>("id")
+            .context("--id is required")?;
+        let token = matches
+            .get_one::<String>("token")
+            .context("--token is required")?;
+        let backup_public_key = matches
+            .get_one::<String>("backup_public_key")
+            .context("--backup-public-key is required")?;
+
+        let path = format!("/instances/{}/claim", urlencoding::encode(id));
+        let body = json!({ "token": token, "backupPublicKey": backup_public_key });
+
+        if matches.get_flag("dryrun") {
+            println!(
+                "[DRYRUN] this would CONSUME the one-time claim for instance {}.",
+                id
+            );
+            // The token is the credential. Echoing it into a dry-run transcript that
+            // people paste into issues would be the easiest way to leak one, so show the
+            // shape of the request without the secret in it.
+            let redacted = json!({
+                "token": "<redacted — the real token would be sent here>",
+                "backupPublicKey": backup_public_key
+            });
+            return print_dryrun("POST", &path, Some(&redacted));
+        }
+
+        // No `resolve_managed_auth` and no `require_managed_mode` preflight here, both on
+        // purpose: this route is public, and the summary endpoint the preflight uses is
+        // not — preflighting would demand a login this command is specifically designed
+        // not to need.
+        let instance: ManagedInstance = post_json_public(
+            &path,
+            body,
+            Missing::Custom(
+                "this claim link is not valid — it may be mistyped, expired, or already used, \
+                 or the instance id may not exist. The platform deliberately does not say which."
+                    .to_string(),
+            ),
+        )?;
+
+        if matches.get_flag("json") {
+            println!("{}", serde_json::to_string_pretty(&instance)?);
+            return Ok(());
+        }
+
+        writeln!(stdout)?;
+        log_ok!(stdout, "Instance claimed — it is now yours.");
+        writeln!(stdout)?;
+        writeln!(stdout, "  Host      {}", dash(&instance.host))?;
+        writeln!(stdout, "  Template  {}", dash(&instance.template_slug))?;
+        writeln!(stdout, "  Region    {}", dash(&instance.region))?;
+        writeln!(stdout, "  State     {}", dash(&instance.state))?;
+        if let Some(version) = instance.current_version_semver.as_deref() {
+            writeln!(stdout, "  Version   {}", version)?;
+        }
+        writeln!(stdout)?;
+
+        stdout.set_color(ColorSpec::new().set_fg(Some(Color::Yellow)).set_bold(true))?;
+        writeln!(
+            stdout,
+            "  Keep your backup passphrase safe. The platform holds only the public half"
+        )?;
+        writeln!(
+            stdout,
+            "  of your key and cannot decrypt your backups. If you lose the passphrase,"
+        )?;
+        writeln!(stdout, "  your backups cannot be recovered by anyone.")?;
+        stdout.reset()?;
+        writeln!(stdout)?;
+
+        Ok(())
+    }
+}

--- a/cli/src/managed/instance/claim_link.rs
+++ b/cli/src/managed/instance/claim_link.rs
@@ -1,0 +1,142 @@
+use std::io::Write;
+
+use anyhow::{Context, Result};
+use clap::{Arg, ArgAction, ArgMatches, Command};
+use serde_json::json;
+use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
+
+use crate::{
+    CliCommand,
+    core::command::command,
+    managed::{
+        client::{Missing, post_json, print_dryrun, require_managed_mode, resolve_managed_auth},
+        types::ClaimLink,
+    },
+};
+
+#[derive(Debug)]
+pub(super) struct ClaimLinkCommand;
+
+impl ClaimLinkCommand {
+    pub(super) fn new() -> Self {
+        Self
+    }
+}
+
+impl CliCommand for ClaimLinkCommand {
+    fn command(&self) -> Command {
+        command(
+            "claim-link",
+            "REVEAL an instance's one-time claim link (operator-side; destroyed on reveal)",
+        )
+        .long_about(
+            "Reveal an instance's one-time claim link.\n\n\
+             *** THIS CAN ONLY BE DONE ONCE. ***\n\n\
+             THIS IS THE OPERATOR-SIDE COMMAND, AND IT IS NOT `instance claim`:\n\
+             \x20 `claim-link`  REVEALS the link, for you to hand to a customer. Requires login.\n\
+             \x20 `claim`       CONSUMES the link, run by the customer. Requires no account.\n\
+             Revealing is not claiming — running this does not activate the instance or\n\
+             transfer anything. It only shows you the link.\n\n\
+             The claim link is what hands ownership of a managed instance to your end\n\
+             customer. Revealing it PURGES it from the platform: the link is erased the\n\
+             moment it is returned to you, and there is no way to retrieve it again. If you\n\
+             lose the value this command prints, the only remedy is to destroy the instance\n\
+             and launch a new one.\n\n\
+             So: capture the output before you run this in a pipeline you cannot read back,\n\
+             and do not run it 'just to check'. Reveal it only when you are ready to hand it\n\
+             to the customer.\n\n\
+             A claim link only exists while an instance is awaiting_claim and unexpired. If\n\
+             the instance is already claimed, its link expired, or it was revealed before,\n\
+             this command reports that no claim link is available.",
+        )
+        .arg(
+            Arg::new("id")
+                .long("id")
+                .required(true)
+                .help("Id of the instance whose one-time claim link should be revealed"),
+        )
+        .arg(
+            Arg::new("dryrun")
+                .long("dryrun")
+                .help("Print the request that would be sent without sending it — does NOT consume the claim link")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("json")
+                .long("json")
+                .help("Output raw JSON instead of formatted terminal output")
+                .action(ArgAction::SetTrue),
+        )
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        let mut stdout = StandardStream::stdout(ColorChoice::Always);
+
+        let id = matches
+            .get_one::<String>("id")
+            .context("--id is required")?;
+        let path = format!("/instances/{}/claim-link", urlencoding::encode(id));
+
+        if matches.get_flag("dryrun") {
+            println!(
+                "[DRYRUN] this would CONSUME the one-time claim link for instance {}.",
+                id
+            );
+            return print_dryrun("POST", &path, None);
+        }
+
+        let auth_mode = resolve_managed_auth()?;
+        require_managed_mode(&auth_mode)?;
+
+        let json_output = matches.get_flag("json");
+
+        // The platform answers 404 both when the instance does not exist and when it has
+        // no claim link left to give (already revealed, expired, or already claimed).
+        // Name all of those, because "not found" alone would be misleading for an
+        // instance the caller can plainly see in `instance list`.
+        let link: ClaimLink = post_json(
+            &auth_mode,
+            &path,
+            json!({}),
+            Missing::Resource(format!("a claim link for instance '{}'", id)),
+        )?;
+
+        if json_output {
+            // Even in --json mode the warning goes to stderr, so it is visible to a human
+            // watching a pipeline without corrupting the JSON on stdout.
+            eprintln!(
+                "[WARN] the claim link for instance {} has now been purged from the platform and cannot be retrieved again.",
+                id
+            );
+            println!("{}", serde_json::to_string_pretty(&link)?);
+            return Ok(());
+        }
+
+        writeln!(stdout)?;
+        log_header!(
+            stdout,
+            Color::Yellow,
+            "ONE-TIME CLAIM LINK — this is the only time it will ever be shown"
+        );
+        writeln!(stdout)?;
+        stdout.set_color(ColorSpec::new().set_fg(Some(Color::Green)).set_bold(true))?;
+        writeln!(stdout, "  {}", link.claim_url)?;
+        stdout.reset()?;
+        writeln!(stdout)?;
+
+        if let Some(expires_at) = link.expires_at.as_deref() {
+            log_info!(stdout, "Expires: {}", expires_at);
+        }
+        log_warn!(
+            stdout,
+            "This link has been purged from the platform. Re-running this command will NOT return it."
+        );
+        log_info!(
+            stdout,
+            "Copy it now and hand it to the customer. If it is lost, destroy the instance and launch a new one."
+        );
+        writeln!(stdout)?;
+
+        Ok(())
+    }
+}

--- a/cli/src/managed/instance/create.rs
+++ b/cli/src/managed/instance/create.rs
@@ -1,0 +1,134 @@
+use std::io::Write;
+
+use anyhow::{Context, Result};
+use clap::{Arg, ArgAction, ArgMatches, Command};
+use serde_json::json;
+use termcolor::{ColorChoice, StandardStream, WriteColor};
+
+use crate::{
+    CliCommand,
+    core::command::command,
+    managed::{
+        client::{Missing, post_json, print_dryrun, require_managed_mode, resolve_managed_auth},
+        types::ManagedInstance,
+    },
+};
+
+#[derive(Debug)]
+pub(super) struct CreateCommand;
+
+impl CreateCommand {
+    pub(super) fn new() -> Self {
+        Self
+    }
+}
+
+impl CliCommand for CreateCommand {
+    fn command(&self) -> Command {
+        command(
+            "create",
+            "Launch a managed instance of a published template",
+        )
+        .long_about(
+            "Launch a managed instance of a published template.\n\n\
+                 This provisions a deployment for one end customer. The template must already\n\
+                 have a published version — launching from a draft or unbuilt template fails.\n\n\
+                 Provisioning is asynchronous: the instance comes back in a provisioning state\n\
+                 and becomes claimable once it is up. Once it reaches awaiting_claim, reveal\n\
+                 its one-time claim link with `forklaunch managed instance claim-link`.",
+        )
+        .arg(
+            Arg::new("template")
+                .long("template")
+                .required(true)
+                .help("Slug of the published template to launch"),
+        )
+        .arg(
+            Arg::new("region")
+                .long("region")
+                .required(true)
+                .help("Region to provision the instance in (for example: us-west-2)"),
+        )
+        .arg(
+            Arg::new("dryrun")
+                .long("dryrun")
+                .help("Print the request that would be sent without sending it")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("json")
+                .long("json")
+                .help("Output raw JSON instead of formatted terminal output")
+                .action(ArgAction::SetTrue),
+        )
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        let mut stdout = StandardStream::stdout(ColorChoice::Always);
+
+        let template = matches
+            .get_one::<String>("template")
+            .context("--template is required")?;
+        let region = matches
+            .get_one::<String>("region")
+            .context("--region is required")?;
+
+        let body = json!({ "templateSlug": template, "region": region });
+
+        if matches.get_flag("dryrun") {
+            return print_dryrun("POST", "/instances", Some(&body));
+        }
+
+        let auth_mode = resolve_managed_auth()?;
+        require_managed_mode(&auth_mode)?;
+
+        // A 404 here is the platform saying there is no *published* template by that
+        // slug, which is a different problem from the endpoint being absent — name the
+        // template so the message points at the real cause.
+        let instance: ManagedInstance = post_json(
+            &auth_mode,
+            "/instances",
+            body,
+            Missing::Resource(format!("published template '{}'", template)),
+        )?;
+
+        if matches.get_flag("json") {
+            println!("{}", serde_json::to_string_pretty(&instance)?);
+            return Ok(());
+        }
+
+        log_ok!(
+            stdout,
+            "Launched instance of '{}' in {}",
+            instance
+                .template_slug
+                .as_deref()
+                .unwrap_or(template.as_str()),
+            instance.region.as_deref().unwrap_or(region.as_str())
+        );
+        if let Some(id) = instance.id.as_deref() {
+            log_info!(stdout, "Instance id: {}", id);
+        }
+        if let Some(host) = instance.host.as_deref() {
+            log_info!(stdout, "Host: {}", host);
+        }
+        if let Some(state) = instance.state.as_deref() {
+            log_info!(stdout, "State: {}", state);
+        }
+
+        writeln!(stdout)?;
+        log_info!(
+            stdout,
+            "Provisioning runs in the background. Watch it with `forklaunch managed instance list`."
+        );
+        if let Some(id) = instance.id.as_deref() {
+            log_info!(
+                stdout,
+                "Once it reaches awaiting_claim, hand the customer their claim link: forklaunch managed instance claim-link --id {}",
+                id
+            );
+        }
+
+        Ok(())
+    }
+}

--- a/cli/src/managed/instance/destroy.rs
+++ b/cli/src/managed/instance/destroy.rs
@@ -1,0 +1,126 @@
+use std::io::{IsTerminal, Write};
+
+use anyhow::{Context, Result, bail};
+use clap::{Arg, ArgAction, ArgMatches, Command};
+use dialoguer::{Input, theme::ColorfulTheme};
+use termcolor::{Color, ColorChoice, StandardStream, WriteColor};
+
+use crate::{
+    CliCommand,
+    core::command::command,
+    managed::client::{
+        Missing, delete_text, print_dryrun, require_managed_mode, resolve_managed_auth,
+    },
+};
+
+#[derive(Debug)]
+pub(super) struct DestroyCommand;
+
+impl DestroyCommand {
+    pub(super) fn new() -> Self {
+        Self
+    }
+}
+
+impl CliCommand for DestroyCommand {
+    fn command(&self) -> Command {
+        command(
+            "destroy",
+            "Permanently destroy a managed instance and its infrastructure",
+        )
+        .long_about(
+            "Permanently destroy a managed instance and its infrastructure.\n\n\
+                 This tears down the customer's deployment. It cannot be undone, and no backup\n\
+                 is taken automatically first.\n\n\
+                 You will be asked to retype the instance id to confirm. Pass --confirm to skip\n\
+                 that prompt in scripts and CI — the prompt is never shown when stdin is not a\n\
+                 terminal, so a forgotten --confirm fails fast instead of hanging a pipeline.",
+        )
+        .arg(
+            Arg::new("id")
+                .long("id")
+                .required(true)
+                .help("Id of the instance to destroy"),
+        )
+        .arg(
+            Arg::new("confirm")
+                .long("confirm")
+                .help("Skip the confirmation prompt (for CI/scripted use) — this is irreversible")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("dryrun")
+                .long("dryrun")
+                .help("Print the request that would be sent without sending it")
+                .action(ArgAction::SetTrue),
+        )
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        let mut stdout = StandardStream::stdout(ColorChoice::Always);
+
+        let id = matches
+            .get_one::<String>("id")
+            .context("--id is required")?;
+        let path = format!("/instances/{}", urlencoding::encode(id));
+
+        if matches.get_flag("dryrun") {
+            return print_dryrun("DELETE", &path, None);
+        }
+
+        if !matches.get_flag("confirm") {
+            // Refuse rather than prompt when there is no terminal to prompt on. A
+            // dialoguer prompt against a closed stdin would hang CI, which the repo has
+            // been bitten by before — every flag here must be supplyable non-interactively.
+            if !std::io::stdin().is_terminal() {
+                bail!(
+                    "refusing to destroy instance '{}' without confirmation — stdin is not a terminal, so re-run with --confirm",
+                    id
+                );
+            }
+
+            log_header!(
+                stdout,
+                Color::Red,
+                "This will PERMANENTLY DESTROY managed instance {} and its infrastructure.",
+                id
+            );
+            writeln!(
+                stdout,
+                "The customer's deployment goes away. This cannot be undone, and no backup is taken first."
+            )?;
+            writeln!(stdout)?;
+
+            let typed: String = Input::with_theme(&ColorfulTheme::default())
+                .with_prompt(format!("Type the instance id ({}) to confirm", id))
+                .allow_empty(true)
+                .interact_text()
+                .with_context(|| "Failed to read confirmation")?;
+
+            if &typed != id {
+                bail!(
+                    "confirmation did not match '{}' — aborted, nothing was destroyed",
+                    id
+                );
+            }
+        }
+
+        let auth_mode = resolve_managed_auth()?;
+        require_managed_mode(&auth_mode)?;
+
+        let message = delete_text(&path, Missing::Resource(format!("instance '{}'", id)))?;
+
+        log_ok!(
+            stdout,
+            "Destroy requested for instance {} — {}",
+            id,
+            message
+        );
+        log_info!(
+            stdout,
+            "Teardown runs in the background. Follow it with `forklaunch managed instance list --state destroying`."
+        );
+
+        Ok(())
+    }
+}

--- a/cli/src/managed/instance/list.rs
+++ b/cli/src/managed/instance/list.rs
@@ -1,0 +1,185 @@
+use std::io::Write;
+
+use anyhow::Result;
+use clap::{Arg, ArgAction, ArgMatches, Command};
+use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
+
+use crate::{
+    CliCommand,
+    core::command::command,
+    managed::{
+        client::{
+            extract_list, get_value_if_supported, require_managed_mode, resolve_managed_auth,
+        },
+        types::{INSTANCE_STATES, ManagedInstance, dash},
+    },
+};
+
+#[derive(Debug)]
+pub(super) struct ListCommand;
+
+impl ListCommand {
+    pub(super) fn new() -> Self {
+        Self
+    }
+}
+
+impl CliCommand for ListCommand {
+    fn command(&self) -> Command {
+        command(
+            "list",
+            "List the managed instances your organization is running",
+        )
+        .long_about(
+            "List the managed instances your organization is running.\n\n\
+                 Each row is one running copy of a template, provisioned for one end customer.\n\
+                 Destroyed instances are not shown.\n\n\
+                 --template and --state narrow the list. They are also applied locally, so they\n\
+                 still work against a control plane whose instance list does not support query\n\
+                 filters yet.",
+        )
+        .arg(
+            Arg::new("template")
+                .long("template")
+                .help("Only show instances of this template slug"),
+        )
+        .arg(
+            Arg::new("state")
+                .long("state")
+                .value_parser(INSTANCE_STATES.to_vec())
+                .help("Only show instances in this lifecycle state"),
+        )
+        .arg(
+            Arg::new("json")
+                .long("json")
+                .help("Output raw JSON instead of formatted terminal output")
+                .action(ArgAction::SetTrue),
+        )
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        let auth_mode = resolve_managed_auth()?;
+        let summary = require_managed_mode(&auth_mode)?;
+
+        let template_filter = matches.get_one::<String>("template");
+        let state_filter = matches.get_one::<String>("state");
+        let json_output = matches.get_flag("json");
+
+        let mut query: Vec<String> = Vec::new();
+        if let Some(template) = template_filter {
+            query.push(format!("templateSlug={}", urlencoding::encode(template)));
+        }
+        if let Some(state) = state_filter {
+            query.push(format!("state={}", urlencoding::encode(state)));
+        }
+        let path = if query.is_empty() {
+            "/instances".to_string()
+        } else {
+            format!("/instances?{}", query.join("&"))
+        };
+
+        // Prefer the dedicated list endpoint, which can page and filter server-side. Not
+        // every control plane mounts it yet, and the summary endpoint — already fetched
+        // above for the availability check — carries the same instance projection, so
+        // fall back to that rather than failing.
+        let (instances, from_summary) = match get_value_if_supported(&auth_mode, &path)? {
+            Some(value) => (
+                extract_list::<ManagedInstance>(value, &["instances"])?,
+                false,
+            ),
+            None => (summary.instances.clone(), true),
+        };
+
+        // Filter locally regardless of source. When the server honored the query this is
+        // a no-op; when it ignored the query, or the data came from the summary, this is
+        // what makes --template and --state mean anything.
+        let instances: Vec<ManagedInstance> = instances
+            .into_iter()
+            .filter(
+                |instance| match (template_filter, &instance.template_slug) {
+                    (Some(wanted), Some(actual)) => actual == wanted,
+                    (Some(_), None) => false,
+                    (None, _) => true,
+                },
+            )
+            .filter(|instance| match (state_filter, &instance.state) {
+                (Some(wanted), Some(actual)) => actual == wanted,
+                (Some(_), None) => false,
+                (None, _) => true,
+            })
+            .collect();
+
+        if json_output {
+            println!("{}", serde_json::to_string_pretty(&instances)?);
+            return Ok(());
+        }
+
+        let mut stdout = StandardStream::stdout(ColorChoice::Always);
+        writeln!(stdout)?;
+        stdout.set_color(ColorSpec::new().set_fg(Some(Color::Cyan)).set_bold(true))?;
+        writeln!(stdout, "Managed instances")?;
+        stdout.reset()?;
+        writeln!(stdout)?;
+
+        if instances.is_empty() {
+            if template_filter.is_some() || state_filter.is_some() {
+                writeln!(stdout, "  No instances match those filters.")?;
+            } else {
+                writeln!(
+                    stdout,
+                    "  No instances running. Launch one with `forklaunch managed instance create`."
+                )?;
+            }
+            writeln!(stdout)?;
+            return Ok(());
+        }
+
+        stdout.set_color(ColorSpec::new().set_bold(true))?;
+        writeln!(
+            stdout,
+            "  {:<38} {:<20} {:<22} {:<14} {:<12}",
+            "ID", "TEMPLATE", "HOST", "REGION", "STATE"
+        )?;
+        stdout.reset()?;
+        for instance in &instances {
+            writeln!(
+                stdout,
+                "  {:<38} {:<20} {:<22} {:<14} {:<12}",
+                dash(&instance.id),
+                dash(&instance.template_slug),
+                dash(&instance.host),
+                dash(&instance.region),
+                dash(&instance.state),
+            )?;
+        }
+        writeln!(stdout)?;
+
+        let failed: Vec<&ManagedInstance> = instances
+            .iter()
+            .filter(|instance| instance.last_error.is_some())
+            .collect();
+        if !failed.is_empty() {
+            stdout.set_color(ColorSpec::new().set_bold(true))?;
+            writeln!(stdout, "  Errors")?;
+            stdout.reset()?;
+            for instance in failed {
+                writeln!(
+                    stdout,
+                    "    {} — {}",
+                    dash(&instance.id),
+                    dash(&instance.last_error)
+                )?;
+            }
+            writeln!(stdout)?;
+        }
+
+        if from_summary {
+            log_info!(
+                stdout,
+                "This control plane has no dedicated instance list endpoint; the rows above came from the managed mode summary and filters were applied locally."
+            );
+        }
+
+        Ok(())
+    }
+}

--- a/cli/src/managed/instance/mod.rs
+++ b/cli/src/managed/instance/mod.rs
@@ -8,12 +8,14 @@ mod claim_link;
 mod create;
 mod destroy;
 mod list;
+mod vars;
 
 use claim::ClaimCommand;
 use claim_link::ClaimLinkCommand;
 use create::CreateCommand;
 use destroy::DestroyCommand;
 use list::ListCommand;
+use vars::VarsCommand;
 
 #[derive(Debug)]
 pub(super) struct InstanceCommand {
@@ -22,6 +24,7 @@ pub(super) struct InstanceCommand {
     claim_link: ClaimLinkCommand,
     claim: ClaimCommand,
     destroy: DestroyCommand,
+    vars: VarsCommand,
 }
 
 impl InstanceCommand {
@@ -32,6 +35,7 @@ impl InstanceCommand {
             claim_link: ClaimLinkCommand::new(),
             claim: ClaimCommand::new(),
             destroy: DestroyCommand::new(),
+            vars: VarsCommand::new(),
         }
     }
 }
@@ -54,13 +58,17 @@ impl CliCommand for InstanceCommand {
              \x20 `claim`       CONSUMES the one-time link. YOUR CUSTOMER runs this, on their\n\
              \x20               own machine. It requires NO ForkLaunch account at all.\n\n\
              The normal sequence is: you `create`, you `claim-link`, you hand the output to\n\
-             the customer, and the customer `claim`s it.",
+             the customer, and the customer `claim`s it.\n\n\
+             `vars` is the one thing that can come BEFORE `create`. If the template declares\n\
+             a REQUIRED custom variable, the instance will not provision until it has a\n\
+             value — run `vars list` to see which are still missing.",
         )
         .subcommand(self.list.command())
         .subcommand(self.create.command())
         .subcommand(self.claim_link.command())
         .subcommand(self.claim.command())
         .subcommand(self.destroy.command())
+        .subcommand(self.vars.command())
         .subcommand_required(true)
     }
 
@@ -71,6 +79,7 @@ impl CliCommand for InstanceCommand {
             Some(("claim-link", sub_matches)) => self.claim_link.handler(sub_matches),
             Some(("claim", sub_matches)) => self.claim.handler(sub_matches),
             Some(("destroy", sub_matches)) => self.destroy.handler(sub_matches),
+            Some(("vars", sub_matches)) => self.vars.handler(sub_matches),
             _ => unreachable!(),
         }
     }

--- a/cli/src/managed/instance/mod.rs
+++ b/cli/src/managed/instance/mod.rs
@@ -1,0 +1,77 @@
+use anyhow::Result;
+use clap::{ArgMatches, Command};
+
+use crate::{CliCommand, core::command::command};
+
+mod claim;
+mod claim_link;
+mod create;
+mod destroy;
+mod list;
+
+use claim::ClaimCommand;
+use claim_link::ClaimLinkCommand;
+use create::CreateCommand;
+use destroy::DestroyCommand;
+use list::ListCommand;
+
+#[derive(Debug)]
+pub(super) struct InstanceCommand {
+    list: ListCommand,
+    create: CreateCommand,
+    claim_link: ClaimLinkCommand,
+    claim: ClaimCommand,
+    destroy: DestroyCommand,
+}
+
+impl InstanceCommand {
+    pub(super) fn new() -> Self {
+        Self {
+            list: ListCommand::new(),
+            create: CreateCommand::new(),
+            claim_link: ClaimLinkCommand::new(),
+            claim: ClaimCommand::new(),
+            destroy: DestroyCommand::new(),
+        }
+    }
+}
+
+impl CliCommand for InstanceCommand {
+    fn command(&self) -> Command {
+        command(
+            "instance",
+            "Launch and manage managed instances of your app templates",
+        )
+        .long_about(
+            "Launch and manage managed instances of your app templates.\n\n\
+             Each instance is one running copy of a template, provisioned for a single end\n\
+             customer with its own deployment. A newly created instance also gets a ONE-TIME\n\
+             claim link, which is how the customer takes ownership.\n\n\
+             TWO COMMANDS HAVE SIMILAR NAMES AND OPPOSITE AUDIENCES:\n\n\
+             \x20 `claim-link`  REVEALS the one-time link. You run this — the operator. It\n\
+             \x20               requires login, and the link is destroyed on reveal, so it can\n\
+             \x20               be run only once per instance.\n\
+             \x20 `claim`       CONSUMES the one-time link. YOUR CUSTOMER runs this, on their\n\
+             \x20               own machine. It requires NO ForkLaunch account at all.\n\n\
+             The normal sequence is: you `create`, you `claim-link`, you hand the output to\n\
+             the customer, and the customer `claim`s it.",
+        )
+        .subcommand(self.list.command())
+        .subcommand(self.create.command())
+        .subcommand(self.claim_link.command())
+        .subcommand(self.claim.command())
+        .subcommand(self.destroy.command())
+        .subcommand_required(true)
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        match matches.subcommand() {
+            Some(("list", sub_matches)) => self.list.handler(sub_matches),
+            Some(("create", sub_matches)) => self.create.handler(sub_matches),
+            Some(("claim-link", sub_matches)) => self.claim_link.handler(sub_matches),
+            Some(("claim", sub_matches)) => self.claim.handler(sub_matches),
+            Some(("destroy", sub_matches)) => self.destroy.handler(sub_matches),
+            _ => unreachable!(),
+        }
+    }
+}

--- a/cli/src/managed/instance/vars/list.rs
+++ b/cli/src/managed/instance/vars/list.rs
@@ -1,0 +1,271 @@
+use std::io::Write;
+
+use anyhow::{Context, Result};
+use clap::{Arg, ArgAction, ArgMatches, Command};
+use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
+
+use crate::{
+    CliCommand,
+    core::command::command,
+    managed::{
+        client::{Missing, extract_list, get_value, require_managed_mode, resolve_managed_auth},
+        types::{InstanceVariable, SetState, dash, yes_no},
+    },
+};
+
+/// What to print in the VALUE column.
+///
+/// Never the value. For `custom` this is the only thing this command exists to tell
+/// you — whether the instance has one — and for the other two kinds the honest answer
+/// is where the value comes from, since there is nothing instance-specific to report.
+fn value_column(variable: &InstanceVariable) -> &'static str {
+    match variable.kind.as_deref() {
+        Some("static") => "(from template)",
+        Some("generated") => "(derived per instance)",
+        Some("custom") => match variable.set_state() {
+            SetState::Set => "SET",
+            SetState::Missing => "MISSING",
+            SetState::Unknown => "?",
+        },
+        _ => "-",
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct ListCommand;
+
+impl ListCommand {
+    pub(super) fn new() -> Self {
+        Self
+    }
+}
+
+impl CliCommand for ListCommand {
+    fn command(&self) -> Command {
+        command(
+            "list",
+            "Show every variable an instance receives, and which custom ones still need a value",
+        )
+        .long_about(
+            "Show every variable an instance receives, and which custom ones still need a value.\n\n\
+             This lists the whole declaration from the template, not just what has been filled\n\
+             in, so a variable nobody has touched still appears — as MISSING rather than as\n\
+             nothing at all.\n\n\
+             THE VALUE COLUMN NEVER CONTAINS A VALUE. For a `custom` variable it says SET or\n\
+             MISSING; for `static` and `generated` it says where the value comes from. There\n\
+             is no flag that changes this and no other command that reads a value back — once\n\
+             a value is set, the only things that can read it are the provisioner and the\n\
+             deployed app.\n\n\
+             A row that is both REQUIRED and MISSING will stop this instance from being\n\
+             provisioned. That is deliberate: failing at launch is better than deploying an\n\
+             app that boots and then misbehaves because an environment variable was absent.",
+        )
+        .arg(
+            Arg::new("id")
+                .long("id")
+                .required(true)
+                .help("Id of the instance whose variables should be listed"),
+        )
+        .arg(
+            Arg::new("json")
+                .long("json")
+                .help("Output raw JSON instead of formatted terminal output")
+                .action(ArgAction::SetTrue),
+        )
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        let id = matches
+            .get_one::<String>("id")
+            .context("--id is required")?;
+
+        let auth_mode = resolve_managed_auth()?;
+        require_managed_mode(&auth_mode)?;
+
+        let path = format!("/instances/{}/variables", urlencoding::encode(id));
+        let value = get_value(
+            &auth_mode,
+            &path,
+            Missing::Resource(format!("instance '{}'", id)),
+        )?;
+        let variables: Vec<InstanceVariable> = extract_list(value, &["variables"])?;
+
+        if matches.get_flag("json") {
+            // `InstanceVariable::value` is `skip_serializing`, so a control plane that
+            // sent values back cannot leak them through `--json` either.
+            println!("{}", serde_json::to_string_pretty(&variables)?);
+            return Ok(());
+        }
+
+        let mut stdout = StandardStream::stdout(ColorChoice::Always);
+        writeln!(stdout)?;
+        stdout.set_color(ColorSpec::new().set_fg(Some(Color::Cyan)).set_bold(true))?;
+        writeln!(stdout, "Variables for instance {}", id)?;
+        stdout.reset()?;
+        writeln!(stdout)?;
+
+        if variables.is_empty() {
+            writeln!(
+                stdout,
+                "  This instance's template declares no variables. Declare one with `forklaunch managed template vars set`."
+            )?;
+            writeln!(stdout)?;
+            return Ok(());
+        }
+
+        stdout.set_color(ColorSpec::new().set_bold(true))?;
+        writeln!(
+            stdout,
+            "  {:<24} {:<10} {:<12} {:<14} {:<9} VALUE",
+            "KEY", "KIND", "SCOPE", "SERVICE", "REQUIRED"
+        )?;
+        stdout.reset()?;
+        for variable in &variables {
+            writeln!(
+                stdout,
+                "  {:<24} {:<10} {:<12} {:<14} {:<9} {}",
+                dash(&variable.key),
+                dash(&variable.kind),
+                dash(&variable.scope),
+                dash(&variable.service_name),
+                yes_no(&variable.required),
+                value_column(variable),
+            )?;
+        }
+        writeln!(stdout)?;
+
+        let blocking: Vec<&str> = variables
+            .iter()
+            .filter(|variable| variable.blocks_provisioning())
+            .map(|variable| variable.key.as_deref().unwrap_or("(unnamed)"))
+            .collect();
+
+        if blocking.is_empty() {
+            log_info!(
+                stdout,
+                "Values are never shown. SET means this instance has one; MISSING means it does not."
+            );
+        } else {
+            log_warn!(
+                stdout,
+                "This instance CANNOT be provisioned yet — required and missing: {}",
+                blocking.join(", ")
+            );
+            log_info!(
+                stdout,
+                "Supply each with: forklaunch managed instance vars set --id {} --key <key> --value <value>",
+                id
+            );
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn custom(required: bool, has_value: Option<bool>) -> InstanceVariable {
+        InstanceVariable {
+            key: Some("STRIPE_KEY".to_string()),
+            kind: Some("custom".to_string()),
+            required: Some(required),
+            has_value,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn a_custom_variable_reports_set_or_missing_but_never_a_value() {
+        assert_eq!(value_column(&custom(true, Some(true))), "SET");
+        assert_eq!(value_column(&custom(true, Some(false))), "MISSING");
+    }
+
+    #[test]
+    fn an_unstated_set_state_is_reported_as_unknown_not_guessed() {
+        // Guessing MISSING would send someone hunting for a value that is already
+        // there; guessing SET would hide a variable that is about to fail the provision.
+        assert_eq!(value_column(&custom(true, None)), "?");
+        assert_eq!(custom(true, None).set_state(), SetState::Unknown);
+    }
+
+    #[test]
+    fn set_state_falls_back_to_the_presence_of_a_value_the_server_should_not_have_sent() {
+        let variable = InstanceVariable {
+            kind: Some("custom".to_string()),
+            value: Some("sk_live_supersecret".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(variable.set_state(), SetState::Set);
+        assert_eq!(value_column(&variable), "SET");
+    }
+
+    #[test]
+    fn a_value_the_control_plane_sent_anyway_is_never_rendered() {
+        // The guarantee this command makes. Both the table cell and the `--json` form
+        // have to be free of it, since `--json` serializes these same structs.
+        let variables = vec![InstanceVariable {
+            key: Some("STRIPE_KEY".to_string()),
+            kind: Some("custom".to_string()),
+            value: Some("sk_live_supersecret".to_string()),
+            ..Default::default()
+        }];
+        assert!(!value_column(&variables[0]).contains("supersecret"));
+        let rendered = serde_json::to_string(&variables).unwrap();
+        assert!(!rendered.contains("supersecret"), "{}", rendered);
+    }
+
+    #[test]
+    fn an_empty_value_counts_as_missing() {
+        // Matches the provisioner, which treats '' the same as absent.
+        let variable = InstanceVariable {
+            kind: Some("custom".to_string()),
+            value: Some(String::new()),
+            ..Default::default()
+        };
+        assert_eq!(variable.set_state(), SetState::Missing);
+    }
+
+    #[test]
+    fn only_required_and_missing_custom_variables_block_provisioning() {
+        assert!(custom(true, Some(false)).blocks_provisioning());
+        assert!(!custom(false, Some(false)).blocks_provisioning());
+        assert!(!custom(true, Some(true)).blocks_provisioning());
+        // A generated variable is always derivable, so it can never block, even if a
+        // control plane marked it required.
+        let generated = InstanceVariable {
+            kind: Some("generated".to_string()),
+            required: Some(true),
+            ..Default::default()
+        };
+        assert!(!generated.blocks_provisioning());
+    }
+
+    #[test]
+    fn static_and_generated_rows_explain_themselves_rather_than_reporting_set_ness() {
+        let static_variable = InstanceVariable {
+            kind: Some("static".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(value_column(&static_variable), "(from template)");
+
+        let generated = InstanceVariable {
+            kind: Some("generated".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(value_column(&generated), "(derived per instance)");
+    }
+
+    #[test]
+    fn set_ness_is_read_from_whichever_field_name_the_control_plane_used() {
+        // The endpoint is still being written; `hasValue`, `isSet` and `set` are all
+        // plausible names for the same fact. Reading only one would render every
+        // variable MISSING if the server picked another.
+        for field in ["hasValue", "isSet", "set"] {
+            let json = format!(r#"{{"key":"K","kind":"custom","{}":true}}"#, field);
+            let variable: InstanceVariable = serde_json::from_str(&json).unwrap();
+            assert_eq!(variable.set_state(), SetState::Set, "{}", field);
+        }
+    }
+}

--- a/cli/src/managed/instance/vars/list.rs
+++ b/cli/src/managed/instance/vars/list.rs
@@ -9,7 +9,7 @@ use crate::{
     core::command::command,
     managed::{
         client::{Missing, extract_list, get_value, require_managed_mode, resolve_managed_auth},
-        types::{InstanceVariable, SetState, dash, yes_no},
+        types::{InstanceVariable, SetState, dash, required_cell},
     },
 };
 
@@ -128,7 +128,7 @@ impl CliCommand for ListCommand {
                 dash(&variable.kind),
                 dash(&variable.scope),
                 dash(&variable.service_name),
-                yes_no(&variable.required),
+                required_cell(&variable.kind, &variable.required),
                 value_column(variable),
             )?;
         }

--- a/cli/src/managed/instance/vars/mod.rs
+++ b/cli/src/managed/instance/vars/mod.rs
@@ -1,0 +1,64 @@
+use anyhow::Result;
+use clap::{ArgMatches, Command};
+
+use crate::{CliCommand, core::command::command};
+
+mod list;
+mod set;
+mod unset;
+
+use list::ListCommand;
+use set::SetCommand;
+use unset::UnsetCommand;
+
+#[derive(Debug)]
+pub(super) struct VarsCommand {
+    list: ListCommand,
+    set: SetCommand,
+    unset: UnsetCommand,
+}
+
+impl VarsCommand {
+    pub(super) fn new() -> Self {
+        Self {
+            list: ListCommand::new(),
+            set: SetCommand::new(),
+            unset: UnsetCommand::new(),
+        }
+    }
+}
+
+impl CliCommand for VarsCommand {
+    fn command(&self) -> Command {
+        command("vars", "Fill in one instance's custom variable values")
+            .long_about(
+                "Fill in one instance's custom variable values.\n\n\
+                 The TEMPLATE decides which variables exist; this command only supplies values\n\
+                 for the `custom` ones — the variables whose value differs per customer, like\n\
+                 that customer's own Stripe key. You cannot add a variable here that the\n\
+                 template did not declare; declare it with `managed template vars set` first.\n\n\
+                 The other two kinds need nothing here. A `static` variable's value lives on\n\
+                 the template and is the same for everyone. A `generated` variable's value is\n\
+                 derived by the instance itself.\n\n\
+                 `list` is the command to run before launching: it shows every variable the\n\
+                 template declares and, for the custom ones, whether this instance has a value\n\
+                 yet. A variable that is both REQUIRED and MISSING will stop the instance from\n\
+                 being provisioned.\n\n\
+                 Values are never printed back. `list` reports SET or MISSING, not the value —\n\
+                 there is no command here that reads a secret back out.",
+            )
+            .subcommand(self.list.command())
+            .subcommand(self.set.command())
+            .subcommand(self.unset.command())
+            .subcommand_required(true)
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        match matches.subcommand() {
+            Some(("list", sub_matches)) => self.list.handler(sub_matches),
+            Some(("set", sub_matches)) => self.set.handler(sub_matches),
+            Some(("unset", sub_matches)) => self.unset.handler(sub_matches),
+            _ => unreachable!(),
+        }
+    }
+}

--- a/cli/src/managed/instance/vars/set.rs
+++ b/cli/src/managed/instance/vars/set.rs
@@ -1,0 +1,136 @@
+use std::io::Write;
+
+use anyhow::{Context, Result, bail};
+use clap::{Arg, ArgAction, ArgMatches, Command};
+use serde_json::json;
+use termcolor::{ColorChoice, StandardStream, WriteColor};
+
+use crate::{
+    CliCommand,
+    core::command::command,
+    managed::client::{
+        Missing, print_dryrun, put_json_optional, require_managed_mode, resolve_managed_auth,
+    },
+};
+
+#[derive(Debug)]
+pub(super) struct SetCommand;
+
+impl SetCommand {
+    pub(super) fn new() -> Self {
+        Self
+    }
+}
+
+impl CliCommand for SetCommand {
+    fn command(&self) -> Command {
+        command("set", "Set one instance's value for a custom variable")
+            .long_about(
+                "Set one instance's value for a custom variable.\n\n\
+                 The key must already be declared on the instance's template with\n\
+                 `--kind custom`. This command supplies a value for a variable that exists; it\n\
+                 does not create one. The other two kinds take no value here: `static` values\n\
+                 live on the template, and `generated` values are derived by the instance.\n\n\
+                 There is no --scope or --service. The template's declaration already fixed how\n\
+                 far this variable reaches; an instance supplies the value, not the scoping.\n\n\
+                 The value is not printed back, here or by `vars list`. Re-running with a\n\
+                 different value replaces the old one.\n\n\
+                 Setting a value that was REQUIRED and MISSING unblocks provisioning; the\n\
+                 instance does not redeploy on its own, so it takes effect at its next\n\
+                 provision.",
+            )
+            .arg(
+                Arg::new("id")
+                    .long("id")
+                    .required(true)
+                    .help("Id of the instance to set the value on"),
+            )
+            .arg(
+                Arg::new("key")
+                    .long("key")
+                    .required(true)
+                    .help("Name of the custom variable the template declared"),
+            )
+            .arg(
+                Arg::new("value")
+                    .long("value")
+                    .required(true)
+                    .help("Value this instance should receive"),
+            )
+            .arg(
+                Arg::new("dryrun")
+                    .long("dryrun")
+                    .help("Print the request that would be sent, with the value redacted")
+                    .action(ArgAction::SetTrue),
+            )
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        let mut stdout = StandardStream::stdout(ColorChoice::Always);
+
+        let id = matches
+            .get_one::<String>("id")
+            .context("--id is required")?;
+        let key = matches
+            .get_one::<String>("key")
+            .context("--key is required")?;
+        let value = matches
+            .get_one::<String>("value")
+            .context("--value is required")?;
+
+        if key.trim().is_empty() {
+            bail!("--key cannot be empty");
+        }
+        // Same paste error as on the template side: `--key FOO=bar` would set a value on
+        // a variable named `FOO=bar`, which no template ever declared, so it would fail
+        // server-side with a not-found that does not explain itself.
+        if key.contains('=') {
+            bail!(
+                "--key '{}' looks like a KEY=VALUE pair — pass the name and the value separately: \
+                 --key {} --value {}",
+                key,
+                key.split_once('=').map(|pair| pair.0).unwrap_or(key),
+                key.split_once('=').map(|pair| pair.1).unwrap_or("<value>")
+            );
+        }
+
+        let path = format!("/instances/{}/variables", urlencoding::encode(id));
+
+        if matches.get_flag("dryrun") {
+            // --dryrun prints the request, and a real credential is exactly what is
+            // being passed here — so it prints the shape, not the secret. Same treatment
+            // `instance claim` gives the one-time token.
+            let redacted = json!({
+                "key": key,
+                "value": "<redacted — the real value would be sent here>",
+            });
+            return print_dryrun("PUT", &path, Some(&redacted));
+        }
+
+        let auth_mode = resolve_managed_auth()?;
+        require_managed_mode(&auth_mode)?;
+
+        put_json_optional(
+            &path,
+            json!({ "key": key, "value": value }),
+            // A 404 here is most likely the key: the instance is one the caller just
+            // listed, whereas the key is typed by hand and must match a `custom`
+            // declaration on the template.
+            Missing::Custom(format!(
+                "no custom variable '{}' is declared for instance '{}' — either the instance \
+                 does not exist, or its template does not declare '{}' with `--kind custom`. \
+                 Check with: forklaunch managed instance vars list --id {}",
+                key, id, key, id
+            )),
+        )?;
+
+        log_ok!(stdout, "Set '{}' for instance {}", key, id);
+        log_info!(
+            stdout,
+            "The value is not shown back. Confirm it registered with: forklaunch managed instance vars list --id {}",
+            id
+        );
+
+        Ok(())
+    }
+}

--- a/cli/src/managed/instance/vars/unset.rs
+++ b/cli/src/managed/instance/vars/unset.rs
@@ -1,0 +1,95 @@
+use std::io::Write;
+
+use anyhow::{Context, Result};
+use clap::{Arg, ArgAction, ArgMatches, Command};
+use termcolor::{ColorChoice, StandardStream, WriteColor};
+
+use crate::{
+    CliCommand,
+    core::command::command,
+    managed::client::{
+        Missing, delete_text, print_dryrun, require_managed_mode, resolve_managed_auth,
+    },
+};
+
+#[derive(Debug)]
+pub(super) struct UnsetCommand;
+
+impl UnsetCommand {
+    pub(super) fn new() -> Self {
+        Self
+    }
+}
+
+impl CliCommand for UnsetCommand {
+    fn command(&self) -> Command {
+        command("unset", "Clear one instance's value for a custom variable")
+            .long_about(
+                "Clear one instance's value for a custom variable.\n\n\
+                 The template's DECLARATION stays. Only this instance's value goes away, so\n\
+                 the variable still appears in `vars list` — as MISSING. If it was declared\n\
+                 --required, clearing it means this instance can no longer be provisioned\n\
+                 until a new value is supplied.\n\n\
+                 To remove the variable everywhere, remove the declaration instead:\n\
+                 `forklaunch managed template vars unset --slug <slug> --key <key>`.\n\n\
+                 There is no --scope or --service, for the same reason `set` has none: the\n\
+                 template's declaration fixed the scoping, and an instance holds one value per\n\
+                 key.",
+            )
+            .arg(
+                Arg::new("id")
+                    .long("id")
+                    .required(true)
+                    .help("Id of the instance whose value should be cleared"),
+            )
+            .arg(
+                Arg::new("key")
+                    .long("key")
+                    .required(true)
+                    .help("Name of the custom variable to clear"),
+            )
+            .arg(
+                Arg::new("dryrun")
+                    .long("dryrun")
+                    .help("Print the request that would be sent without sending it")
+                    .action(ArgAction::SetTrue),
+            )
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        let mut stdout = StandardStream::stdout(ColorChoice::Always);
+
+        let id = matches
+            .get_one::<String>("id")
+            .context("--id is required")?;
+        let key = matches
+            .get_one::<String>("key")
+            .context("--key is required")?;
+
+        let path = format!(
+            "/instances/{}/variables/{}",
+            urlencoding::encode(id),
+            urlencoding::encode(key)
+        );
+
+        if matches.get_flag("dryrun") {
+            return print_dryrun("DELETE", &path, None);
+        }
+
+        let auth_mode = resolve_managed_auth()?;
+        require_managed_mode(&auth_mode)?;
+
+        delete_text(
+            &path,
+            Missing::Resource(format!("value for '{}' on instance '{}'", key, id)),
+        )?;
+
+        log_ok!(stdout, "Cleared '{}' for instance {}", key, id);
+        log_info!(
+            stdout,
+            "The template still declares it, so it now shows as MISSING. If it is required, this instance cannot be provisioned until a new value is set."
+        );
+
+        Ok(())
+    }
+}

--- a/cli/src/managed/mod.rs
+++ b/cli/src/managed/mod.rs
@@ -3,19 +3,35 @@ use clap::{ArgMatches, Command};
 
 use crate::{CliCommand, core::command::command};
 
+mod client;
+mod instance;
 mod summary;
+mod template;
+mod types;
 
+use instance::InstanceCommand;
 use summary::SummaryCommand;
+use template::TemplateCommand;
 
+/// `forklaunch managed` — publish app templates and run managed instances of them.
+///
+/// Two nouns matter here. A **template** is an app your organization publishes once:
+/// a git repository plus a series of published versions. An **instance** is one
+/// running copy of a template, provisioned for one end customer, with its own
+/// deployment and its own one-time claim link.
 #[derive(Debug)]
 pub(crate) struct ManagedCommand {
     summary: SummaryCommand,
+    template: TemplateCommand,
+    instance: InstanceCommand,
 }
 
 impl ManagedCommand {
     pub(crate) fn new() -> Self {
         Self {
             summary: SummaryCommand::new(),
+            template: TemplateCommand::new(),
+            instance: InstanceCommand::new(),
         }
     }
 }
@@ -24,15 +40,38 @@ impl CliCommand for ManagedCommand {
     fn command(&self) -> Command {
         command(
             "managed",
-            "Inspect managed app instances and the OAuth relay that routes their sign-ins",
+            "Publish app templates and launch managed instances of them for customers",
+        )
+        .long_about(
+            "Publish app templates and launch managed instances of them for customers.\n\n\
+             A TEMPLATE is an app your organization publishes once — a git repository plus a\n\
+             series of published versions. An INSTANCE is one running copy of a template,\n\
+             provisioned for a single end customer, with its own deployment and its own\n\
+             one-time claim link that hands ownership to that customer.\n\n\
+             The usual order is:\n\
+             \x20 1. template create            register the template (it starts as a DRAFT)\n\
+             \x20 2. template publish           add a version, pinning a semver to a git ref\n\
+             \x20 3. template publish-template  flip the template itself to PUBLISHED\n\
+             \x20 4. instance create            launch a copy for one customer\n\
+             \x20 5. instance claim-link        reveal the one-time link, hand it to them\n\n\
+             Steps 2 and 3 are both required and are NOT the same thing — see\n\
+             `forklaunch managed template --help`.\n\n\
+             All of these commands talk to the ForkLaunch control plane (platform-management),\n\
+             never to the managed-apps service directly. Run `forklaunch login` first — the\n\
+             one exception is `instance claim`, which is the customer-facing command and\n\
+             needs no ForkLaunch account at all.",
         )
         .subcommand(self.summary.command())
+        .subcommand(self.template.command())
+        .subcommand(self.instance.command())
         .subcommand_required(true)
     }
 
     fn handler(&self, matches: &ArgMatches) -> Result<()> {
         match matches.subcommand() {
             Some(("summary", sub_matches)) => self.summary.handler(sub_matches),
+            Some(("template", sub_matches)) => self.template.handler(sub_matches),
+            Some(("instance", sub_matches)) => self.instance.handler(sub_matches),
             _ => unreachable!(),
         }
     }

--- a/cli/src/managed/template/create.rs
+++ b/cli/src/managed/template/create.rs
@@ -1,0 +1,139 @@
+use std::io::Write;
+
+use anyhow::{Context, Result};
+use clap::{Arg, ArgAction, ArgMatches, Command};
+use serde_json::{Map, Value, json};
+use termcolor::{ColorChoice, StandardStream, WriteColor};
+
+use crate::{
+    CliCommand,
+    core::command::command,
+    managed::{
+        client::{Missing, post_json, print_dryrun, require_managed_mode, resolve_managed_auth},
+        types::AppTemplate,
+    },
+};
+
+#[derive(Debug)]
+pub(super) struct CreateCommand;
+
+impl CreateCommand {
+    pub(super) fn new() -> Self {
+        Self
+    }
+}
+
+impl CliCommand for CreateCommand {
+    fn command(&self) -> Command {
+        command("create", "Register a new app template for your organization")
+            .long_about(
+                "Register a new app template for your organization.\n\n\
+                 A NEW TEMPLATE IS A DRAFT, AND NOTHING CAN LAUNCH FROM A DRAFT. Two further\n\
+                 steps are required before `instance create` will work:\n\
+                 \x20 1. `template publish`          — add a version (a semver pinned to a git ref)\n\
+                 \x20 2. `template publish-template` — move the template itself to `published`\n\n\
+                 This command takes exactly what the control plane's create API accepts:\n\
+                 slug, name, source repo, and an optional description. The Stripe product is\n\
+                 set afterwards with `template update --stripe-product <id>`. The base domain\n\
+                 is not settable through the API at all — instances use the platform-wide\n\
+                 default.",
+            )
+            .arg(
+                Arg::new("slug")
+                    .long("slug")
+                    .required(true)
+                    .help("Short url-safe identifier for the template (for example: clinic-portal)"),
+            )
+            .arg(
+                Arg::new("name")
+                    .long("name")
+                    .required(true)
+                    .help("Human-readable template name"),
+            )
+            .arg(
+                Arg::new("repo")
+                    .long("repo")
+                    .required(true)
+                    .help("Git repository URL the template is built from"),
+            )
+            .arg(
+                Arg::new("description")
+                    .long("description")
+                    .help("Optional description shown alongside the template"),
+            )
+            .arg(
+                Arg::new("dryrun")
+                    .long("dryrun")
+                    .help("Print the request that would be sent without sending it")
+                    .action(ArgAction::SetTrue),
+            )
+            .arg(
+                Arg::new("json")
+                    .long("json")
+                    .help("Output raw JSON instead of formatted terminal output")
+                    .action(ArgAction::SetTrue),
+            )
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        let mut stdout = StandardStream::stdout(ColorChoice::Always);
+
+        let slug = matches
+            .get_one::<String>("slug")
+            .context("--slug is required")?;
+        let name = matches
+            .get_one::<String>("name")
+            .context("--name is required")?;
+        let repo = matches
+            .get_one::<String>("repo")
+            .context("--repo is required")?;
+
+        let mut body = Map::new();
+        body.insert("slug".to_string(), json!(slug));
+        body.insert("name".to_string(), json!(name));
+        // The platform's schema calls the repository URL `sourceRepo`. The flag is
+        // `--repo` because that is what it reads as on a command line; do not rename the
+        // wire field to match.
+        body.insert("sourceRepo".to_string(), json!(repo));
+        if let Some(description) = matches.get_one::<String>("description") {
+            body.insert("description".to_string(), json!(description));
+        }
+
+        let body = Value::Object(body);
+
+        if matches.get_flag("dryrun") {
+            return print_dryrun("POST", "/templates", Some(&body));
+        }
+
+        let auth_mode = resolve_managed_auth()?;
+        require_managed_mode(&auth_mode)?;
+
+        let template: AppTemplate = post_json(&auth_mode, "/templates", body, Missing::Endpoint)?;
+
+        if matches.get_flag("json") {
+            println!("{}", serde_json::to_string_pretty(&template)?);
+            return Ok(());
+        }
+
+        log_ok!(
+            stdout,
+            "Created template '{}' ({}) — status: {}",
+            template.slug.as_deref().unwrap_or(slug.as_str()),
+            template.name.as_deref().unwrap_or(name.as_str()),
+            template.status.as_deref().unwrap_or("draft")
+        );
+        // Both remaining steps, in order. Naming only the version step here is what let
+        // the flow dead-end before: a template can have a published version and still be
+        // a draft, and `instance create` refuses a draft.
+        log_info!(
+            stdout,
+            "Nothing can launch from a draft. Two steps remain:\n    \
+             1. forklaunch managed template publish --slug {} --semver <v> --git-ref <ref>\n    \
+             2. forklaunch managed template publish-template --slug {}",
+            slug,
+            slug
+        );
+
+        Ok(())
+    }
+}

--- a/cli/src/managed/template/list.rs
+++ b/cli/src/managed/template/list.rs
@@ -1,0 +1,102 @@
+use std::io::Write;
+
+use anyhow::Result;
+use clap::{Arg, ArgAction, ArgMatches, Command};
+use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
+
+use crate::{
+    CliCommand,
+    core::command::command,
+    managed::{
+        client::{Missing, extract_list, get_value, require_managed_mode, resolve_managed_auth},
+        types::{AppTemplate, dash},
+    },
+};
+
+#[derive(Debug)]
+pub(super) struct ListCommand;
+
+impl ListCommand {
+    pub(super) fn new() -> Self {
+        Self
+    }
+}
+
+impl CliCommand for ListCommand {
+    fn command(&self) -> Command {
+        command(
+            "list",
+            "List the app templates your organization has published",
+        )
+        .long_about(
+            "List the app templates your organization has published.\n\n\
+                 By default only published templates are shown, because only a published\n\
+                 template can have instances launched from it. Pass --include-unpublished to\n\
+                 also see drafts and retired templates.",
+        )
+        .arg(
+            Arg::new("include_unpublished")
+                .long("include-unpublished")
+                .help("Also show draft and retired templates, not just published ones")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("json")
+                .long("json")
+                .help("Output raw JSON instead of formatted terminal output")
+                .action(ArgAction::SetTrue),
+        )
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        let auth_mode = resolve_managed_auth()?;
+        require_managed_mode(&auth_mode)?;
+
+        let json_output = matches.get_flag("json");
+        let path = if matches.get_flag("include_unpublished") {
+            "/templates?includeUnpublished=true"
+        } else {
+            "/templates"
+        };
+
+        let value = get_value(&auth_mode, path, Missing::Endpoint)?;
+        let templates: Vec<AppTemplate> = extract_list(value, &["templates"])?;
+
+        if json_output {
+            println!("{}", serde_json::to_string_pretty(&templates)?);
+            return Ok(());
+        }
+
+        let mut stdout = StandardStream::stdout(ColorChoice::Always);
+        writeln!(stdout)?;
+        stdout.set_color(ColorSpec::new().set_fg(Some(Color::Cyan)).set_bold(true))?;
+        writeln!(stdout, "App templates")?;
+        stdout.reset()?;
+        writeln!(stdout)?;
+
+        if templates.is_empty() {
+            writeln!(
+                stdout,
+                "  No templates published yet. Create one with `forklaunch managed template create`."
+            )?;
+            writeln!(stdout)?;
+            return Ok(());
+        }
+
+        stdout.set_color(ColorSpec::new().set_bold(true))?;
+        writeln!(stdout, "  {:<24} {:<28} {:<12}", "SLUG", "NAME", "STATUS")?;
+        stdout.reset()?;
+        for template in &templates {
+            writeln!(
+                stdout,
+                "  {:<24} {:<28} {:<12}",
+                dash(&template.slug),
+                dash(&template.name),
+                dash(&template.status),
+            )?;
+        }
+        writeln!(stdout)?;
+
+        Ok(())
+    }
+}

--- a/cli/src/managed/template/mod.rs
+++ b/cli/src/managed/template/mod.rs
@@ -8,12 +8,14 @@ mod list;
 mod publish;
 mod publish_template;
 mod update;
+mod vars;
 
 use create::CreateCommand;
 use list::ListCommand;
 use publish::PublishCommand;
 use publish_template::PublishTemplateCommand;
 use update::UpdateCommand;
+use vars::VarsCommand;
 
 #[derive(Debug)]
 pub(super) struct TemplateCommand {
@@ -22,6 +24,7 @@ pub(super) struct TemplateCommand {
     update: UpdateCommand,
     publish: PublishCommand,
     publish_template: PublishTemplateCommand,
+    vars: VarsCommand,
 }
 
 impl TemplateCommand {
@@ -32,6 +35,7 @@ impl TemplateCommand {
             update: UpdateCommand::new(),
             publish: PublishCommand::new(),
             publish_template: PublishTemplateCommand::new(),
+            vars: VarsCommand::new(),
         }
     }
 }
@@ -54,13 +58,18 @@ impl CliCommand for TemplateCommand {
              \x20 create  ->  publish  ->  publish-template\n\n\
              `update` is the general form of `publish-template`: it can set the status to any\n\
              of draft/published/retired, and can change the name, description, or Stripe\n\
-             product at the same time.",
+             product at the same time.\n\n\
+             `vars` declares the environment variables every instance of the template gets —\n\
+             a literal shared by all of them, a recipe each instance derives its own value\n\
+             from, or a placeholder you fill in per customer. See\n\
+             `forklaunch managed template vars --help`.",
         )
         .subcommand(self.list.command())
         .subcommand(self.create.command())
         .subcommand(self.update.command())
         .subcommand(self.publish.command())
         .subcommand(self.publish_template.command())
+        .subcommand(self.vars.command())
         .subcommand_required(true)
     }
 
@@ -71,6 +80,7 @@ impl CliCommand for TemplateCommand {
             Some(("update", sub_matches)) => self.update.handler(sub_matches),
             Some(("publish", sub_matches)) => self.publish.handler(sub_matches),
             Some(("publish-template", sub_matches)) => self.publish_template.handler(sub_matches),
+            Some(("vars", sub_matches)) => self.vars.handler(sub_matches),
             _ => unreachable!(),
         }
     }

--- a/cli/src/managed/template/mod.rs
+++ b/cli/src/managed/template/mod.rs
@@ -1,0 +1,77 @@
+use anyhow::Result;
+use clap::{ArgMatches, Command};
+
+use crate::{CliCommand, core::command::command};
+
+mod create;
+mod list;
+mod publish;
+mod publish_template;
+mod update;
+
+use create::CreateCommand;
+use list::ListCommand;
+use publish::PublishCommand;
+use publish_template::PublishTemplateCommand;
+use update::UpdateCommand;
+
+#[derive(Debug)]
+pub(super) struct TemplateCommand {
+    list: ListCommand,
+    create: CreateCommand,
+    update: UpdateCommand,
+    publish: PublishCommand,
+    publish_template: PublishTemplateCommand,
+}
+
+impl TemplateCommand {
+    pub(super) fn new() -> Self {
+        Self {
+            list: ListCommand::new(),
+            create: CreateCommand::new(),
+            update: UpdateCommand::new(),
+            publish: PublishCommand::new(),
+            publish_template: PublishTemplateCommand::new(),
+        }
+    }
+}
+
+impl CliCommand for TemplateCommand {
+    fn command(&self) -> Command {
+        command(
+            "template",
+            "Manage the app templates your organization publishes",
+        )
+        .long_about(
+            "Manage the app templates your organization publishes.\n\n\
+             TWO DIFFERENT THINGS ARE CALLED PUBLISHING, and a template needs both before\n\
+             an instance can launch from it:\n\n\
+             \x20 `publish`           adds a VERSION — a semver pinned to a git ref. A template\n\
+             \x20                     with no version has nothing to deploy.\n\
+             \x20 `publish-template`  publishes the TEMPLATE itself, moving it out of `draft`.\n\
+             \x20                     `instance create` refuses a draft template outright.\n\n\
+             So the full path from nothing to a launchable template is:\n\
+             \x20 create  ->  publish  ->  publish-template\n\n\
+             `update` is the general form of `publish-template`: it can set the status to any\n\
+             of draft/published/retired, and can change the name, description, or Stripe\n\
+             product at the same time.",
+        )
+        .subcommand(self.list.command())
+        .subcommand(self.create.command())
+        .subcommand(self.update.command())
+        .subcommand(self.publish.command())
+        .subcommand(self.publish_template.command())
+        .subcommand_required(true)
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        match matches.subcommand() {
+            Some(("list", sub_matches)) => self.list.handler(sub_matches),
+            Some(("create", sub_matches)) => self.create.handler(sub_matches),
+            Some(("update", sub_matches)) => self.update.handler(sub_matches),
+            Some(("publish", sub_matches)) => self.publish.handler(sub_matches),
+            Some(("publish-template", sub_matches)) => self.publish_template.handler(sub_matches),
+            _ => unreachable!(),
+        }
+    }
+}

--- a/cli/src/managed/template/publish.rs
+++ b/cli/src/managed/template/publish.rs
@@ -1,0 +1,146 @@
+use std::io::Write;
+
+use anyhow::{Context, Result};
+use clap::{Arg, ArgAction, ArgMatches, Command};
+use serde_json::{Map, Value, json};
+use termcolor::{ColorChoice, StandardStream, WriteColor};
+
+use crate::{
+    CliCommand,
+    core::command::command,
+    managed::{
+        client::{Missing, post_json, print_dryrun, require_managed_mode, resolve_managed_auth},
+        types::TemplateVersion,
+    },
+};
+
+#[derive(Debug)]
+pub(super) struct PublishCommand;
+
+impl PublishCommand {
+    pub(super) fn new() -> Self {
+        Self
+    }
+}
+
+impl CliCommand for PublishCommand {
+    fn command(&self) -> Command {
+        command(
+            "publish",
+            "Publish a new VERSION of a template (see publish-template for the template itself)",
+        )
+        .long_about(
+            "Publish a new VERSION of an app template.\n\n\
+             THIS IS NOT THE COMMAND THAT PUBLISHES A TEMPLATE. It adds a version — a\n\
+             semantic version pinned to a git ref — to a template that already exists.\n\
+             To move the TEMPLATE itself from `draft` to `published`, which is what\n\
+             `instance create` requires, use `template publish-template`. Both steps are\n\
+             needed, and doing only this one leaves the template still unlaunchable.\n\n\
+             A newly added version starts pending: the platform builds the image from\n\
+             --git-ref before instances can launch from it. There is no way to supply a\n\
+             prebuilt image — the control plane's version API takes a semver and a git ref\n\
+             and nothing else.",
+        )
+        .arg(
+            Arg::new("slug")
+                .long("slug")
+                .required(true)
+                .help("Slug of the template to publish a version of"),
+        )
+        .arg(
+            Arg::new("semver")
+                .long("semver")
+                .required(true)
+                .help("Semantic version for this release (for example: 1.4.0)"),
+        )
+        .arg(
+            Arg::new("git_ref")
+                .long("git-ref")
+                .required(true)
+                .help("Git ref (tag, branch, or commit sha) this version is built from"),
+        )
+        .arg(
+            Arg::new("dryrun")
+                .long("dryrun")
+                .help("Print the request that would be sent without sending it")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("json")
+                .long("json")
+                .help("Output raw JSON instead of formatted terminal output")
+                .action(ArgAction::SetTrue),
+        )
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        let mut stdout = StandardStream::stdout(ColorChoice::Always);
+
+        let slug = matches
+            .get_one::<String>("slug")
+            .context("--slug is required")?;
+        let semver = matches
+            .get_one::<String>("semver")
+            .context("--semver is required")?;
+        let git_ref = matches
+            .get_one::<String>("git_ref")
+            .context("--git-ref is required")?;
+
+        let mut body = Map::new();
+        body.insert("semver".to_string(), json!(semver));
+        body.insert("gitRef".to_string(), json!(git_ref));
+        let body = Value::Object(body);
+
+        // Slugs are organization-authored identifiers, not free-form user input, but they
+        // still land in a URL path — encode so a slug containing a separator cannot
+        // restructure the request.
+        let path = format!("/templates/{}/versions", urlencoding::encode(slug));
+
+        if matches.get_flag("dryrun") {
+            return print_dryrun("POST", &path, Some(&body));
+        }
+
+        let auth_mode = resolve_managed_auth()?;
+        require_managed_mode(&auth_mode)?;
+
+        let version: TemplateVersion = post_json(
+            &auth_mode,
+            &path,
+            body,
+            Missing::Resource(format!("template '{}'", slug)),
+        )?;
+
+        if matches.get_flag("json") {
+            println!("{}", serde_json::to_string_pretty(&version)?);
+            return Ok(());
+        }
+
+        log_ok!(
+            stdout,
+            "Published version {} of '{}' from {}",
+            version.semver.as_deref().unwrap_or(semver.as_str()),
+            slug,
+            version.git_ref.as_deref().unwrap_or(git_ref.as_str())
+        );
+        if let Some(status) = version.status.as_deref() {
+            log_info!(stdout, "Version status: {}", status);
+            if status == "pending" || status == "building" {
+                log_info!(
+                    stdout,
+                    "The platform still has to build this version before instances can launch from it."
+                );
+            }
+        }
+        // A version is not the same as a published template, and the difference is
+        // invisible until `instance create` refuses. Say it here every time.
+        log_info!(
+            stdout,
+            "This published a VERSION, not the template. If '{}' is still a draft, run:\n    \
+             forklaunch managed template publish-template --slug {}",
+            slug,
+            slug
+        );
+
+        Ok(())
+    }
+}

--- a/cli/src/managed/template/publish_template.rs
+++ b/cli/src/managed/template/publish_template.rs
@@ -1,0 +1,80 @@
+use anyhow::{Context, Result};
+use clap::{Arg, ArgAction, ArgMatches, Command};
+
+use crate::{
+    CliCommand,
+    core::command::command,
+    managed::template::update::{TemplateUpdate, update_template},
+};
+
+/// `forklaunch managed template publish-template`
+///
+/// This is `template update --status published` under a name that says what it is for.
+/// It exists because the step it performs is mandatory and was, until the control plane
+/// gained `PATCH /managed-mode/templates/:slug`, impossible: templates are created as
+/// `draft`, `instance create` requires `published`, and nothing could move one short of
+/// writing the database column by hand.
+#[derive(Debug)]
+pub(super) struct PublishTemplateCommand;
+
+impl PublishTemplateCommand {
+    pub(super) fn new() -> Self {
+        Self
+    }
+}
+
+impl CliCommand for PublishTemplateCommand {
+    fn command(&self) -> Command {
+        command(
+            "publish-template",
+            "Mark the TEMPLATE ITSELF as published, so instances can be launched from it",
+        )
+        .long_about(
+            "Mark the template itself as published, so instances can be launched from it.\n\n\
+             DO NOT CONFUSE THIS WITH `template publish`:\n\
+             \x20 `template publish`           adds a VERSION to a template (a semver + git ref)\n\
+             \x20 `template publish-template`  publishes the TEMPLATE, which is what makes it\n\
+             \x20                              launchable at all\n\n\
+             A template is created as a draft. `instance create` only accepts a published\n\
+             template, so until this command is run — however many versions the template\n\
+             has — no instance can be launched from it.\n\n\
+             This is exactly `template update --status published`, under a name that says\n\
+             what it is for. Use `template update` if you want to set other fields at the\n\
+             same time, or to move a template to `retired`.",
+        )
+        .arg(
+            Arg::new("slug")
+                .long("slug")
+                .required(true)
+                .help("Slug of the template to publish"),
+        )
+        .arg(
+            Arg::new("dryrun")
+                .long("dryrun")
+                .help("Print the request that would be sent without sending it")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("json")
+                .long("json")
+                .help("Output raw JSON instead of formatted terminal output")
+                .action(ArgAction::SetTrue),
+        )
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        let slug = matches
+            .get_one::<String>("slug")
+            .context("--slug is required")?;
+
+        update_template(
+            slug,
+            TemplateUpdate {
+                status: Some("published"),
+                dryrun: matches.get_flag("dryrun"),
+                json: matches.get_flag("json"),
+                ..Default::default()
+            },
+        )
+    }
+}

--- a/cli/src/managed/template/update.rs
+++ b/cli/src/managed/template/update.rs
@@ -1,0 +1,245 @@
+use std::io::Write;
+
+use anyhow::{Context, Result, bail};
+use clap::{Arg, ArgAction, ArgMatches, Command};
+use serde_json::{Map, Value, json};
+use termcolor::{ColorChoice, StandardStream, WriteColor};
+
+use crate::{
+    CliCommand,
+    core::command::command,
+    managed::{
+        client::{Missing, patch_json, print_dryrun, require_managed_mode, resolve_managed_auth},
+        types::{AppTemplate, TEMPLATE_STATUSES},
+    },
+};
+
+/// The fields `PATCH /managed-mode/templates/:slug` accepts, plus the two output flags.
+///
+/// Passed explicitly rather than by handing the shared code an `ArgMatches`, because
+/// `publish-template` deliberately does not define `--name` / `--description` /
+/// `--status`, and `ArgMatches::get_one` panics on an argument id the command never
+/// declared.
+#[derive(Debug, Default)]
+pub(super) struct TemplateUpdate<'a> {
+    pub(super) name: Option<&'a String>,
+    pub(super) description: Option<&'a String>,
+    pub(super) status: Option<&'a str>,
+    pub(super) stripe_product: Option<&'a String>,
+    pub(super) dryrun: bool,
+    pub(super) json: bool,
+}
+
+#[derive(Debug)]
+pub(super) struct UpdateCommand;
+
+impl UpdateCommand {
+    pub(super) fn new() -> Self {
+        Self
+    }
+}
+
+impl CliCommand for UpdateCommand {
+    fn command(&self) -> Command {
+        command(
+            "update",
+            "Change a template's name, description, status, or Stripe product",
+        )
+        .long_about(
+            "Change a template's name, description, status, or Stripe product.\n\n\
+             Only the fields you pass are changed; everything else is left alone.\n\n\
+             --status is the important one. A template is created as `draft`, and\n\
+             `instance create` will only launch from a `published` template, so a template\n\
+             stays uninstantiable until its status is moved. `template publish-template` is\n\
+             the shorthand for exactly that, and is usually what you want.\n\n\
+             The three statuses:\n\
+             \x20 draft      registered but not launchable — the state every template starts in\n\
+             \x20 published  launchable; `instance create` accepts it\n\
+             \x20 retired    no longer launchable for new instances\n\n\
+             --stripe-product records a Stripe product id against the template. Note that\n\
+             nothing in billing reads that id today, so setting it does not by itself cause\n\
+             anyone to be charged — it is stored for later use.",
+        )
+        .arg(
+            Arg::new("slug")
+                .long("slug")
+                .required(true)
+                .help("Slug of the template to update"),
+        )
+        .arg(
+            Arg::new("name")
+                .long("name")
+                .help("New human-readable template name"),
+        )
+        .arg(
+            Arg::new("description")
+                .long("description")
+                .help("New description shown alongside the template"),
+        )
+        .arg(
+            Arg::new("status")
+                .long("status")
+                .value_parser(TEMPLATE_STATUSES.to_vec())
+                .help("New status — `published` is what makes the template launchable"),
+        )
+        .arg(
+            Arg::new("stripe_product")
+                .long("stripe-product")
+                .help("Stripe product id to record against the template (not yet read by billing)"),
+        )
+        .arg(
+            Arg::new("dryrun")
+                .long("dryrun")
+                .help("Print the request that would be sent without sending it")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("json")
+                .long("json")
+                .help("Output raw JSON instead of formatted terminal output")
+                .action(ArgAction::SetTrue),
+        )
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        let slug = matches
+            .get_one::<String>("slug")
+            .context("--slug is required")?;
+
+        update_template(
+            slug,
+            TemplateUpdate {
+                name: matches.get_one::<String>("name"),
+                description: matches.get_one::<String>("description"),
+                status: matches.get_one::<String>("status").map(String::as_str),
+                stripe_product: matches.get_one::<String>("stripe_product"),
+                dryrun: matches.get_flag("dryrun"),
+                json: matches.get_flag("json"),
+            },
+        )
+    }
+}
+
+/// Issues the PATCH. Shared by `template update` and `template publish-template`.
+pub(super) fn update_template(slug: &str, update: TemplateUpdate<'_>) -> Result<()> {
+    let mut stdout = StandardStream::stdout(ColorChoice::Always);
+
+    let mut body = Map::new();
+    if let Some(name) = update.name {
+        body.insert("name".to_string(), json!(name));
+    }
+    if let Some(description) = update.description {
+        body.insert("description".to_string(), json!(description));
+    }
+    if let Some(status) = update.status {
+        body.insert("status".to_string(), json!(status));
+    }
+    if let Some(stripe_product) = update.stripe_product {
+        body.insert("stripeProductId".to_string(), json!(stripe_product));
+    }
+
+    // An empty PATCH is accepted by the control plane and changes nothing, so it would
+    // report success while having done nothing at all. Refuse instead — someone who
+    // typed `template update --slug x` and saw "Updated" would reasonably believe
+    // something had happened.
+    if body.is_empty() {
+        bail!(
+            "nothing to update — pass at least one of --name, --description, --status, or \
+             --stripe-product (to publish a template, `forklaunch managed template \
+             publish-template --slug {}` is the shorthand)",
+            slug
+        );
+    }
+
+    let body = Value::Object(body);
+    // Slugs are organization-authored identifiers, not free-form user input, but they
+    // still land in a URL path — encode so a slug containing a separator cannot
+    // restructure the request.
+    let path = format!("/templates/{}", urlencoding::encode(slug));
+
+    if update.dryrun {
+        return print_dryrun("PATCH", &path, Some(&body));
+    }
+
+    let auth_mode = resolve_managed_auth()?;
+    require_managed_mode(&auth_mode)?;
+
+    let template: AppTemplate = patch_json(
+        &path,
+        body,
+        Missing::Resource(format!("template '{}'", slug)),
+    )?;
+
+    if update.json {
+        println!("{}", serde_json::to_string_pretty(&template)?);
+        return Ok(());
+    }
+
+    // The control plane echoes the resulting status back; fall back to what was asked
+    // for only if it did not.
+    let new_status = template
+        .status
+        .as_deref()
+        .or(update.status)
+        .unwrap_or("unchanged");
+
+    log_ok!(
+        stdout,
+        "Updated template '{}' — status: {}",
+        slug,
+        new_status
+    );
+
+    if new_status == "published" {
+        log_info!(
+            stdout,
+            "Instances can now be launched from it: forklaunch managed instance create --template {} --region <region>",
+            slug
+        );
+    } else if new_status == "draft" {
+        log_info!(
+            stdout,
+            "This template is still a draft, so `instance create` will refuse it. Publish it with: forklaunch managed template publish-template --slug {}",
+            slug
+        );
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_update_with_no_fields_is_refused_rather_than_reported_as_success() {
+        // Reaches the guard before any network or auth: an empty PATCH is accepted by
+        // the control plane and changes nothing, so succeeding here would be a lie.
+        let error = update_template("clinic", TemplateUpdate::default()).unwrap_err();
+        let message = error.to_string();
+        assert!(message.contains("nothing to update"), "{}", message);
+        assert!(message.contains("publish-template"), "{}", message);
+    }
+
+    #[test]
+    fn publish_template_sends_exactly_a_published_status() {
+        // What `publish-template` forwards, asserted without a server: status only, and
+        // none of the other patchable fields silently along for the ride.
+        let update = TemplateUpdate {
+            status: Some("published"),
+            dryrun: true,
+            ..Default::default()
+        };
+        assert_eq!(update.status, Some("published"));
+        assert!(update.name.is_none());
+        assert!(update.description.is_none());
+        assert!(update.stripe_product.is_none());
+    }
+
+    #[test]
+    fn the_cli_status_list_matches_what_the_control_plane_validates() {
+        // The control plane answers 400 with exactly this list. If the two drift, the
+        // CLI would reject a status the server accepts (or vice versa).
+        assert_eq!(TEMPLATE_STATUSES, &["draft", "published", "retired"]);
+    }
+}

--- a/cli/src/managed/template/vars/list.rs
+++ b/cli/src/managed/template/vars/list.rs
@@ -1,0 +1,237 @@
+use std::io::Write;
+
+use anyhow::{Context, Result};
+use clap::{Arg, ArgAction, ArgMatches, Command};
+use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
+
+use crate::{
+    CliCommand,
+    core::command::command,
+    managed::{
+        client::{Missing, extract_list, get_value, require_managed_mode, resolve_managed_auth},
+        types::{TemplateVariable, dash, yes_no},
+    },
+};
+
+/// Stands in for a static variable's literal unless `--reveal` was passed.
+///
+/// Static values are the one place a template holds something sensitive: the platform's
+/// own entity classifies the column as payment-card data precisely because "a template
+/// author will put a shared credential here whatever the docs say". Printing that into
+/// terminal scrollback or a CI log on every `vars list` is the wrong default, so the
+/// value is withheld behind an explicit flag — and the placeholder says which flag, so
+/// nobody mistakes a withheld value for an empty one.
+const HIDDEN: &str = "<hidden — pass --reveal>";
+
+/// Replaces static values with a placeholder. Applied before BOTH the table and the
+/// `--json` output, so `--json` cannot be used as a way around `--reveal`.
+fn redact(variables: &mut [TemplateVariable]) {
+    for variable in variables.iter_mut() {
+        if variable.value.is_some() {
+            variable.value = Some(HIDDEN.to_string());
+        }
+    }
+}
+
+/// What to show a reader in the SOURCE column: where this variable's value comes from.
+fn source(variable: &TemplateVariable) -> String {
+    match variable.kind.as_deref() {
+        Some("static") => variable
+            .value
+            .clone()
+            .unwrap_or_else(|| "(no value)".to_string()),
+        Some("generated") => dash(&variable.generator_type).to_string(),
+        Some("custom") => "set per instance".to_string(),
+        _ => "-".to_string(),
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct ListCommand;
+
+impl ListCommand {
+    pub(super) fn new() -> Self {
+        Self
+    }
+}
+
+impl CliCommand for ListCommand {
+    fn command(&self) -> Command {
+        command("list", "List the variables a template declares")
+            .long_about(
+                "List the variables a template declares, and where each one's value comes from.\n\n\
+                 The SOURCE column reads differently per kind: for `static` it is the literal,\n\
+                 for `generated` it is the recipe each instance derives from, and for `custom`\n\
+                 it says the value lives on the instance rather than here.\n\n\
+                 Static values are WITHHELD by default and shown only with --reveal, because a\n\
+                 static variable is the one kind that can hold a secret shared across every\n\
+                 customer's instance. --json withholds them too — it is not a way around\n\
+                 --reveal.\n\n\
+                 To see whether a particular instance has values for the `custom` ones, use\n\
+                 `forklaunch managed instance vars list --id <instance-id>`.",
+            )
+            .arg(
+                Arg::new("slug")
+                    .long("slug")
+                    .required(true)
+                    .help("Slug of the template whose variables should be listed"),
+            )
+            .arg(
+                Arg::new("reveal")
+                    .long("reveal")
+                    .help("Print static values in full instead of withholding them")
+                    .action(ArgAction::SetTrue),
+            )
+            .arg(
+                Arg::new("json")
+                    .long("json")
+                    .help("Output raw JSON instead of formatted terminal output")
+                    .action(ArgAction::SetTrue),
+            )
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        let slug = matches
+            .get_one::<String>("slug")
+            .context("--slug is required")?;
+
+        let auth_mode = resolve_managed_auth()?;
+        require_managed_mode(&auth_mode)?;
+
+        let path = format!("/templates/{}/variables", urlencoding::encode(slug));
+        let value = get_value(
+            &auth_mode,
+            &path,
+            Missing::Resource(format!("template '{}'", slug)),
+        )?;
+        let mut variables: Vec<TemplateVariable> = extract_list(value, &["variables"])?;
+
+        if !matches.get_flag("reveal") {
+            redact(&mut variables);
+        }
+
+        if matches.get_flag("json") {
+            println!("{}", serde_json::to_string_pretty(&variables)?);
+            return Ok(());
+        }
+
+        let mut stdout = StandardStream::stdout(ColorChoice::Always);
+        writeln!(stdout)?;
+        stdout.set_color(ColorSpec::new().set_fg(Some(Color::Cyan)).set_bold(true))?;
+        writeln!(stdout, "Variables declared by template '{}'", slug)?;
+        stdout.reset()?;
+        writeln!(stdout)?;
+
+        if variables.is_empty() {
+            writeln!(
+                stdout,
+                "  This template declares no variables. Add one with `forklaunch managed template vars set`."
+            )?;
+            writeln!(stdout)?;
+            return Ok(());
+        }
+
+        stdout.set_color(ColorSpec::new().set_bold(true))?;
+        writeln!(
+            stdout,
+            "  {:<24} {:<10} {:<12} {:<14} {:<9} SOURCE",
+            "KEY", "KIND", "SCOPE", "SERVICE", "REQUIRED"
+        )?;
+        stdout.reset()?;
+        for variable in &variables {
+            writeln!(
+                stdout,
+                "  {:<24} {:<10} {:<12} {:<14} {:<9} {}",
+                dash(&variable.key),
+                dash(&variable.kind),
+                dash(&variable.scope),
+                dash(&variable.service_name),
+                yes_no(&variable.required),
+                source(variable),
+            )?;
+        }
+        writeln!(stdout)?;
+
+        let required_custom = variables.iter().any(|variable| {
+            variable.kind.as_deref() == Some("custom") && variable.required == Some(true)
+        });
+        if required_custom {
+            log_info!(
+                stdout,
+                "Variables marked required must have a value on an instance before it can be provisioned. Check one with: forklaunch managed instance vars list --id <instance-id>"
+            );
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn static_variable(value: &str) -> TemplateVariable {
+        TemplateVariable {
+            key: Some("STRIPE_KEY".to_string()),
+            kind: Some("static".to_string()),
+            value: Some(value.to_string()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn static_values_are_withheld_by_default() {
+        let mut variables = vec![static_variable("sk_live_supersecret")];
+        redact(&mut variables);
+        assert_eq!(variables[0].value.as_deref(), Some(HIDDEN));
+        assert!(!source(&variables[0]).contains("supersecret"));
+    }
+
+    #[test]
+    fn json_output_cannot_be_used_to_bypass_reveal() {
+        // `--json` serializes the same redacted structs the table renders, so the secret
+        // has to be gone from the serialized form too.
+        let mut variables = vec![static_variable("sk_live_supersecret")];
+        redact(&mut variables);
+        let rendered = serde_json::to_string(&variables).unwrap();
+        assert!(!rendered.contains("supersecret"), "{}", rendered);
+    }
+
+    #[test]
+    fn revealing_leaves_the_value_alone() {
+        // `redact` is simply not called for --reveal; assert the value survives so a
+        // future refactor cannot make --reveal a no-op.
+        let variable = static_variable("sk_live_supersecret");
+        assert_eq!(source(&variable), "sk_live_supersecret");
+    }
+
+    #[test]
+    fn the_source_column_reads_differently_per_kind() {
+        let generated = TemplateVariable {
+            kind: Some("generated".to_string()),
+            generator_type: Some("32-bytes-base64".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(source(&generated), "32-bytes-base64");
+
+        let custom = TemplateVariable {
+            kind: Some("custom".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(source(&custom), "set per instance");
+    }
+
+    #[test]
+    fn a_generated_variable_has_no_value_to_redact() {
+        // The design guarantee behind `generated`: the template stores no secret. If a
+        // control plane ever sent one back it would still be withheld, but there should
+        // not be one to begin with.
+        let mut variables = vec![TemplateVariable {
+            kind: Some("generated".to_string()),
+            generator_type: Some("hex-key".to_string()),
+            ..Default::default()
+        }];
+        redact(&mut variables);
+        assert!(variables[0].value.is_none());
+    }
+}

--- a/cli/src/managed/template/vars/list.rs
+++ b/cli/src/managed/template/vars/list.rs
@@ -9,37 +9,21 @@ use crate::{
     core::command::command,
     managed::{
         client::{Missing, extract_list, get_value, require_managed_mode, resolve_managed_auth},
-        types::{TemplateVariable, dash, yes_no},
+        types::{TemplateVariable, dash, required_cell},
     },
 };
 
-/// Stands in for a static variable's literal unless `--reveal` was passed.
-///
-/// Static values are the one place a template holds something sensitive: the platform's
-/// own entity classifies the column as payment-card data precisely because "a template
-/// author will put a shared credential here whatever the docs say". Printing that into
-/// terminal scrollback or a CI log on every `vars list` is the wrong default, so the
-/// value is withheld behind an explicit flag — and the placeholder says which flag, so
-/// nobody mistakes a withheld value for an empty one.
-const HIDDEN: &str = "<hidden — pass --reveal>";
-
-/// Replaces static values with a placeholder. Applied before BOTH the table and the
-/// `--json` output, so `--json` cannot be used as a way around `--reveal`.
-fn redact(variables: &mut [TemplateVariable]) {
-    for variable in variables.iter_mut() {
-        if variable.value.is_some() {
-            variable.value = Some(HIDDEN.to_string());
-        }
-    }
-}
-
 /// What to show a reader in the SOURCE column: where this variable's value comes from.
+///
+/// A `static` row reports only that the template holds the value, never what it is. The
+/// control plane does not send it — `TemplateVariableSchema` omits `value` on both the
+/// managed-apps handler and the `/managed-mode` proxy, on the reasoning that a static
+/// value can be a credential every instance shares and a list endpoint is the wrong
+/// place to hand one back. That matches the question a list answers, which is "is this
+/// configured", not "what is it".
 fn source(variable: &TemplateVariable) -> String {
     match variable.kind.as_deref() {
-        Some("static") => variable
-            .value
-            .clone()
-            .unwrap_or_else(|| "(no value)".to_string()),
+        Some("static") => "set on template".to_string(),
         Some("generated") => dash(&variable.generator_type).to_string(),
         Some("custom") => "set per instance".to_string(),
         _ => "-".to_string(),
@@ -60,13 +44,15 @@ impl CliCommand for ListCommand {
         command("list", "List the variables a template declares")
             .long_about(
                 "List the variables a template declares, and where each one's value comes from.\n\n\
-                 The SOURCE column reads differently per kind: for `static` it is the literal,\n\
-                 for `generated` it is the recipe each instance derives from, and for `custom`\n\
-                 it says the value lives on the instance rather than here.\n\n\
-                 Static values are WITHHELD by default and shown only with --reveal, because a\n\
-                 static variable is the one kind that can hold a secret shared across every\n\
-                 customer's instance. --json withholds them too — it is not a way around\n\
-                 --reveal.\n\n\
+                 The SOURCE column reads differently per kind: for `generated` it is the recipe\n\
+                 each instance derives from, for `custom` it says the value lives on the\n\
+                 instance, and for `static` it says only that the template holds one.\n\n\
+                 STATIC VALUES ARE NOT READABLE BACK, here or anywhere else in the CLI. The\n\
+                 control plane does not return them — a static value can be a credential every\n\
+                 instance shares, so listing is not the place to hand one out. This command\n\
+                 tells you a variable IS configured, not what it is set to. To change one,\n\
+                 declare it again with the new value:\n\
+                 \x20 forklaunch managed template vars set --slug <slug> --key <key> --kind static --value <new>\n\n\
                  To see whether a particular instance has values for the `custom` ones, use\n\
                  `forklaunch managed instance vars list --id <instance-id>`.",
             )
@@ -75,12 +61,6 @@ impl CliCommand for ListCommand {
                     .long("slug")
                     .required(true)
                     .help("Slug of the template whose variables should be listed"),
-            )
-            .arg(
-                Arg::new("reveal")
-                    .long("reveal")
-                    .help("Print static values in full instead of withholding them")
-                    .action(ArgAction::SetTrue),
             )
             .arg(
                 Arg::new("json")
@@ -104,11 +84,7 @@ impl CliCommand for ListCommand {
             &path,
             Missing::Resource(format!("template '{}'", slug)),
         )?;
-        let mut variables: Vec<TemplateVariable> = extract_list(value, &["variables"])?;
-
-        if !matches.get_flag("reveal") {
-            redact(&mut variables);
-        }
+        let variables: Vec<TemplateVariable> = extract_list(value, &["variables"])?;
 
         if matches.get_flag("json") {
             println!("{}", serde_json::to_string_pretty(&variables)?);
@@ -146,16 +122,27 @@ impl CliCommand for ListCommand {
                 dash(&variable.kind),
                 dash(&variable.scope),
                 dash(&variable.service_name),
-                yes_no(&variable.required),
+                required_cell(&variable.kind, &variable.required),
                 source(variable),
             )?;
         }
         writeln!(stdout)?;
 
-        let required_custom = variables.iter().any(|variable| {
+        // Said only when there is a static row to explain. A blanket note on a template
+        // with no static variables would be answering a question nobody asked.
+        if variables
+            .iter()
+            .any(|variable| variable.kind.as_deref() == Some("static"))
+        {
+            log_info!(
+                stdout,
+                "Static values are not readable back — this shows that a value is set, not what it is. To change one, set it again with a new --value."
+            );
+        }
+
+        if variables.iter().any(|variable| {
             variable.kind.as_deref() == Some("custom") && variable.required == Some(true)
-        });
-        if required_custom {
+        }) {
             log_info!(
                 stdout,
                 "Variables marked required must have a value on an instance before it can be provisioned. Check one with: forklaunch managed instance vars list --id <instance-id>"
@@ -170,39 +157,29 @@ impl CliCommand for ListCommand {
 mod tests {
     use super::*;
 
-    fn static_variable(value: &str) -> TemplateVariable {
-        TemplateVariable {
-            key: Some("STRIPE_KEY".to_string()),
+    #[test]
+    fn a_static_row_states_that_a_value_is_set_without_stating_the_value() {
+        let variable = TemplateVariable {
+            key: Some("SHARED_API_KEY".to_string()),
             kind: Some("static".to_string()),
-            value: Some(value.to_string()),
             ..Default::default()
-        }
+        };
+        assert_eq!(source(&variable), "set on template");
     }
 
     #[test]
-    fn static_values_are_withheld_by_default() {
-        let mut variables = vec![static_variable("sk_live_supersecret")];
-        redact(&mut variables);
-        assert_eq!(variables[0].value.as_deref(), Some(HIDDEN));
-        assert!(!source(&variables[0]).contains("supersecret"));
-    }
-
-    #[test]
-    fn json_output_cannot_be_used_to_bypass_reveal() {
-        // `--json` serializes the same redacted structs the table renders, so the secret
-        // has to be gone from the serialized form too.
-        let mut variables = vec![static_variable("sk_live_supersecret")];
-        redact(&mut variables);
+    fn the_parsed_shape_has_nowhere_to_put_a_value_the_server_might_send() {
+        // The guarantee, enforced by the type rather than by a redaction step: the
+        // control plane omits `value` from TemplateVariableSchema, and this struct has
+        // no field for it, so a server that started sending one could not leak it
+        // through the table or through `--json`.
+        let variables: Vec<TemplateVariable> = serde_json::from_str(
+            r#"[{"key":"SHARED_API_KEY","kind":"static","scope":"application","value":"sk_live_supersecret"}]"#,
+        )
+        .unwrap();
+        assert_eq!(source(&variables[0]), "set on template");
         let rendered = serde_json::to_string(&variables).unwrap();
         assert!(!rendered.contains("supersecret"), "{}", rendered);
-    }
-
-    #[test]
-    fn revealing_leaves_the_value_alone() {
-        // `redact` is simply not called for --reveal; assert the value survives so a
-        // future refactor cannot make --reveal a no-op.
-        let variable = static_variable("sk_live_supersecret");
-        assert_eq!(source(&variable), "sk_live_supersecret");
     }
 
     #[test]
@@ -222,16 +199,19 @@ mod tests {
     }
 
     #[test]
-    fn a_generated_variable_has_no_value_to_redact() {
-        // The design guarantee behind `generated`: the template stores no secret. If a
-        // control plane ever sent one back it would still be withheld, but there should
-        // not be one to begin with.
-        let mut variables = vec![TemplateVariable {
-            kind: Some("generated".to_string()),
-            generator_type: Some("hex-key".to_string()),
-            ..Default::default()
-        }];
-        redact(&mut variables);
-        assert!(variables[0].value.is_none());
+    fn the_control_planes_bare_array_response_parses() {
+        // Both layers declare `200: array(TemplateVariableSchema)` — a bare array, not a
+        // wrapped one. `required` is non-optional server-side; the rest may be absent.
+        let variables: Vec<TemplateVariable> = extract_list(
+            serde_json::json!([
+                {"key":"LOG_LEVEL","scope":"application","kind":"static","required":false},
+                {"key":"SESSION_SECRET","scope":"application","kind":"generated","generatorType":"32-bytes-base64","required":false}
+            ]),
+            &["variables"],
+        )
+        .unwrap();
+        assert_eq!(variables.len(), 2);
+        assert_eq!(source(&variables[0]), "set on template");
+        assert_eq!(source(&variables[1]), "32-bytes-base64");
     }
 }

--- a/cli/src/managed/template/vars/mod.rs
+++ b/cli/src/managed/template/vars/mod.rs
@@ -1,0 +1,134 @@
+use anyhow::{Result, bail};
+use clap::{ArgMatches, Command};
+
+use crate::{CliCommand, core::command::command};
+
+mod list;
+mod set;
+mod unset;
+
+use list::ListCommand;
+use set::SetCommand;
+use unset::UnsetCommand;
+
+/// Validates the `--scope` / `--service` pair, which is the one coupling between two
+/// flags that the control plane cannot report as clearly as the CLI can: server-side it
+/// surfaces as a schema violation on `serviceName`, which does not mention `--scope` at
+/// all.
+///
+/// Returns the service name to send, if any.
+pub(super) fn resolve_scope<'a>(scope: &str, service: Option<&'a str>) -> Result<Option<&'a str>> {
+    match (scope, service) {
+        ("service", None) => bail!(
+            "--service is required when --scope service — a service-scoped variable reaches \
+             exactly one service in the deployed app, so it has to name which one. Drop \
+             --scope to make it application-scoped instead, which reaches every service."
+        ),
+        ("application", Some(name)) => bail!(
+            "--service '{}' is meaningless with --scope application — an application-scoped \
+             variable already reaches every service. Pass --scope service to target just '{}'.",
+            name,
+            name
+        ),
+        (_, service) => Ok(service),
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct VarsCommand {
+    list: ListCommand,
+    set: SetCommand,
+    unset: UnsetCommand,
+}
+
+impl VarsCommand {
+    pub(super) fn new() -> Self {
+        Self {
+            list: ListCommand::new(),
+            set: SetCommand::new(),
+            unset: UnsetCommand::new(),
+        }
+    }
+}
+
+impl CliCommand for VarsCommand {
+    fn command(&self) -> Command {
+        command(
+            "vars",
+            "Declare the variables every instance of a template receives",
+        )
+        .long_about(
+            "Declare the variables every instance of a template receives.\n\n\
+             A template declares WHAT each of its instances needs as a deployment\n\
+             environment variable. How the value is arrived at differs by KIND, and picking\n\
+             the right one is the whole point of this command:\n\n\
+             \x20 static     the same literal for every instance (LOG_LEVEL=info). The\n\
+             \x20            template holds the value, so every customer gets the same one.\n\
+             \x20 generated  a recipe, not a value. Each instance derives its OWN value,\n\
+             \x20            seeded on its instance id so a provisioning retry re-derives the\n\
+             \x20            same one. The template stores no secret at all.\n\
+             \x20 custom     you set the value per instance (one customer's own Stripe key).\n\
+             \x20            The template only declares that the variable exists; the value\n\
+             \x20            lives on each instance — see `managed instance vars`.\n\n\
+             If you are about to use `static` for a secret, you almost certainly want\n\
+             `generated` instead: a static secret is one secret shared across every\n\
+             customer's instance, and it sits in the template at rest.\n\n\
+             SCOPE decides how far a variable reaches. `application` (the default) reaches\n\
+             every service in the deployed app; `service` reaches exactly one named service\n\
+             and requires --service.\n\n\
+             A `custom` variable may be marked --required, which means an instance CANNOT be\n\
+             provisioned until it has a value. That is a deliberate launch-time failure: the\n\
+             alternative is deploying an app that boots and then misbehaves in a way nobody\n\
+             traces back to a missing environment variable.",
+        )
+        .subcommand(self.list.command())
+        .subcommand(self.set.command())
+        .subcommand(self.unset.command())
+        .subcommand_required(true)
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        match matches.subcommand() {
+            Some(("list", sub_matches)) => self.list.handler(sub_matches),
+            Some(("set", sub_matches)) => self.set.handler(sub_matches),
+            Some(("unset", sub_matches)) => self.unset.handler(sub_matches),
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn service_scope_without_a_service_name_is_refused() {
+        let error = resolve_scope("service", None).unwrap_err().to_string();
+        assert!(error.contains("--service is required"), "{}", error);
+    }
+
+    #[test]
+    fn application_scope_with_a_service_name_is_refused() {
+        // Accepting this would be worse than rejecting it: the control plane would store
+        // an application-scoped variable and silently drop the service name, so the
+        // variable would reach every service when the operator asked for one.
+        let error = resolve_scope("application", Some("billing"))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            error.contains("meaningless with --scope application"),
+            "{}",
+            error
+        );
+        assert!(error.contains("billing"), "{}", error);
+    }
+
+    #[test]
+    fn matching_scope_and_service_pass_through() {
+        assert_eq!(
+            resolve_scope("service", Some("billing")).unwrap(),
+            Some("billing")
+        );
+        assert_eq!(resolve_scope("application", None).unwrap(), None);
+    }
+}

--- a/cli/src/managed/template/vars/set.rs
+++ b/cli/src/managed/template/vars/set.rs
@@ -1,0 +1,570 @@
+use std::io::Write;
+
+use anyhow::{Context, Result, bail};
+use clap::{Arg, ArgAction, ArgMatches, Command};
+use serde_json::{Map, Value, json};
+use termcolor::{ColorChoice, StandardStream, WriteColor};
+
+use crate::{
+    CliCommand,
+    core::command::command,
+    managed::{
+        client::{
+            Missing, print_dryrun, put_json_optional, require_managed_mode, resolve_managed_auth,
+        },
+        template::vars::resolve_scope,
+        types::{GENERATOR_TYPES, VARIABLE_KINDS, VARIABLE_SCOPES},
+    },
+};
+
+/// Everything `PUT /managed-mode/templates/:slug/variables` needs, before validation.
+///
+/// Taken as a struct rather than an `ArgMatches` so the flag-combination rules can be
+/// unit tested without standing up a control plane — they are the part most likely to
+/// be got wrong, and they are pure.
+#[derive(Debug, Default)]
+pub(super) struct VariableSpec<'a> {
+    pub(super) key: &'a str,
+    pub(super) kind: &'a str,
+    pub(super) scope: &'a str,
+    pub(super) service: Option<&'a str>,
+    pub(super) value: Option<&'a str>,
+    pub(super) generator: Option<&'a str>,
+    pub(super) required: bool,
+    pub(super) description: Option<&'a str>,
+}
+
+/// Validates the flag combination and builds the request body.
+///
+/// The rules enforced here are all ones where the client-side error is meaningfully
+/// clearer than the server's. The server would reject `--value` on a `generated`
+/// variable too, but as a schema error naming a field the operator never typed; here it
+/// can say what the operator should have used instead.
+pub(super) fn build_variable_body(spec: &VariableSpec<'_>) -> Result<Value> {
+    if spec.key.trim().is_empty() {
+        bail!("--key cannot be empty");
+    }
+    // A key containing `=` is nearly always a paste error — someone typed
+    // `--key FOO=bar` meaning `--key FOO --value bar`. Accepting it would create a
+    // variable literally named `FOO=bar`, which the deployed app can never read.
+    if spec.key.contains('=') {
+        bail!(
+            "--key '{}' looks like a KEY=VALUE pair — pass the name and the value separately: \
+             --key {} --value {}",
+            spec.key,
+            spec.key
+                .split_once('=')
+                .map(|pair| pair.0)
+                .unwrap_or(spec.key),
+            spec.key
+                .split_once('=')
+                .map(|pair| pair.1)
+                .unwrap_or("<value>")
+        );
+    }
+    if spec.key.chars().any(char::is_whitespace) {
+        bail!(
+            "--key '{}' contains whitespace — an environment variable name cannot",
+            spec.key
+        );
+    }
+
+    let service = resolve_scope(spec.scope, spec.service)?;
+
+    match spec.kind {
+        "static" => {
+            if spec.value.is_none() {
+                bail!(
+                    "--value is required with --kind static — a static variable IS its literal \
+                     value, the same one for every instance. If you want each instance to get \
+                     its own, use --kind generated; if you want to fill it in per instance, use \
+                     --kind custom."
+                );
+            }
+            if spec.generator.is_some() {
+                bail!(
+                    "--generator is meaningless with --kind static — a static variable holds a \
+                     literal, not a recipe. Use --kind generated to have each instance derive \
+                     its own value."
+                );
+            }
+            if spec.required {
+                bail!(
+                    "--required only applies to --kind custom — a static variable always has a \
+                     value, so it can never be missing at launch."
+                );
+            }
+        }
+        "generated" => {
+            if spec.generator.is_none() {
+                bail!(
+                    "--generator is required with --kind generated — it names the recipe each \
+                     instance derives its value from. One of: {}",
+                    GENERATOR_TYPES.join(", ")
+                );
+            }
+            if spec.value.is_some() {
+                bail!(
+                    "--value is meaningless with --kind generated — the point of a generated \
+                     variable is that the template stores NO value; each instance derives its \
+                     own, seeded on its instance id. Use --kind static to set one literal for \
+                     every instance instead."
+                );
+            }
+            if spec.required {
+                bail!(
+                    "--required only applies to --kind custom — a generated variable is always \
+                     derivable, so it can never be missing at launch."
+                );
+            }
+        }
+        "custom" => {
+            if spec.value.is_some() {
+                bail!(
+                    "--value is meaningless with --kind custom — the template only declares that \
+                     the variable exists. Set the value per instance with: forklaunch managed \
+                     instance vars set --id <instance-id> --key {} --value <value>",
+                    spec.key
+                );
+            }
+            if spec.generator.is_some() {
+                bail!(
+                    "--generator is meaningless with --kind custom — a custom value is typed in \
+                     per instance, not derived. Use --kind generated to derive one instead."
+                );
+            }
+        }
+        other => bail!(
+            "unknown --kind '{}' — expected one of: {}",
+            other,
+            VARIABLE_KINDS.join(", ")
+        ),
+    }
+
+    let mut body = Map::new();
+    body.insert("key".to_string(), json!(spec.key));
+    body.insert("scope".to_string(), json!(spec.scope));
+    body.insert("kind".to_string(), json!(spec.kind));
+    if let Some(service) = service {
+        body.insert("serviceName".to_string(), json!(service));
+    }
+    if let Some(value) = spec.value {
+        body.insert("value".to_string(), json!(value));
+    }
+    if let Some(generator) = spec.generator {
+        body.insert("generatorType".to_string(), json!(generator));
+    }
+    // Sent explicitly rather than only when true. This is an upsert, so re-running
+    // `set` on an existing required variable without `--required` has to be able to
+    // clear the flag — omitting the field would leave the old value in place and make
+    // the flag one-way.
+    if spec.kind == "custom" {
+        body.insert("required".to_string(), json!(spec.required));
+    }
+    if let Some(description) = spec.description {
+        body.insert("description".to_string(), json!(description));
+    }
+
+    Ok(Value::Object(body))
+}
+
+#[derive(Debug)]
+pub(super) struct SetCommand;
+
+impl SetCommand {
+    pub(super) fn new() -> Self {
+        Self
+    }
+}
+
+impl CliCommand for SetCommand {
+    fn command(&self) -> Command {
+        command(
+            "set",
+            "Declare (or redeclare) a variable every instance of a template receives",
+        )
+        .long_about(
+            "Declare (or redeclare) a variable every instance of a template receives.\n\n\
+             This is an upsert: running it again for the same key, scope and service replaces\n\
+             the declaration rather than adding a second one.\n\n\
+             THE KIND DECIDES WHICH OTHER FLAGS APPLY:\n\n\
+             \x20 --kind static     requires --value. Every instance gets that same literal.\n\
+             \x20 --kind generated  requires --generator. Each instance derives its own value\n\
+             \x20                   from that recipe, seeded on its instance id so a\n\
+             \x20                   provisioning retry produces the SAME value rather than a\n\
+             \x20                   new one that no longer matches what was already deployed.\n\
+             \x20                   The template stores no secret.\n\
+             \x20 --kind custom     takes neither. The template just declares that the\n\
+             \x20                   variable exists; you set each instance's value with\n\
+             \x20                   `managed instance vars set`. Add --required to make an\n\
+             \x20                   instance refuse to provision until it has one.\n\n\
+             Passing a flag that does not apply to the chosen kind is an error, not a\n\
+             warning — `--value` with `--kind generated` almost always means the wrong kind\n\
+             was chosen, and silently dropping the value would publish a template that hands\n\
+             every customer a secret nobody meant to share.\n\n\
+             Examples:\n\
+             \x20 vars set --slug clinic --key LOG_LEVEL --kind static --value info\n\
+             \x20 vars set --slug clinic --key SESSION_SECRET --kind generated --generator 32-bytes-base64\n\
+             \x20 vars set --slug clinic --key STRIPE_KEY --kind custom --required --scope service --service billing",
+        )
+        .arg(
+            Arg::new("slug")
+                .long("slug")
+                .required(true)
+                .help("Slug of the template to declare the variable on"),
+        )
+        .arg(
+            Arg::new("key")
+                .long("key")
+                .required(true)
+                .help("Environment variable name the deployed app will read"),
+        )
+        .arg(
+            Arg::new("kind")
+                .long("kind")
+                .required(true)
+                .value_parser(VARIABLE_KINDS.to_vec())
+                .help("Where the value comes from: static | generated | custom"),
+        )
+        .arg(
+            Arg::new("value")
+                .long("value")
+                .help("The literal value — `--kind static` only"),
+        )
+        .arg(
+            Arg::new("generator")
+                .long("generator")
+                .value_parser(GENERATOR_TYPES.to_vec())
+                .help("Recipe each instance derives its value from — `--kind generated` only"),
+        )
+        .arg(
+            Arg::new("required")
+                .long("required")
+                .help("Refuse to provision an instance until it has a value — `--kind custom` only")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("scope")
+                .long("scope")
+                .value_parser(VARIABLE_SCOPES.to_vec())
+                .default_value("application")
+                .help("How far the variable reaches: application (every service) or service (one)"),
+        )
+        .arg(
+            Arg::new("service")
+                .long("service")
+                .help("Which service the variable reaches — required with `--scope service`"),
+        )
+        .arg(
+            Arg::new("description")
+                .long("description")
+                .help("Shown to whoever fills in a custom value"),
+        )
+        .arg(
+            Arg::new("dryrun")
+                .long("dryrun")
+                .help("Print the request that would be sent without sending it")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("json")
+                .long("json")
+                .help("Output raw JSON instead of formatted terminal output")
+                .action(ArgAction::SetTrue),
+        )
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        let mut stdout = StandardStream::stdout(ColorChoice::Always);
+
+        let slug = matches
+            .get_one::<String>("slug")
+            .context("--slug is required")?;
+        let key = matches
+            .get_one::<String>("key")
+            .context("--key is required")?;
+        let kind = matches
+            .get_one::<String>("kind")
+            .context("--kind is required")?;
+        let scope = matches
+            .get_one::<String>("scope")
+            .map(String::as_str)
+            .unwrap_or("application");
+
+        let body = build_variable_body(&VariableSpec {
+            key,
+            kind,
+            scope,
+            service: matches.get_one::<String>("service").map(String::as_str),
+            value: matches.get_one::<String>("value").map(String::as_str),
+            generator: matches.get_one::<String>("generator").map(String::as_str),
+            required: matches.get_flag("required"),
+            description: matches.get_one::<String>("description").map(String::as_str),
+        })?;
+
+        // Slugs are organization-authored identifiers, but they still land in a URL
+        // path — encode so a slug containing a separator cannot restructure the request.
+        let path = format!("/templates/{}/variables", urlencoding::encode(slug));
+
+        if matches.get_flag("dryrun") {
+            return print_dryrun("PUT", &path, Some(&body));
+        }
+
+        let auth_mode = resolve_managed_auth()?;
+        require_managed_mode(&auth_mode)?;
+
+        let response = put_json_optional(
+            &path,
+            body,
+            Missing::Resource(format!("template '{}'", slug)),
+        )?;
+
+        if matches.get_flag("json") {
+            // An upsert that answered 204 has nothing to print; say so in JSON rather
+            // than printing nothing at all and leaving a script unable to tell success
+            // from a swallowed error.
+            let payload = response.unwrap_or_else(|| json!({ "status": "ok" }));
+            println!("{}", serde_json::to_string_pretty(&payload)?);
+            return Ok(());
+        }
+
+        let where_it_reaches = match matches.get_one::<String>("service") {
+            Some(service) => format!("service '{}'", service),
+            None => "every service".to_string(),
+        };
+        log_ok!(
+            stdout,
+            "Declared {} variable '{}' on template '{}' — reaches {}",
+            kind,
+            key,
+            slug,
+            where_it_reaches
+        );
+
+        match kind.as_str() {
+            "custom" if matches.get_flag("required") => log_info!(
+                stdout,
+                "Instances now REFUSE to provision until this has a value: forklaunch managed instance vars set --id <instance-id> --key {} --value <value>",
+                key
+            ),
+            "custom" => log_info!(
+                stdout,
+                "Set each instance's value with: forklaunch managed instance vars set --id <instance-id> --key {} --value <value>",
+                key
+            ),
+            "generated" => log_info!(
+                stdout,
+                "Each instance derives its own value; the template stores no secret. Existing instances pick it up on their next provision."
+            ),
+            _ => log_info!(
+                stdout,
+                "Existing instances pick this up on their next provision."
+            ),
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn spec<'a>(kind: &'a str) -> VariableSpec<'a> {
+        VariableSpec {
+            key: "SESSION_SECRET",
+            kind,
+            scope: "application",
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn static_requires_a_value() {
+        let error = build_variable_body(&spec("static"))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("--value is required"), "{}", error);
+    }
+
+    #[test]
+    fn static_refuses_a_generator() {
+        let error = build_variable_body(&VariableSpec {
+            value: Some("info"),
+            generator: Some("hex-key"),
+            ..spec("static")
+        })
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("--generator is meaningless"), "{}", error);
+    }
+
+    #[test]
+    fn generated_refuses_a_value() {
+        // The important one. Silently dropping the value would publish a template that
+        // looks like it pins a secret and does not; accepting it would store one.
+        let error = build_variable_body(&VariableSpec {
+            value: Some("hunter2"),
+            generator: Some("32-bytes-base64"),
+            ..spec("generated")
+        })
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("--value is meaningless"), "{}", error);
+        assert!(error.contains("--kind static"), "{}", error);
+    }
+
+    #[test]
+    fn generated_requires_a_generator() {
+        let error = build_variable_body(&spec("generated"))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("--generator is required"), "{}", error);
+        // The message has to list the recipes; there is nowhere else to discover them.
+        assert!(error.contains("32-bytes-base64"), "{}", error);
+        assert!(error.contains("private-pem"), "{}", error);
+    }
+
+    #[test]
+    fn custom_refuses_both_a_value_and_a_generator() {
+        let value_error = build_variable_body(&VariableSpec {
+            value: Some("sk_live_x"),
+            ..spec("custom")
+        })
+        .unwrap_err()
+        .to_string();
+        assert!(value_error.contains("instance vars set"), "{}", value_error);
+
+        let generator_error = build_variable_body(&VariableSpec {
+            generator: Some("hex-key"),
+            ..spec("custom")
+        })
+        .unwrap_err()
+        .to_string();
+        assert!(
+            generator_error.contains("--generator is meaningless"),
+            "{}",
+            generator_error
+        );
+    }
+
+    #[test]
+    fn required_only_applies_to_custom() {
+        for (kind, extra) in [("static", Some("info")), ("generated", None)] {
+            let error = build_variable_body(&VariableSpec {
+                required: true,
+                value: extra,
+                generator: if kind == "generated" {
+                    Some("hex-key")
+                } else {
+                    None
+                },
+                ..spec(kind)
+            })
+            .unwrap_err()
+            .to_string();
+            assert!(
+                error.contains("--required only applies to --kind custom"),
+                "{}: {}",
+                kind,
+                error
+            );
+        }
+    }
+
+    #[test]
+    fn service_scope_needs_a_service_name() {
+        let error = build_variable_body(&VariableSpec {
+            scope: "service",
+            ..spec("custom")
+        })
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("--service is required"), "{}", error);
+    }
+
+    #[test]
+    fn a_key_that_is_really_a_pair_is_refused() {
+        let error = build_variable_body(&VariableSpec {
+            key: "LOG_LEVEL=info",
+            value: Some("info"),
+            ..spec("static")
+        })
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("KEY=VALUE"), "{}", error);
+        assert!(error.contains("--key LOG_LEVEL --value info"), "{}", error);
+    }
+
+    #[test]
+    fn a_valid_static_declaration_builds_the_expected_body() {
+        let body = build_variable_body(&VariableSpec {
+            key: "LOG_LEVEL",
+            value: Some("info"),
+            description: Some("verbosity"),
+            ..spec("static")
+        })
+        .unwrap();
+        assert_eq!(body["key"], json!("LOG_LEVEL"));
+        assert_eq!(body["kind"], json!("static"));
+        assert_eq!(body["scope"], json!("application"));
+        assert_eq!(body["value"], json!("info"));
+        assert_eq!(body["description"], json!("verbosity"));
+        assert!(body.get("serviceName").is_none());
+        assert!(body.get("generatorType").is_none());
+        // `required` is a custom-only concept; sending it for a static variable would
+        // ask the control plane to store a flag that can never be true.
+        assert!(body.get("required").is_none());
+    }
+
+    #[test]
+    fn a_valid_generated_declaration_carries_the_recipe_and_no_value() {
+        let body = build_variable_body(&VariableSpec {
+            generator: Some("32-bytes-base64"),
+            ..spec("generated")
+        })
+        .unwrap();
+        assert_eq!(body["generatorType"], json!("32-bytes-base64"));
+        assert!(
+            body.get("value").is_none(),
+            "a generated declaration must never carry a value: {}",
+            body
+        );
+    }
+
+    #[test]
+    fn a_custom_declaration_always_states_required_either_way() {
+        // `set` is an upsert, so an omitted `required` would make the flag one-way:
+        // once set, nothing could ever clear it.
+        let required = build_variable_body(&VariableSpec {
+            required: true,
+            scope: "service",
+            service: Some("billing"),
+            ..spec("custom")
+        })
+        .unwrap();
+        assert_eq!(required["required"], json!(true));
+        assert_eq!(required["serviceName"], json!("billing"));
+        assert_eq!(required["scope"], json!("service"));
+
+        let optional = build_variable_body(&spec("custom")).unwrap();
+        assert_eq!(optional["required"], json!(false));
+    }
+
+    #[test]
+    fn the_generator_list_matches_the_platforms_key_material_vocabulary() {
+        // These are platform-management's `generateKeyMaterial` names, not names this
+        // CLI chose. If they drift, every generated variable resolves to nothing.
+        assert_eq!(
+            GENERATOR_TYPES,
+            &[
+                "32-bytes-base64",
+                "64-bytes-base64",
+                "hex-key",
+                "key-material",
+                "private-pem",
+                "public-pem",
+            ]
+        );
+    }
+}

--- a/cli/src/managed/template/vars/set.rs
+++ b/cli/src/managed/template/vars/set.rs
@@ -202,6 +202,9 @@ impl CliCommand for SetCommand {
              warning — `--value` with `--kind generated` almost always means the wrong kind\n\
              was chosen, and silently dropping the value would publish a template that hands\n\
              every customer a secret nobody meant to share.\n\n\
+             A `static` value cannot be read back afterwards — `vars list` reports that one is\n\
+             set, not what it is. Setting it again is how you change it, and is the only way\n\
+             to correct a typo in one.\n\n\
              Examples:\n\
              \x20 vars set --slug clinic --key LOG_LEVEL --kind static --value info\n\
              \x20 vars set --slug clinic --key SESSION_SECRET --kind generated --generator 32-bytes-base64\n\

--- a/cli/src/managed/template/vars/unset.rs
+++ b/cli/src/managed/template/vars/unset.rs
@@ -1,0 +1,131 @@
+use std::io::Write;
+
+use anyhow::{Context, Result};
+use clap::{Arg, ArgAction, ArgMatches, Command};
+use termcolor::{ColorChoice, StandardStream, WriteColor};
+
+use crate::{
+    CliCommand,
+    core::command::command,
+    managed::{
+        client::{Missing, delete_text, print_dryrun, require_managed_mode, resolve_managed_auth},
+        template::vars::resolve_scope,
+        types::VARIABLE_SCOPES,
+    },
+};
+
+#[derive(Debug)]
+pub(super) struct UnsetCommand;
+
+impl UnsetCommand {
+    pub(super) fn new() -> Self {
+        Self
+    }
+}
+
+impl CliCommand for UnsetCommand {
+    fn command(&self) -> Command {
+        command("unset", "Remove a variable declaration from a template")
+            .long_about(
+                "Remove a variable declaration from a template.\n\n\
+                 New instances stop receiving the variable. Instances already deployed keep\n\
+                 whatever they were given until their next provision.\n\n\
+                 --scope and --service identify WHICH declaration to remove, not just which\n\
+                 key: the same key can be declared once application-wide and again for a\n\
+                 single service, and those are different declarations. Both default to the\n\
+                 application-scoped one.\n\n\
+                 To clear one instance's value while leaving the declaration in place, use\n\
+                 `forklaunch managed instance vars unset` instead.",
+            )
+            .arg(
+                Arg::new("slug")
+                    .long("slug")
+                    .required(true)
+                    .help("Slug of the template to remove the declaration from"),
+            )
+            .arg(
+                Arg::new("key")
+                    .long("key")
+                    .required(true)
+                    .help("Name of the variable to remove"),
+            )
+            .arg(
+                Arg::new("scope")
+                    .long("scope")
+                    .value_parser(VARIABLE_SCOPES.to_vec())
+                    .default_value("application")
+                    .help("Which scope's declaration to remove"),
+            )
+            .arg(
+                Arg::new("service").long("service").help(
+                    "Which service's declaration to remove — required with `--scope service`",
+                ),
+            )
+            .arg(
+                Arg::new("dryrun")
+                    .long("dryrun")
+                    .help("Print the request that would be sent without sending it")
+                    .action(ArgAction::SetTrue),
+            )
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        let mut stdout = StandardStream::stdout(ColorChoice::Always);
+
+        let slug = matches
+            .get_one::<String>("slug")
+            .context("--slug is required")?;
+        let key = matches
+            .get_one::<String>("key")
+            .context("--key is required")?;
+        let scope = matches
+            .get_one::<String>("scope")
+            .map(String::as_str)
+            .unwrap_or("application");
+        let service = resolve_scope(
+            scope,
+            matches.get_one::<String>("service").map(String::as_str),
+        )?;
+
+        // Both the key and the scope go into the request — the key in the path, the
+        // scope in the query — because a key alone does not identify a declaration.
+        let mut path = format!(
+            "/templates/{}/variables/{}?scope={}",
+            urlencoding::encode(slug),
+            urlencoding::encode(key),
+            urlencoding::encode(scope)
+        );
+        if let Some(service) = service {
+            path.push_str(&format!("&serviceName={}", urlencoding::encode(service)));
+        }
+
+        if matches.get_flag("dryrun") {
+            return print_dryrun("DELETE", &path, None);
+        }
+
+        let auth_mode = resolve_managed_auth()?;
+        require_managed_mode(&auth_mode)?;
+
+        delete_text(
+            &path,
+            Missing::Resource(format!(
+                "variable '{}' ({} scope) on template '{}'",
+                key, scope, slug
+            )),
+        )?;
+
+        log_ok!(
+            stdout,
+            "Removed the {}-scoped declaration of '{}' from template '{}'",
+            scope,
+            key,
+            slug
+        );
+        log_info!(
+            stdout,
+            "New instances no longer receive it. Instances already deployed keep it until their next provision."
+        );
+
+        Ok(())
+    }
+}

--- a/cli/src/managed/types.rs
+++ b/cli/src/managed/types.rs
@@ -1,0 +1,97 @@
+use serde::{Deserialize, Serialize};
+
+/// One managed instance as the control plane reports it.
+///
+/// Every field past `id` is optional on purpose. The `/managed-mode` routes are being
+/// written in parallel with this CLI, and the summary endpoint and the (not yet
+/// implemented) list endpoint return overlapping but not identical projections. A
+/// missing field should render as a blank column, not fail the whole command.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct ManagedInstance {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) template_slug: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) host: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) region: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) state: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) relay_eligible: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) current_version_semver: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) last_error: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) claimed_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) created_at: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct AppTemplate {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) slug: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) status: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) source_repo: Option<String>,
+}
+
+/// The template statuses the platform defines. A template is created as `draft`;
+/// `instance create` requires `published`, so a template stays uninstantiable until
+/// something moves it. The control plane validates this list server-side and answers
+/// 400 with the allowed values, but validating here too turns a typo into an instant
+/// local error instead of a round trip.
+pub(super) const TEMPLATE_STATUSES: &[&str] = &["draft", "published", "retired"];
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct TemplateVersion {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) semver: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) git_ref: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) status: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) published_at: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct ClaimLink {
+    pub(super) claim_url: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) expires_at: Option<String>,
+}
+
+/// The instance lifecycle states the platform defines, in rough lifecycle order.
+///
+/// Used to validate and document `--state` in `--help`. Kept as a plain list rather
+/// than an enum because the CLI only ever passes these through to the control plane
+/// and displays them back — it never branches on them.
+pub(super) const INSTANCE_STATES: &[&str] = &[
+    "provisioning",
+    "provisioning_failed",
+    "awaiting_claim",
+    "awaiting_claim_blocked",
+    "active",
+    "suspended",
+    "destroying",
+    "destroyed",
+];
+
+pub(super) fn dash(value: &Option<String>) -> &str {
+    value.as_deref().unwrap_or("-")
+}

--- a/cli/src/managed/types.rs
+++ b/cli/src/managed/types.rs
@@ -92,6 +92,150 @@ pub(super) const INSTANCE_STATES: &[&str] = &[
     "destroyed",
 ];
 
+/// Where a template variable's value comes from.
+///
+/// The three kinds exist because the answer to "where does this value come from" is
+/// genuinely different, not because someone wanted three flavors of the same thing:
+///
+/// - `static`    the same literal for every instance; the TEMPLATE holds the value
+/// - `generated` a recipe, not a value; each INSTANCE derives its own
+/// - `custom`    the maintainer types it in per instance; the INSTANCE holds the value
+pub(super) const VARIABLE_KINDS: &[&str] = &["static", "generated", "custom"];
+
+/// How far a variable reaches in the deployed app. Mirrors the platform's own
+/// environment-variable scoping: `application` reaches every service, `service` reaches
+/// exactly one named service.
+pub(super) const VARIABLE_SCOPES: &[&str] = &["application", "service"];
+
+/// The generator recipes a `generated` variable may name.
+///
+/// This is platform-management's `generateKeyMaterial` vocabulary, not a list this CLI
+/// invented — the same strings the platform's own `component_property` column is
+/// constrained to. Validating them here turns a typo into an instant local error rather
+/// than a template that provisions every instance with an empty variable.
+pub(super) const GENERATOR_TYPES: &[&str] = &[
+    "32-bytes-base64",
+    "64-bytes-base64",
+    "hex-key",
+    "key-material",
+    "private-pem",
+    "public-pem",
+];
+
+/// One variable a template declares, as the control plane reports it.
+///
+/// Every field is optional for the same reason `ManagedInstance`'s are: the
+/// `/managed-mode` variable routes are being written in parallel with this CLI, and a
+/// field this CLI has not been told about should render as a blank column rather than
+/// failing the whole command.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct TemplateVariable {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) key: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) scope: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) service_name: Option<String>,
+    /// Set for `static` only. Masked on output unless `--reveal` is passed — see
+    /// `template::vars::list`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) value: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) generator_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) required: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) description: Option<String>,
+}
+
+/// One declared variable as it applies to ONE instance.
+///
+/// This is the template's declaration plus, for `custom` variables, whether that
+/// instance has a value yet. It is deliberately not the value itself.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct InstanceVariable {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) key: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) scope: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) service_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) required: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) description: Option<String>,
+    /// Whether this instance has a value for a `custom` variable. The aliases exist
+    /// because the endpoint is still being written and the obvious names for this field
+    /// are all in play; accepting each of them beats rendering every variable as
+    /// MISSING because the server picked a different one.
+    #[serde(
+        default,
+        alias = "isSet",
+        alias = "set",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub(super) has_value: Option<bool>,
+    /// NEVER printed and NEVER re-serialized, including under `--json`.
+    ///
+    /// The field exists only so that a control plane which returns the value anyway
+    /// still yields a correct SET/MISSING answer — dropping it at parse time would make
+    /// this CLI report MISSING for a variable that is set. `skip_serializing` is what
+    /// keeps it from leaking back out of `--json`, and `set_state` is the only thing
+    /// allowed to look at it.
+    #[serde(default, skip_serializing)]
+    pub(super) value: Option<String>,
+}
+
+/// Whether an instance has a value for a `custom` variable.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum SetState {
+    Set,
+    Missing,
+    /// The control plane said nothing either way. Reported as `?` rather than guessed:
+    /// claiming MISSING would send someone hunting for a value that is already there,
+    /// and claiming SET would hide a variable that will fail the provision.
+    Unknown,
+}
+
+impl InstanceVariable {
+    /// Reads set-ness from whichever signal the control plane provided, preferring the
+    /// explicit boolean over inferring it from a value that should not have been sent.
+    pub(super) fn set_state(&self) -> SetState {
+        let known = self
+            .has_value
+            .or_else(|| self.value.as_ref().map(|value| !value.is_empty()));
+        match known {
+            Some(true) => SetState::Set,
+            Some(false) => SetState::Missing,
+            None => SetState::Unknown,
+        }
+    }
+
+    /// True when this variable will block `instance create`: a required `custom`
+    /// variable with no value.
+    pub(super) fn blocks_provisioning(&self) -> bool {
+        self.kind.as_deref() == Some("custom")
+            && self.required == Some(true)
+            && self.set_state() == SetState::Missing
+    }
+}
+
 pub(super) fn dash(value: &Option<String>) -> &str {
     value.as_deref().unwrap_or("-")
+}
+
+/// Renders an optional boolean for a table cell, where "the server did not say" and
+/// "the server said false" are different facts.
+pub(super) fn yes_no(value: &Option<bool>) -> &'static str {
+    match value {
+        Some(true) => "yes",
+        Some(false) => "no",
+        None => "-",
+    }
 }

--- a/cli/src/managed/types.rs
+++ b/cli/src/managed/types.rs
@@ -124,10 +124,10 @@ pub(super) const GENERATOR_TYPES: &[&str] = &[
 
 /// One variable a template declares, as the control plane reports it.
 ///
-/// Every field is optional for the same reason `ManagedInstance`'s are: the
-/// `/managed-mode` variable routes are being written in parallel with this CLI, and a
-/// field this CLI has not been told about should render as a blank column rather than
-/// failing the whole command.
+/// Mirrors the control plane's `TemplateVariableSchema`, where `key`, `scope`, `kind`
+/// and `required` are non-optional and the rest are not. Everything is `Option` here
+/// anyway, for the same reason `ManagedInstance`'s fields are: a field a future server
+/// stops sending should render as a blank column rather than failing the whole command.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(super) struct TemplateVariable {
@@ -139,10 +139,12 @@ pub(super) struct TemplateVariable {
     pub(super) scope: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(super) service_name: Option<String>,
-    /// Set for `static` only. Masked on output unless `--reveal` is passed — see
-    /// `template::vars::list`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub(super) value: Option<String>,
+    // There is deliberately NO `value` field. The control plane's
+    // `TemplateVariableSchema` omits it on both the managed-apps handler and the
+    // `/managed-mode` proxy: a `static` value can be a credential shared by every
+    // instance, and a list endpoint is the wrong place to hand one back. Adding the
+    // field here would only ever deserialize to `None` and invite a column that is
+    // always blank.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(super) generator_type: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -170,10 +172,10 @@ pub(super) struct InstanceVariable {
     pub(super) required: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(super) description: Option<String>,
-    /// Whether this instance has a value for a `custom` variable. The aliases exist
-    /// because the endpoint is still being written and the obvious names for this field
-    /// are all in play; accepting each of them beats rendering every variable as
-    /// MISSING because the server picked a different one.
+    /// Whether this instance has a value for a `custom` variable. The control plane's
+    /// `InstanceVariableStatusSchema` calls it `isSet`; the other two aliases are kept
+    /// because they were the plausible alternatives while this was being written, and
+    /// reading only one name would render every variable MISSING if it ever changed.
     #[serde(
         default,
         alias = "isSet",
@@ -232,10 +234,54 @@ pub(super) fn dash(value: &Option<String>) -> &str {
 
 /// Renders an optional boolean for a table cell, where "the server did not say" and
 /// "the server said false" are different facts.
-pub(super) fn yes_no(value: &Option<bool>) -> &'static str {
+fn yes_no(value: &Option<bool>) -> &'static str {
     match value {
         Some(true) => "yes",
         Some(false) => "no",
         None => "-",
+    }
+}
+
+/// Renders the REQUIRED column.
+///
+/// `required` only means anything for `custom` — the CLI refuses `--required` on the
+/// other two kinds, because a static variable always has a value and a generated one is
+/// always derivable, so neither can be missing at launch. The control plane nonetheless
+/// sends `required: false` on every row, since its schema declares the field
+/// non-optional. Printing "no" against a static variable would imply the flag means
+/// something there, so those rows get a dash instead.
+pub(super) fn required_cell(kind: &Option<String>, required: &Option<bool>) -> &'static str {
+    match kind.as_deref() {
+        Some("custom") => yes_no(required),
+        _ => "-",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn required_reads_as_a_dash_for_the_kinds_it_cannot_apply_to() {
+        // The control plane sends `required: false` on every row because its schema
+        // declares the field non-optional; only `custom` rows should render it.
+        for kind in ["static", "generated"] {
+            assert_eq!(
+                required_cell(&Some(kind.to_string()), &Some(false)),
+                "-",
+                "{}",
+                kind
+            );
+        }
+        assert_eq!(
+            required_cell(&Some("custom".to_string()), &Some(true)),
+            "yes"
+        );
+        assert_eq!(
+            required_cell(&Some("custom".to_string()), &Some(false)),
+            "no"
+        );
+        // A kind the CLI has not been told about should not claim to know either.
+        assert_eq!(required_cell(&None, &Some(true)), "-");
     }
 }


### PR DESCRIPTION
## What this adds

A `forklaunch managed` command group. There was no CLI surface for managed apps before this.

**In plain terms:** an organization can publish an app *template* (a git repo plus versions), then launch managed *instances* of it — one running copy per end customer, each with its own deployment and a one-time link the customer uses to claim ownership. A template also declares the *variables* every instance of it gets, and each instance can carry its own values for the per-customer ones. This PR gives all of that a command line.

```
managed summary
managed template list             [--include-unpublished] [--json]
managed template create           --slug --name --repo [--description] [--dryrun] [--json]
managed template update           --slug [--name] [--description] [--status] [--stripe-product] [--dryrun] [--json]
managed template publish          --slug --semver --git-ref [--dryrun] [--json]
managed template publish-template --slug [--dryrun] [--json]
managed template vars list        --slug [--json]
managed template vars set         --slug --key --kind {static|generated|custom}
                                  [--value] [--generator] [--required]
                                  [--scope application|service] [--service] [--description]
                                  [--dryrun] [--json]
managed template vars unset       --slug --key [--scope] [--service] [--dryrun]
managed instance list             [--template] [--state] [--json]
managed instance create           --template --region [--dryrun] [--json]
managed instance claim-link       --id [--dryrun] [--json]
managed instance claim            --id --token ... (customer-side, no account needed)
managed instance destroy          --id [--confirm] [--dryrun]
managed instance vars list        --id [--json]
managed instance vars set         --id --key --value [--dryrun]
managed instance vars unset       --id --key [--dryrun]
```

Everything goes through platform-management's `/managed-mode` router, never the managed-apps service directly, per that service's own design rule. Host resolution reuses `get_platform_management_api_url()`; auth reuses the existing token/`resolve_auth` path. No secrets or URLs are hardcoded.

---

## Design decisions worth reviewing

### Two things called "publishing"

`template publish` adds a **version** (semver + git ref). `template publish-template` publishes the **template itself**. Both are required: templates are created as `draft` and `instance create` refuses a draft, so a template with versions but no published status is still unlaunchable. `template update` is the general form (name/description/status/stripeProductId); `publish-template` is the shorthand for the one case that is mandatory. The help text for both commands, and for the `template` and `managed` groups, spells the distinction out.

### Two things called "claiming"

`instance claim-link` **reveals** the one-time link — operator-side, authenticated, purged on reveal. `instance claim` **consumes** it — customer-side and **public**, matching the control plane's `access: 'public'` declaration, because the person claiming has no ForkLaunch account and the one-time token is the credential. `claim` deliberately skips both `resolve_managed_auth` and the `/managed-mode/summary` preflight: the summary route is authenticated, so preflighting would demand a login this command is designed not to need.

### Three kinds of variable, because the value genuinely comes from three places

| kind | where the value lives | why |
|---|---|---|
| `static` | the **template** | one literal every instance shares (`LOG_LEVEL=info`) |
| `generated` | **nowhere** — it's a recipe | each instance derives its own, seeded on the instance id so a provisioning **retry re-derives the same value** instead of a new one that no longer matches what was already deployed |
| `custom` | the **instance** | one customer's own Stripe key |

The `template vars --help` says outright that a `static` secret is one secret shared across every customer's instance, sitting in the template at rest, and points at `generated` instead. That is the choice this command group exists to get right.

A `custom` variable can be `--required`, which means an instance **cannot be provisioned** until it has a value. `instance vars list` surfaces that as a WARN naming the blocking keys. That is a launch-time failure by design — better than deploying an app that boots and then misbehaves because an environment variable was missing.

### Wrong flag combinations are refused client-side

Not because the server wouldn't reject them, but because the CLI's error can name the flag the operator should have used and a schema error cannot:

| combination | refused with |
|---|---|
| `--value` + `--kind generated` | "the point of a generated variable is that the template stores NO value… use `--kind static` to set one literal for every instance" |
| `--value` + `--kind custom` | "the template only declares the variable exists" + the exact `instance vars set` command |
| `--generator` + `--kind static`/`custom` | "a static variable holds a literal, not a recipe" |
| `--required` + `--kind static`/`generated` | "always has a value / is always derivable, so it can never be missing at launch" |
| `--kind static` with no `--value` | required |
| `--kind generated` with no `--generator` | required, and the message **lists the six recipes** — there is nowhere else to discover them |
| `--scope service` with no `--service` | required |
| `--service X` with `--scope application` | refused **bidirectionally** — the server would store it with the service name silently dropped, so a variable meant for one service would reach all of them |
| `--key FOO=bar` | caught as a paste error, on both the template and instance side |

`--kind generated --value <secret>` is an **error, not a warning with the value dropped**. It almost always means the wrong kind was chosen, and quietly proceeding either publishes a template that looks like it pins a secret and does not, or stores one that should not exist.

`--kind` and `--generator` are also clap `value_parser` lists, so bad values are rejected with the allowed set before any network or auth.

### Values are not readable back — at either level

- **`instance vars list` never prints a value.** It reports `SET` / `MISSING` for a `custom` variable, and for `static`/`generated` it says where the value comes from. This holds **under `--json` too**: `InstanceVariable::value` is `#[serde(skip_serializing)]`. The field is parsed at all only so that a control plane which returns values anyway still yields a correct SET/MISSING answer — dropping it at parse time would report MISSING for a variable that is set. **Verified against a mock that deliberately returns the value.**
- **`template vars list` cannot show static values either, and says so.** The control plane omits `value` from `TemplateVariableSchema` on both the managed-apps handler and the `/managed-mode` proxy — a static value can be a credential every instance shares, so listing is not the place to hand one back. The SOURCE column reads `set on template`, and both the table footer and `--help` state that setting the variable again is the way to change one. `TemplateVariable` has **no `value` field at all**, so the guarantee is enforced by the type rather than by a redaction pass.
- **`instance vars set --dryrun` redacts the value it would have sent**, the way `instance claim --dryrun` redacts its token.
- If the control plane says nothing about set-ness, the column reads `?` rather than guessing. Guessing MISSING sends someone hunting for a value that is already there; guessing SET hides a variable that is about to fail the provision.
- **REQUIRED renders `-` for `static` and `generated` rows.** The schema declares `required` non-optional so the server sends `required: false` on every row; printing "no" would imply the flag means something on a kind where the CLI refuses it outright.

### Preflight on `/managed-mode/summary`

Every authenticated subcommand fetches the summary before its real request. It costs one round trip and buys the difference between "you have no templates" and "managed apps was never wired up on this deployment" — the documented `{ available: false, unavailableReason }` case prints that reason plainly rather than showing an empty list.

### 404 disambiguation

A 404 is read against the response body. A framework-generated `Cannot GET /managed-mode/...` means the route is not mounted and reports *"this control plane does not support managed apps yet — upgrade the platform"*. A handler-authored 404 (`No published template 'clinic'`) is surfaced as a genuine not-found. Without this, "you asked for something that isn't there" and "your platform is too old" collapse into the same confusing message. **Both flavors are exercised on all six new variable routes.**

### Other

- **`instance list` degrades instead of failing.** The dedicated list endpoint does not exist yet, but `/managed-mode/summary` already returns the same instance projection. When the list route 404s, rows come from the summary and `--template`/`--state` are applied locally, with a note saying so.
- **`destroy` is non-interactive-safe.** Requires retyping the instance id; when stdin is not a terminal it *refuses* rather than prompting, so a forgotten `--confirm` fails fast instead of hanging CI. Every flag on every command is supplyable non-interactively.
- **Session auth only.** Templates and instances are organization-scoped and HMAC/CI credentials carry no organization identity, so HMAC mode is refused with an explanation rather than silently acting on the wrong org.
- **Flags that the server drops were removed, not warned about.** Verified against the platform schemas: `--base-domain` (in neither the create nor update schema), `--image-uri` (the version schema is `{semver, gitRef}`). `--stripe-product` moved to `template update`, where the schema does accept it. A flag that always warns teaches people to ignore warnings.
- **The six generator names are platform-management's `generateKeyMaterial` vocabulary**, not names this CLI chose — the same strings its `component_property` column is constrained to. A test pins them: if they drift, every generated variable resolves to nothing.
- **`--scope`/`--service` go in the DELETE query**, not just the key in the path, because the same key can be declared once application-wide and again for one service, and those are different declarations.
- **`template vars set` always sends `required` explicitly for `custom`.** It is an upsert, so omitting the field would make the flag one-way — once set, nothing could clear it.

## Shared-file edits (kept minimal for clean rebase)

Another branch owns `cli/src/change/**` and `cli/src/core/env.rs`. **This PR touches neither.** The only shared-file edits are additive:

- `cli/src/main.rs` — **+5 lines, 0 deletions** (import, `mod`, constructor, `.subcommand()`, match arm)
- `cli/src/core/http_client.rs` — **+20 lines, 0 deletions** (`post_unauthenticated`, for the public `claim` route; every other helper funnels through `make_authenticated_request`, which drops the user into an interactive login on token failure — wrong for a route a non-account-holder calls). The variable commands needed no change here: `put` already existed.

Deliberately does **not** re-add `patch_with_auth`/`delete_with_auth`. 817afe8d6 removed that dead HMAC dispatch, and since `resolve_managed_auth` refuses HMAC up front the HMAC arms would be unreachable again.

## What I verified

- `cargo build` clean. `cargo clippy --all-targets`: **0 errors, and 0 findings in `src/managed/`** (the repo's pre-existing warnings elsewhere are untouched). `rustfmt --check` clean on every file this PR touches.
- `cargo test`: **505 passed, 0 failed** — including **45 in `src/managed/`, 28 of them new**. CI runs `cargo test`, and the `test` job is green.
- **`--help` renders (exit 0) for all 11 pages**: `managed`, both subgroups, both `vars` subgroups, and every leaf. `--kind`, `--generator`, `--scope` and `--state` self-document their possible values.
- **Every `--dryrun` path** prints the exact request without network or auth — including `instance vars set --dryrun` redacting its value.
- **All 15 client-side validation combinations** listed above, each exercised end-to-end and each exiting non-zero (1 for CLI validation, 2 for clap).
- Against a mock **rebuilt to match the landed server schemas** (platform `ea2f28f5`) — bare-array list responses, no `value` key on template variables, `isSet` on instance variables, and `200` upserts with a plain non-JSON string body:
  - all six variable endpoints on their happy paths, with the wire requests captured and checked (`PUT /managed-mode/templates/clinic/variables` bodies, `DELETE …/variables/STRIPE_KEY?scope=service&serviceName=billing`, etc.)
  - `instance vars list` and `--json` against a response that **deliberately included a real value** — `grep` for the secret returns 0 hits in both
  - `template vars list` and `--json` showing `set on template` with the "not readable back" note
  - the `200`-plain-string upsert response handled without a parse error, including under `--json`
  - framework 404 (`Cannot GET /…`) → "upgrade the platform", on all six routes
  - handler-authored 404 → genuine not-found, with the per-command message
  - earlier commits' paths: summary 404, `available:false`, `template list`, `instance create`, `instance list` summary fallback, `claim-link` one-time banner, `destroy` 202 and 409
- Unreachable host → connection-refused error, no hang. Missing auth (empty `HOME`, non-TTY) → `No token found`, no hang, exit 1. `destroy` without `--confirm` on non-TTY → refuses, exit 1, no hang.

### Contract check against the landed server

I wrote these commands before the endpoints existed and guessed the contract from the entities. After platform `ea2f28f5` landed I re-read both controllers and checked every guess:

| | result |
|---|---|
| route shapes (all six) | ✅ exactly as specified |
| PUT bodies (`key`, `scope`, `serviceName`, `kind`, `value`, `generatorType`, `required`, `description`) | ✅ field for field |
| DELETE query (`scope`, `serviceName`) | ✅ |
| instance set-ness field name | ✅ `isSet` — one of the three names accepted |
| list envelope | ✅ bare array, which `extract_list` handles |
| `template vars list` returning `value` | ❌ **wrong — fixed in `3990d2cb1`** (see below) |

**The one mismatch:** I had added a `--reveal` flag to print static values. The server never returns them, deliberately. `--reveal` would have printed an empty column and looked broken, so it is removed and the command now states the constraint instead. I agree with the server's call — it is the same reasoning I had applied to `instance vars list`, one level further up — so the CLI states it rather than papering over it.

---

## What I could NOT verify

**No call was made against a real running platform-management.** Everything above is against a mock, now written to match the landed controllers line for line, but still a mock. Treat the wire behavior as unproven until someone runs it against a live control plane. In particular the **auth path is untested**: these routes are `access: 'protected'` with `allowedRoles: PLATFORM_ADMIN_ROLES`, and my mock does not check the bearer token, so a non-admin's 403 has never been exercised.

**`instance vars list` accepts three names for set-ness** (`hasValue`, `isSet`, `set`). The server sends `isSet`; the other two are harmless slack. Not a risk, just noted so nobody thinks it is load-bearing.

**Earlier commits' endpoints are still partly unimplemented.** `POST /managed-mode/templates`, `POST /managed-mode/templates/:slug/versions` and `GET /managed-mode/instances` still have no control-plane route, so `template create` and `template publish` success paths remain **untested against any server, mock or real** — only their 404 and `--dryrun` paths were checked.

**Response shapes are still parsed permissively** (all fields optional, list envelopes accepted bare or wrapped). Now that the schemas exist this is slack rather than necessity, but it means a future field rename shows as a blank column rather than an error.

---

## Note on the two red `Init Tests` jobs

`Init Tests (components)` and `Init Tests (heavy modules)` fail on this PR. **They fail identically on `main`** (e.g. run `33060280033`) and are unrelated to this change — I did not touch any TypeScript.

The root cause, which I do not think has been written down before:

```
ERR_PNPM_FETCH_404  GET https://registry.npmjs.org/@forklaunch%2Finterfaces-cac: Not Found - 404
@forklaunch/interfaces-cac is not in the npm registry, or you have no permission to fetch it.
```

`forklaunch init module -m cac-base` scaffolds a module that depends on `@forklaunch/interfaces-cac`, and **that package was never published to npm**. The install fails, so `init_module.sh` fails, so both jobs go red. It is a publishing gap, not a test or CLI bug — publishing the package (or dropping `cac-base` from the init test matrix) should clear both jobs. Worth fixing separately, since these two being permanently red is what makes every PR's `mergeStateStatus` read `BLOCKED`.

Every other check on this PR is green, including `test`, `Analyze (rust)`, `Change Tests`, `Delete Tests`, `Sync Tests` and `Other Tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
