### PR TITLE
fix(cli): clear the three dead-code warnings from cargo build

### DIFF
--- a/cli/src/compliance/audit.rs
+++ b/cli/src/compliance/audit.rs
@@ -920,25 +920,6 @@ impl ModuleEncryptionContext {
         out
     }
 
-    /// Modules that declare classified fields but never register an encryptor —
-    /// those columns are silently written in plaintext.
-    fn unprotected_modules(&self) -> Vec<(String, usize)> {
-        let mut out: Vec<(String, usize)> = self
-            .module_classified_fields
-            .iter()
-            .filter(|(m, count)| {
-                **count > 0
-                    && !self
-                        .module_registers_encryptor
-                        .get(*m)
-                        .copied()
-                        .unwrap_or(false)
-            })
-            .map(|(m, count)| (m.clone(), *count))
-            .collect();
-        out.sort_by(|a, b| a.0.cmp(&b.0));
-        out
-    }
 }
 
 /// Detect, per module, which entities it owns and whether it registers a

--- a/cli/src/infra/resource_resolver.rs
+++ b/cli/src/infra/resource_resolver.rs
@@ -140,8 +140,6 @@ pub(crate) fn fetch_resource_metrics(
 /// resource.
 pub(crate) struct ResolvedResource {
     pub(crate) id: String,
-    pub(crate) project_name: String,
-    pub(crate) resource_type: String,
 }
 
 /// Resolves a `<project-name>:<resource-type>` identifier (or an explicit
@@ -164,11 +162,7 @@ pub(crate) fn resolve(
     let mapped_type = resource_type_to_integration_type(resource_type)?;
 
     if let Some(id) = resource_id_override {
-        return Ok(ResolvedResource {
-            id: id.to_string(),
-            project_name: project_name.to_string(),
-            resource_type: resource_type.to_string(),
-        });
+        return Ok(ResolvedResource { id: id.to_string() });
     }
 
     let project = manifest
@@ -214,8 +208,6 @@ pub(crate) fn resolve(
         }
         1 => Ok(ResolvedResource {
             id: matches[0].id.clone(),
-            project_name: project_name.to_string(),
-            resource_type: resource_type.to_string(),
         }),
         _ => {
             let candidates = matches

--- a/cli/src/infra/types.rs
+++ b/cli/src/infra/types.rs
@@ -1,6 +1,13 @@
 use serde::{Deserialize, Serialize};
 
 /// One entry from `GET /platform-resources/application/:applicationId`.
+///
+/// This mirrors the response body, so it carries fields nothing reads yet.
+/// They are kept deliberately: the struct documents the wire contract, and
+/// dropping a field here would silently discard it the moment a caller wants
+/// it. Serde ignores unknown fields, so their absence would not have failed
+/// loudly either.
+#[allow(dead_code)]
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct ResourceListItem {
     pub(crate) id: String,


### PR DESCRIPTION
`cargo build` emitted three warnings, and they had three different causes — so they get three different fixes rather than a blanket `#[allow(dead_code)]`.

### `src/infra/types.rs` — `ResourceListItem`

Mirrors the body of `GET /platform-resources/application/:applicationId`, so it carries fields nothing reads yet. **Annotated rather than trimmed:** the struct documents the wire contract, and deleting a field would silently discard it the moment a caller wants it. Serde ignores unknown fields, so nothing would have failed loudly to say the data had stopped arriving.

### `src/infra/resource_resolver.rs` — `ResolvedResource`

An internal type, not a wire format. Only `id` is ever read; `project_name` and `resource_type` were written at both construction sites and never looked at. They are derived from the caller's own `<project>:<type>` argument, so callers already hold them — **removed.**

### `src/compliance/audit.rs` — `unprotected_modules`

**Deleted.** It looked like a security check going unused, which would be worth wiring up rather than removing — but it computes something `module_reports` already reports: a module with `classified_field_count > 0` and `encryptor_registered` false *is* an unprotected module. The capability stays in the report; only the duplicate derivation goes.

### Verification

Verified on a **clean rebuild** — warnings surface only once per build, so a warm build would have looked clean regardless of whether anything was fixed. 515 tests pass.

Rebased onto main after #294, and re-verified there: 0 warnings, 515 passing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forklaunch/codesmith/forklaunch/pr/297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790505779&installation_model_id=434648&pr_number=297&repository=forklaunch%2Fforklaunch&return_to=https%3A%2F%2Fgithub.com%2Fforklaunch%2Fforklaunch%2Fpull%2F297&signature=f2ca25d67a5380ea50e3cb7d351f8440b64f753eb223840b6f8d7246f1a33f01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->