### PR TITLE
fix(cli): make `change service --to worker` produce code that compiles

### DIFF
--- a/cli/src/change/service.rs
+++ b/cli/src/change/service.rs
@@ -869,6 +869,32 @@ export type {pascal_case_name}EventRecord = InferEntity<
         },
     );
 
+    // mikro-orm.config.ts discovers entities through
+    // `import * as entities from './persistence/entities'`, so an entity that
+    // the barrel file does not re-export is invisible to the ORM: no migration
+    // is ever generated for it and the DatabaseWorkerConsumer has no table to
+    // read. Re-export it, the way the `init worker` template does.
+    let entities_index_path = entities_dir.join("index.ts");
+    let event_entity_export = format!("export * from './{camel_case_name}EventRecord.entity';");
+    let entities_index_content = rendered_templates_cache
+        .get(&entities_index_path)?
+        .map(|template| template.content);
+    let updated_entities_index = match entities_index_content {
+        Some(content) if content.contains(&format!("{camel_case_name}EventRecord.entity")) => None,
+        Some(content) => Some(format!("{}\n{}\n", content.trim_end(), event_entity_export)),
+        None => Some(format!("{event_entity_export}\n")),
+    };
+    if let Some(content) = updated_entities_index {
+        rendered_templates_cache.insert(
+            entities_index_path.to_string_lossy().to_string(),
+            RenderedTemplate {
+                path: entities_index_path.clone(),
+                content,
+                context: None,
+            },
+        );
+    }
+
     // Generate the event record interface type file
     let types_dir = base_path.join("domain").join("types");
     let event_record_types_path =

--- a/cli/src/change/service.rs
+++ b/cli/src/change/service.rs
@@ -53,7 +53,7 @@ use crate::{
             clean_up_unused_infrastructure_services, remove_redis_from_docker_compose,
             remove_s3_from_docker_compose, update_dockerfile_contents,
         },
-        env::Env,
+        env::read_env_local_or_default,
         format::format_code,
         manifest::{
             InitializableManifestConfig, InitializableManifestConfigMetadata, ManifestData,
@@ -233,11 +233,8 @@ fn change_database(
     }
 
     let env_local_path = base_path.join(".env.local");
-    let env_local_content = rendered_templates_cache
-        .get(&env_local_path)?
-        .unwrap()
-        .content;
-    let mut env_local_content = serde_envfile::from_str::<Env>(&env_local_content)?;
+    let mut env_local_content =
+        read_env_local_or_default(rendered_templates_cache, &env_local_path)?;
 
     change_database_env_variables(
         &mut env_local_content,
@@ -339,12 +336,8 @@ fn change_infrastructure(
                     .environment = Some(environment);
 
                 let env_local_path = base_path.join(".env.local");
-                let mut env_local_content = serde_envfile::from_str::<Env>(
-                    &rendered_templates_cache
-                        .get(&env_local_path)?
-                        .unwrap()
-                        .content,
-                )?;
+                let mut env_local_content =
+                    read_env_local_or_default(rendered_templates_cache, &env_local_path)?;
 
                 env_local_content.redis_url = Some("redis://localhost:6379".to_string());
 
@@ -428,12 +421,8 @@ fn change_infrastructure(
                     .environment = Some(environment);
 
                 let env_local_path = base_path.join(".env.local");
-                let mut env_local_content = serde_envfile::from_str::<Env>(
-                    &rendered_templates_cache
-                        .get(&env_local_path)?
-                        .unwrap()
-                        .content,
-                )?;
+                let mut env_local_content =
+                    read_env_local_or_default(rendered_templates_cache, &env_local_path)?;
 
                 env_local_content.s3_url = Some("http://localhost:9000".to_string());
                 env_local_content.s3_bucket = Some(format!(
@@ -529,12 +518,8 @@ fn change_infrastructure(
                 }
 
                 let env_local_path = base_path.join(".env.local");
-                let mut env_local_content = serde_envfile::from_str::<Env>(
-                    &rendered_templates_cache
-                        .get(&env_local_path)?
-                        .unwrap()
-                        .content,
-                )?;
+                let mut env_local_content =
+                    read_env_local_or_default(rendered_templates_cache, &env_local_path)?;
 
                 env_local_content.redis_url = None;
 
@@ -626,12 +611,8 @@ fn change_infrastructure(
                 }
 
                 let env_local_path = base_path.join(".env.local");
-                let mut env_local_content = serde_envfile::from_str::<Env>(
-                    &rendered_templates_cache
-                        .get(&env_local_path)?
-                        .unwrap()
-                        .content,
-                )?;
+                let mut env_local_content =
+                    read_env_local_or_default(rendered_templates_cache, &env_local_path)?;
 
                 env_local_content.s3_bucket = None;
                 env_local_content.s3_url = None;
@@ -733,8 +714,13 @@ fn service_to_worker(
         },
     );
 
-    // Detect naming convention from existing registrations file
-    let registrations_content = std::fs::read_to_string(base_path.join("registrations.ts"))
+    // Detect naming convention from the registrations file. Read through the
+    // cache, not the filesystem: at this point the transformed registrations
+    // only exist in the cache, and on a chained change the on-disk copy may be
+    // stale (or missing) entirely.
+    let registrations_content = rendered_templates_cache
+        .get(&registrations_path)?
+        .map(|template| template.content)
         .unwrap_or_default();
     let otel_token = if registrations_content.contains("OtelCollector:") {
         "OtelCollector"
@@ -742,15 +728,78 @@ fn service_to_worker(
         "OpenTelemetryCollector"
     };
 
+    // Database workers consume the persisted entity directly; every other
+    // worker type consumes the decrypted event-record interface.
+    let is_database_worker = *worker_type == WorkerType::Database;
+    let event_record_import_path = if is_database_worker {
+        format!("./persistence/entities/{camel_case_name}EventRecord.entity")
+    } else {
+        format!("./domain/types/{camel_case_name}EventRecord.types")
+    };
+
+    // worker.ts previously imported `processEvents`/`processErrors` from
+    // `./services/{name}.service` — a path that no scaffold uses (services live
+    // under ./domain/services) holding symbols the CLI never generated, so the
+    // import could never resolve. Emit the handlers inline instead, typed
+    // against the real WorkerProcessFunction/WorkerFailureHandler contracts, so
+    // the generated worker compiles as-is and the TODO is where the business
+    // logic goes rather than a broken import.
     let worker_ts_path = base_path.join("worker.ts");
     let worker_ts_content = format!(
-        r#"import {{ ci, tokens }} from './bootstrapper';
-import {{ processEvents, processErrors }} from './services/{camel_case_name}.service';
+        r#"import type {{
+  WorkerFailureHandler,
+  WorkerProcessFailureResult,
+  WorkerProcessFunction
+}} from '@forklaunch/interfaces-worker/types';
+import {{ ci, tokens }} from './bootstrapper';
+import type {{ {pascal_case_name}EventRecord }} from '{event_record_import_path}';
 
 /**
  * Creates an instance of OpenTelemetryCollector
  */
 const openTelemetryCollector = ci.resolve(tokens.{otel_token});
+
+/**
+ * TODO: replace this with your own event handling. Return one entry per event
+ * that failed; anything you return here is passed to processErrors below.
+ */
+const processEvents: WorkerProcessFunction<{pascal_case_name}EventRecord> = async (
+  events
+) => {{
+  const failedEvents: WorkerProcessFailureResult<{pascal_case_name}EventRecord>[] = [];
+
+  for (const event of events) {{
+    try {{
+      openTelemetryCollector.info(
+        `processing message from ${{ci.resolve(tokens.QUEUE_NAME)}}: ${{event.message}}`
+      );
+      event.processed = true;
+    }} catch (error) {{
+      failedEvents.push({{
+        value: event,
+        error: error as Error
+      }});
+    }}
+  }}
+
+  return failedEvents;
+}};
+
+/**
+ * TODO: replace this with your own failure handling (dead letter queue, alert,
+ * retry budget, ...).
+ */
+const processErrors: WorkerFailureHandler<{pascal_case_name}EventRecord> = async (
+  results
+) => {{
+  results.forEach((result) => {{
+    openTelemetryCollector.error(
+      result.error,
+      'error processing message',
+      result.value
+    );
+  }});
+}};
 
 /**
  * Main worker entry point
@@ -766,7 +815,8 @@ const openTelemetryCollector = ci.resolve(tokens.{otel_token});
   openTelemetryCollector.info('🎉 {pascal_case_name} Worker is running! 🎉');
 }})();
 "#,
-        camel_case_name = camel_case_name,
+        event_record_import_path = event_record_import_path,
+        otel_token = otel_token,
         pascal_case_name = pascal_case_name
     );
     rendered_templates_cache.insert(
@@ -781,8 +831,15 @@ const openTelemetryCollector = ci.resolve(tokens.{otel_token});
     let entities_dir = base_path.join("persistence").join("entities");
     let event_entity_path = entities_dir.join(format!("{}EventRecord.entity.ts", camel_case_name));
     let is_mongo = manifest_data.database == "mongodb";
+    // `defineEntity` produces a VALUE. Without the companion `InferEntity` type
+    // alias, registrations.ts writing `WorkerProcessFunction<XEventRecord>`
+    // fails with TS2749 ("refers to a value, but is being used as a type").
+    // The alias shares the entity's name so the single import serves both the
+    // value and the type position, which is what the `init worker` template
+    // does.
     let event_entity_content = format!(
         r#"import {{ defineEntity, p }} from '@mikro-orm/core';
+import type {{ InferEntity }} from '@mikro-orm/core';
 import {{ {mongo_prefix}sqlBaseProperties }} from '@{app_name}/core';
 
 export const {pascal_case_name}EventRecord = defineEntity({{
@@ -794,6 +851,10 @@ export const {pascal_case_name}EventRecord = defineEntity({{
     retryCount: p.integer(),
   }},
 }});
+
+export type {pascal_case_name}EventRecord = InferEntity<
+  typeof {pascal_case_name}EventRecord
+>;
 "#,
         mongo_prefix = if is_mongo { "no" } else { "" },
         app_name = manifest_data.app_name,
@@ -833,12 +894,8 @@ export interface {pascal_case_name}EventRecord extends WorkerEventEntity {{
     );
 
     let env_local_path = base_path.join(".env.local");
-    let mut env_local_content = serde_envfile::from_str::<Env>(
-        &rendered_templates_cache
-            .get(&env_local_path)?
-            .unwrap()
-            .content,
-    )?;
+    let mut env_local_content =
+                    read_env_local_or_default(rendered_templates_cache, &env_local_path)?;
     env_local_content.queue_name =
         Some(format!("{}-{}-queue", manifest_data.app_name, project_name));
     rendered_templates_cache.insert(

--- a/cli/src/change/worker.rs
+++ b/cli/src/change/worker.rs
@@ -42,7 +42,7 @@ use crate::{
             add_redis_to_docker_compose, clean_up_unused_infrastructure_services,
             remove_service_from_docker_compose,
         },
-        env::Env,
+        env::read_env_local_or_default,
         format::format_code,
         manifest::{
             InitializableManifestConfig, InitializableManifestConfigMetadata, ManifestData,
@@ -182,12 +182,8 @@ fn change_type(
         .clone();
 
     let env_local_path = base_path.join(".env.local");
-    let mut env_local_content: Env = serde_envfile::from_str(
-        &rendered_templates_cache
-            .get(&env_local_path)?
-            .unwrap()
-            .content,
-    )?;
+    let mut env_local_content =
+        read_env_local_or_default(rendered_templates_cache, &env_local_path)?;
 
     env_local_content.db_name = None;
     env_local_content.db_host = None;

--- a/cli/src/core/ast/transformations/transform_service_to_worker.rs
+++ b/cli/src/core/ast/transformations/transform_service_to_worker.rs
@@ -201,23 +201,29 @@ pub(crate) fn transform_registrations_ts_service_to_worker(
         )?;
     }
 
-    // Add event record entity import (used at runtime in database worker factory)
+    // Add event record entity import. Only database workers need it: the
+    // DatabaseWorkerConsumer factory passes the entity as a runtime value, and
+    // its `InferEntity` alias supplies the type positions. The other worker
+    // types already import a type of the same name from ./domain/types, so
+    // importing the entity as well would be a duplicate identifier.
     let event_record_text = format!(
         "import {{ {}EventRecord }} from './persistence/entities/{}EventRecord.entity';",
         pascal_case_name,
         project_name.to_case(Case::Camel)
     );
-    let mut event_record_import =
-        parse_ast_program(&allocator, &event_record_text, SourceType::ts());
-    inject_into_import_statement(
-        &mut program,
-        &mut event_record_import,
-        &format!(
-            "./persistence/entities/{}EventRecord.entity",
-            project_name.to_case(Case::Camel)
-        ),
-        &registrations_text,
-    )?;
+    if is_database_worker {
+        let mut event_record_import =
+            parse_ast_program(&allocator, &event_record_text, SourceType::ts());
+        inject_into_import_statement(
+            &mut program,
+            &mut event_record_import,
+            &format!(
+                "./persistence/entities/{}EventRecord.entity",
+                project_name.to_case(Case::Camel)
+            ),
+            &registrations_text,
+        )?;
+    }
 
     // Detect naming convention from existing registrations file
     let otel_token = if registrations_text.contains("OtelCollector:") {
@@ -649,5 +655,123 @@ export const createDependencyContainer = (envFilePath: string) => ({
 
         // Verify Redis infrastructure was added
         assert!(transformed_code.contains("REDIS_URL"));
+
+        // Non-database workers take the event record from the types file. The
+        // entity export carries the same name, so importing it too was a
+        // duplicate identifier (TS2300).
+        assert!(
+            transformed_code.contains("EventRecord.types"),
+            "Expected types import for a non-database worker: {transformed_code}"
+        );
+        assert!(
+            !transformed_code.contains("persistence/entities/testServiceEventRecord.entity"),
+            "Non-database worker must not also import the entity: {transformed_code}"
+        );
+    }
+
+    // Regenerating registrations.ts must not silently drop config entries or
+    // service registrations that were added by hand — the template does not
+    // know about them, and losing them is invisible until the build breaks.
+    #[test]
+    fn test_transform_registrations_ts_service_to_worker_preserves_hand_added_registrations() {
+        let registrations_content = r#"
+import {
+  number,
+  SchemaValidator,
+  string
+} from '@test-app/core';
+import { OpenTelemetryCollector } from '@forklaunch/core/http';
+import {
+  createConfigInjector,
+  getEnvVar,
+  Lifetime
+} from '@forklaunch/core/services';
+import { EntityManager, MikroORM } from '@mikro-orm/postgresql';
+import { CustomThing } from './domain/services/custom-thing.service';
+
+const configInjector = createConfigInjector(SchemaValidator(), {
+  SERVICE_METADATA: {
+    lifetime: Lifetime.Singleton,
+    type: {
+      name: string,
+      version: string
+    },
+    value: {
+      name: 'test-service',
+      version: '0.1.0'
+    }
+  }
+});
+
+const environmentConfig = configInjector.chain({
+  HOST: {
+    lifetime: Lifetime.Singleton,
+    type: string,
+    value: getEnvVar('HOST')
+  },
+  APP_BASE_DOMAIN: {
+    lifetime: Lifetime.Singleton,
+    type: string,
+    value: getEnvVar('APP_BASE_DOMAIN') || 'localhost'
+  }
+});
+
+const runtimeDependencies = environmentConfig.chain({
+  Orm: {
+    lifetime: Lifetime.Singleton,
+    type: MikroORM,
+    factory: () => new MikroORM(mikroOrmOptionsConfig)
+  },
+  EntityMgr: {
+    lifetime: Lifetime.Scoped,
+    type: EntityManager,
+    factory: ({ Orm }) => Orm.em.fork()
+  }
+});
+
+const serviceDependencies = runtimeDependencies.chain({
+  CustomThingService: {
+    lifetime: Lifetime.Scoped,
+    type: CustomThing,
+    factory: ({ EntityMgr }) => new CustomThing(EntityMgr)
+  }
+});
+
+export const createDependencyContainer = (envFilePath: string) => ({
+  ci: serviceDependencies.validateConfigSingletons(envFilePath),
+  tokens: serviceDependencies.tokens()
+});
+"#;
+
+        let temp_dir = create_temp_project_structure(registrations_content);
+        let project_path = temp_dir.path().join("test-project");
+        let cache = RenderedTemplatesCache::new();
+
+        let transformed_code = transform_registrations_ts_service_to_worker(
+            &cache,
+            &project_path,
+            "test-app",
+            "test-service",
+            &WorkerType::Database,
+        )
+        .unwrap();
+
+        // Hand-added environment config entry survives.
+        assert!(
+            transformed_code.contains("APP_BASE_DOMAIN"),
+            "Hand-added config entry was dropped: {transformed_code}"
+        );
+        // Hand-added service registration and its import survive.
+        assert!(
+            transformed_code.contains("CustomThingService"),
+            "Hand-added service registration was dropped: {transformed_code}"
+        );
+        assert!(
+            transformed_code.contains("./domain/services/custom-thing.service"),
+            "Hand-added import was dropped: {transformed_code}"
+        );
+        // ...alongside the worker registrations that were just injected.
+        assert!(transformed_code.contains("QUEUE_NAME"));
+        assert!(transformed_code.contains("WorkerConsumer"));
     }
 }

--- a/cli/src/core/env.rs
+++ b/cli/src/core/env.rs
@@ -9,6 +9,8 @@ use anyhow::{Context, Result};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
+use crate::core::rendered_template::RenderedTemplatesCache;
+
 #[derive(Debug, Serialize)]
 pub(crate) struct Env {
     #[serde(rename = "DB_NAME", skip_serializing_if = "Option::is_none")]
@@ -215,6 +217,27 @@ impl<'de> Deserialize<'de> for Env {
 
         deserializer.deserialize_map(EnvVisitor)
     }
+}
+
+/// Reads a project's `.env.local` out of the rendered templates cache,
+/// treating an absent file as an empty environment rather than an error.
+///
+/// `*.env.local` is gitignored in generated applications, so a fresh
+/// checkout legitimately has none. Unwrapping the `Option` here made every
+/// `forklaunch change` subcommand abort with an opaque
+/// `called Option::unwrap() on a None value` panic. The callers all insert
+/// the result back into the cache, so the file is created on the way out.
+pub(crate) fn read_env_local_or_default(
+    rendered_templates_cache: &RenderedTemplatesCache,
+    env_local_path: &Path,
+) -> Result<Env> {
+    let content = rendered_templates_cache
+        .get(env_local_path)?
+        .map(|template| template.content)
+        .unwrap_or_default();
+
+    serde_envfile::from_str::<Env>(&content)
+        .with_context(|| format!("Failed to parse {}", env_local_path.display()))
 }
 
 #[derive(Debug, Clone)]
@@ -613,6 +636,56 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
+
+    // `*.env.local` is gitignored in generated applications, so a fresh
+    // checkout has none. Every `forklaunch change` subcommand used to unwrap
+    // the missing file and panic; a missing file must read as an empty Env.
+    #[test]
+    fn test_read_env_local_or_default_missing_file_is_empty_not_a_panic() {
+        let temp_dir = TempDir::new().unwrap();
+        let env_local_path = temp_dir.path().join(".env.local");
+        let cache = RenderedTemplatesCache::new();
+
+        let env = read_env_local_or_default(&cache, &env_local_path).unwrap();
+
+        assert!(env.queue_name.is_none());
+        assert!(env.db_name.is_none());
+        assert!(env.additional_env_vars.is_empty());
+        // Round-trips to an empty file that the caller can then populate.
+        assert_eq!(serde_envfile::to_string(&env).unwrap(), "");
+    }
+
+    #[test]
+    fn test_read_env_local_or_default_reads_existing_file_and_keeps_unknown_vars() {
+        let temp_dir = TempDir::new().unwrap();
+        let env_local_path = temp_dir.path().join(".env.local");
+        fs::write(
+            &env_local_path,
+            "DB_NAME=app-dev\nAPP_BASE_DOMAIN=example.test\n",
+        )
+        .unwrap();
+        let cache = RenderedTemplatesCache::new();
+
+        let env = read_env_local_or_default(&cache, &env_local_path).unwrap();
+
+        // NOTE: serde_envfile lower-cases keys on read and upper-cases them on
+        // write, so nothing lands in the named fields and everything round
+        // trips through `additional_env_vars`. That is pre-existing behaviour;
+        // what matters here is that an existing file is read and every
+        // variable in it survives the round trip.
+        assert_eq!(
+            env.additional_env_vars.get("db_name"),
+            Some(&"app-dev".to_string())
+        );
+        assert_eq!(
+            env.additional_env_vars.get("app_base_domain"),
+            Some(&"example.test".to_string())
+        );
+
+        let round_tripped = serde_envfile::to_string(&env).unwrap();
+        assert!(round_tripped.contains("DB_NAME"));
+        assert!(round_tripped.contains("APP_BASE_DOMAIN"));
+    }
 
     #[test]
     fn test_load_env_file() {


### PR DESCRIPTION
## What was broken

`forklaunch change service --to worker` did not work. Found by running it against a real module (`managed-apps` in forklaunch-platform), then reproduced on clean scaffolds.

### 1. Panicked on a missing `.env.local` — the blocker

```rust
rendered_templates_cache.get(&env_local_path)?.unwrap()  // Option::unwrap() on None
```

`*.env.local` is **gitignored in generated apps**, so a fresh clone has none and the command died with a raw Rust panic. This made the command unusable on every module in a fresh checkout.

The same unwrap pattern existed in **six other places** across the `change` commands. All seven now go through one shared helper, `read_env_local_or_default`, which treats a missing file as empty and writes a fresh one.

### 2. Generated code used the entity CONST as a TYPE

The generated entity is `defineEntity({...})` — a value. Generated `registrations.ts` then wrote `WorkerProcessFunction<FooEventRecord>`, giving five `TS2749` errors. The entity template now also exports a matching type, as the built-in worker template does. Fixing this surfaced a second error on non-database worker types (same name imported twice), also fixed.

### 3. `worker.ts` imported things that do not exist

It imported `processEvents` / `processErrors` from `./services/<name>.service`. Two problems: scaffolds put services in `./domain/services/` (verified against what `init service` produces today), and those handlers were never generated at all. `worker.ts` now defines both inline, correctly typed against `WorkerProcessFunction` / `WorkerFailureHandler`, with TODO markers for user logic.

### 4. The event entity was never registered in the entities barrel

Found while verifying the others, and the most consequential at runtime. The generated `<name>EventRecord` entity was created but not exported from `persistence/entities/index.ts` — and that barrel is how the ORM discovers entities. So **no migration was ever generated for the worker's table**, and the worker would start against a table that does not exist. Now registered.

## One reported bug that was NOT real

A claim that the conversion drops existing config keys from `registrations.ts` (citing `APP_BASE_DOMAIN`) **could not be reproduced and is false**. `registrations.ts` is edited in place and keeps what it finds: a scaffold carrying a custom config entry and a custom service registration was converted with the *pre-fix* binary and both survived. In the downstream repo, `APP_BASE_DOMAIN` was added by a hand-rolled commit, removed by a `git revert`, and re-added later — the revert deleted it, not the CLI. A regression test now pins the preserve-what-is-there behaviour anyway.

## Verification

- `cargo build` and `cargo clippy`: no errors, and **no new warnings** (642 before, 642 after).
- 349 unit tests pass. New tests: 2 for the env helper, 2 regression tests for the transformation.
- End to end: scaffolded a real app + service, converted with **and** without `.env.local`, typechecked the output.

Measured on identical scaffolds (`tsgo --noEmit`):

| worker type | before | after |
|---|---|---|
| `database` | 6 errors (5× TS2749, 1× TS2307) | **0** |
| `bullmq` | 13 errors | **3** |

The pre-fix binary still crashes without `.env.local` and reports 6 errors with it, so the fixes are doing real work rather than masking.

## Deliberately not fixed

1. **Non-database conversions still do not compile.** The 3 remaining bullmq errors are a separate feature gap: `service_to_worker` adds `@forklaunch/implementation-worker-bullmq` but not `@forklaunch/infrastructure-redis` / `bullmq` / `ioredis`, nor the docker-compose redis service, manifest `resources.cache`, or redis partition that `change/worker.rs:198-215` does. Adding just the dependency line would make it *compile* while remaining unrunnable (no `REDIS_URL`, no redis service). That deserves its own change rather than a paper-over.
2. **`Env` has a key-case mismatch.** `serde_envfile` lowercases keys on read and uppercases on write, so nothing lands in `Env`'s named fields — everything round-trips through `additional_env_vars`. Consequences: mutations like `env_local_content.s3_bucket = None` in the infrastructure-removal paths are **silent no-ops**, and re-running a conversion appends a duplicate `QUEUE_NAME=` line. Pre-existing and untouched; documented in a test rather than changing deserialization under every `change` command.
3. `--to worker` never calls `format_code`, so `registrations.ts` comes out codegen-formatted (tabs, double quotes) rather than prettier-formatted. Cosmetic, pre-existing.

## Not verified

The entity-barrel fix is verified at file-content and typecheck level only — no migration was run against a live database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)