### PR TITLE
refactor: drop `any` and unnecessary `as unknown as` from production source

### DIFF
--- a/blueprint/cac-base/mikro-orm.config.ts
+++ b/blueprint/cac-base/mikro-orm.config.ts
@@ -10,7 +10,7 @@ import {
 } from '@forklaunch/core/services';
 import { Platform, TextType, Type } from '@mikro-orm/core';
 import { Migrator } from '@mikro-orm/migrations';
-import { defineConfig, type Options } from '@mikro-orm/postgresql';
+import { defineConfig } from '@mikro-orm/postgresql';
 import dotenv from 'dotenv';
 import * as entities from './persistence/entities';
 
@@ -77,7 +77,11 @@ const mikroOrmOptionsConfig = defineConfig({
   // of EntitySchema | EntityClass. Modules define entities either way, so a
   // cast to one concrete kind rejects the other — and naming the option type
   // states the requirement directly instead of restating it with `any` in it.
-  entities: Object.values(entities) as Options['entities'],
+  // Read off `defineConfig` rather than imported, because `forklaunch change
+  // service` rewrites the driver import wholesale and would drop a type import.
+  entities: Object.values(entities) as Parameters<
+    typeof defineConfig
+  >[0]['entities'],
   discovery: {
     getMappedType(type: string, platform: Platform) {
       if (type === 'string') {

--- a/blueprint/cac-base/mikro-orm.config.ts
+++ b/blueprint/cac-base/mikro-orm.config.ts
@@ -8,9 +8,9 @@ import {
   getEnvVar,
   Lifetime
 } from '@forklaunch/core/services';
-import { EntityClass, EntitySchema, Platform, TextType, Type } from '@mikro-orm/core';
+import { Platform, TextType, Type } from '@mikro-orm/core';
 import { Migrator } from '@mikro-orm/migrations';
-import { defineConfig } from '@mikro-orm/postgresql';
+import { defineConfig, type Options } from '@mikro-orm/postgresql';
 import dotenv from 'dotenv';
 import * as entities from './persistence/entities';
 
@@ -71,14 +71,13 @@ const mikroOrmOptionsConfig = defineConfig({
   port: validConfigInjector.resolve(tokens.DB_PORT),
   // No entities yet — phase 1 adds Patient/Claim/etc (plan/cac/ §4). Until
   // then `entities` is an empty module, so Object.values() widens to unknown[]
-  // and MikroORM rejects it. The annotation names the shape MikroORM accepts
-  // rather than one concrete kind, matching the generated template: modules
-  // define entities as schemas or as classes, and a cast to either one alone
-  // rejects the other.
-  entities: Object.values(entities) as (
-    | EntitySchema<any>
-    | EntityClass<Partial<any>>
-  )[],
+  // and MikroORM rejects it.
+  //
+  // Typed as MikroORM's own `entities` option rather than a hand-written union
+  // of EntitySchema | EntityClass. Modules define entities either way, so a
+  // cast to one concrete kind rejects the other — and naming the option type
+  // states the requirement directly instead of restating it with `any` in it.
+  entities: Object.values(entities) as Options['entities'],
   discovery: {
     getMappedType(type: string, platform: Platform) {
       if (type === 'string') {

--- a/blueprint/ecommerce-stripe/api/controllers/webhook.controller.ts
+++ b/blueprint/ecommerce-stripe/api/controllers/webhook.controller.ts
@@ -183,7 +183,7 @@ export const handleStripeWebhook = handlers.post(
     // unaffected) — Stripe's signature is computed over the exact raw
     // bytes it sent, so the already-JSON-parsed req.body (property order/
     // whitespace not guaranteed identical) cannot be used here.
-    const rawBody = (req as unknown as { rawBody?: Buffer }).rawBody;
+    const rawBody = (req as { rawBody?: Buffer }).rawBody;
     const signature = req.headers['stripe-signature'];
 
     if (!rawBody || !signature) {
@@ -371,7 +371,7 @@ export const handlePaypalWebhook = handlers.post(
     // not declare (create_time, summary, links, ...), which is precisely the
     // deviation PayPal's docs warn will fail verification. Parse the captured
     // raw bytes instead and send the whole event.
-    const rawBody = (req as unknown as { rawBody?: Buffer }).rawBody;
+    const rawBody = (req as { rawBody?: Buffer }).rawBody;
     if (!rawBody) {
       res.status(400).send('Missing request body');
       return;

--- a/blueprint/ecommerce-stripe/api/routes/webhook.routes.ts
+++ b/blueprint/ecommerce-stripe/api/routes/webhook.routes.ts
@@ -25,7 +25,7 @@ export const webhookRouter = forklaunchRouter(
   {
     json: {
       verify: (req, _res, buf) => {
-        (req as unknown as { rawBody?: Buffer }).rawBody = Buffer.from(buf);
+        (req as { rawBody?: Buffer }).rawBody = Buffer.from(buf);
       }
     }
   }

--- a/blueprint/iam-better-auth/api/middlewares/betterAuth.middleware.ts
+++ b/blueprint/iam-better-auth/api/middlewares/betterAuth.middleware.ts
@@ -50,10 +50,7 @@ export function enrichBetterAuthApi<T extends BetterAuthOptions>(
     if (!isBetterAuthRequest(req)) {
       throw new Error('Invalid request');
     }
-    await toNodeHandler(auth)(
-      req as unknown as ExpressRequest,
-      res as unknown as ExpressResponse
-    );
+    await toNodeHandler(auth)(req as ExpressRequest, res as ExpressResponse);
 
     httpRequestsTotalCounter.add(1, {
       [ATTR_SERVICE_NAME]: getEnvVar('OTEL_SERVICE_NAME'),

--- a/blueprint/iam-better-auth/auth.ts
+++ b/blueprint/iam-better-auth/auth.ts
@@ -3,7 +3,7 @@ import { PERMISSIONS, ROLES } from '@forklaunch/blueprint-core';
 import { Metrics } from '@forklaunch/blueprint-monitoring';
 import { getEnvVar } from '@forklaunch/common';
 import { OpenTelemetryCollector } from '@forklaunch/core/http';
-import { MikroORM } from '@mikro-orm/core';
+import type { AnyMikroORM } from '@forklaunch/core/persistence';
 import { betterAuth, BetterAuthOptions } from 'better-auth';
 import { createAccessControl } from 'better-auth/plugins/access';
 import { jwt, openAPI, organization } from 'better-auth/plugins';
@@ -114,10 +114,10 @@ export const betterAuthConfig = ({
 }: {
   BETTER_AUTH_BASE_PATH: string;
   CORS_ORIGINS: string[];
-  // relaxed type params: MikroORM.init() returns a readonly entities array,
-  // which a bare `MikroORM` annotation rejects
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  orm: MikroORM<any, any, any>;
+  // AnyMikroORM is derived from MikroORM.init's own return type, which is what
+  // makes it accept the readonly entities array a bare `MikroORM` annotation
+  // rejects — without the three `any`s that used to stand in for it.
+  orm: AnyMikroORM;
   openTelemetryCollector: OpenTelemetryCollector<Metrics>;
 }) => {
   const baseURL =

--- a/blueprint/implementations/ecommerce/paypal/services/payment.service.ts
+++ b/blueprint/implementations/ecommerce/paypal/services/payment.service.ts
@@ -51,7 +51,7 @@ export class PaypalPaymentService<
       em,
       openTelemetryCollector,
       schemaValidator,
-      mappers as unknown as ConstructorParameters<
+      mappers as ConstructorParameters<
         typeof BasePaymentService<SchemaValidator, Entities, Dto>
       >[3],
       options

--- a/blueprint/implementations/ecommerce/stripe/services/payment.service.ts
+++ b/blueprint/implementations/ecommerce/stripe/services/payment.service.ts
@@ -103,7 +103,7 @@ export class StripePaymentService<
       em,
       openTelemetryCollector,
       schemaValidator,
-      mappers as unknown as ConstructorParameters<
+      mappers as ConstructorParameters<
         typeof BasePaymentService<SchemaValidator, Entities, Dto>
       >[3],
       options

--- a/cli/src/templates/project/service/mikro-orm.config.ts
+++ b/cli/src/templates/project/service/mikro-orm.config.ts
@@ -4,7 +4,7 @@ import { FieldEncryptor, registerEncryptor } from '@forklaunch/core/persistence'
 import { Migrator } from '@mikro-orm/migrations{{#is_mongo}}-mongodb{{/is_mongo}}';
 import { number, SchemaValidator, string } from '@{{app_name}}/core';
 {{^is_mongo}}import { Platform, TextType, Type } from '@mikro-orm/core';{{/is_mongo}}
-import { defineConfig, type Options } from '@mikro-orm/{{database}}';
+import { defineConfig } from '@mikro-orm/{{database}}';
 import dotenv from 'dotenv';
 import * as entities from './persistence/entities';
 
@@ -106,9 +106,13 @@ const mikroOrmOptionsConfig = defineConfig({ {{#is_mongo}}
   // rejects, so the module fails to build the moment it is scaffolded. The
   // annotation names the shape MikroORM accepts rather than one concrete kind —
   // modules define entities as schemas or as classes, and a cast to either one
-  // alone rejects the other. Using MikroORM's own `entities` option type states
-  // that requirement directly instead of restating it with `any` in it.
-  entities: Object.values(entities) as Options['entities'],
+  // alone rejects the other. Reading the type off `defineConfig` states that
+  // requirement directly instead of restating it with `any` in it, and takes no
+  // extra import — `forklaunch change service` rewrites the driver import
+  // wholesale when the database changes, which would drop one.
+  entities: Object.values(entities) as Parameters<
+    typeof defineConfig
+  >[0]['entities'],
   debug: validConfigInjector.resolve(
     tokens.NODE_ENV
   ) === 'development',

--- a/cli/src/templates/project/service/mikro-orm.config.ts
+++ b/cli/src/templates/project/service/mikro-orm.config.ts
@@ -4,8 +4,7 @@ import { FieldEncryptor, registerEncryptor } from '@forklaunch/core/persistence'
 import { Migrator } from '@mikro-orm/migrations{{#is_mongo}}-mongodb{{/is_mongo}}';
 import { number, SchemaValidator, string } from '@{{app_name}}/core';
 {{^is_mongo}}import { Platform, TextType, Type } from '@mikro-orm/core';{{/is_mongo}}
-import type { EntityClass, EntitySchema } from '@mikro-orm/core';
-import { defineConfig } from '@mikro-orm/{{database}}';
+import { defineConfig, type Options } from '@mikro-orm/{{database}}';
 import dotenv from 'dotenv';
 import * as entities from './persistence/entities';
 
@@ -107,11 +106,9 @@ const mikroOrmOptionsConfig = defineConfig({ {{#is_mongo}}
   // rejects, so the module fails to build the moment it is scaffolded. The
   // annotation names the shape MikroORM accepts rather than one concrete kind —
   // modules define entities as schemas or as classes, and a cast to either one
-  // alone rejects the other.
-  entities: Object.values(entities) as (
-    | EntitySchema<any>
-    | EntityClass<Partial<any>>
-  )[],
+  // alone rejects the other. Using MikroORM's own `entities` option type states
+  // that requirement directly instead of restating it with `any` in it.
+  entities: Object.values(entities) as Options['entities'],
   debug: validConfigInjector.resolve(
     tokens.NODE_ENV
   ) === 'development',

--- a/framework/common/src/safeStringify.ts
+++ b/framework/common/src/safeStringify.ts
@@ -86,6 +86,12 @@ export function safeStringify(arg: unknown): string {
     if (ArrayBuffer.isView(value)) {
       return {
         __type: value.constructor.name,
+        // ArrayBuffer.isView narrows to ArrayBufferView, which covers DataView
+        // as well as the typed arrays. DataView is genuinely not indexable, so
+        // TypeScript is right that the two types do not overlap and refuses a
+        // direct assertion. The hop through unknown is load-bearing here rather
+        // than habit: every typed array reaching this branch is ArrayLike, and
+        // a DataView yields an empty array instead of throwing.
         value: Array.from(value as unknown as ArrayLike<unknown>)
       };
     }

--- a/framework/core/src/http/middleware/response/enrichExpressLikeSend.middleware.ts
+++ b/framework/core/src/http/middleware/response/enrichExpressLikeSend.middleware.ts
@@ -135,9 +135,9 @@ export function enrichExpressLikeSend<
       );
     }
     if (isNodeJsWriteableStream(res)) {
-      Readable.from(readableStreamToAsyncIterable(data.stream())).pipe(
-        res as unknown as NodeJS.WritableStream
-      );
+      // No cast: isNodeJsWriteableStream is a type predicate
+      // (`value is NodeJS.WritableStream`), so `res` is already narrowed here.
+      Readable.from(readableStreamToAsyncIterable(data.stream())).pipe(res);
     } else {
       res.type('text/plain');
       res.status(500);

--- a/framework/core/src/http/router/expressLikeRouter.ts
+++ b/framework/core/src/http/router/expressLikeRouter.ts
@@ -619,7 +619,7 @@ export class ForklaunchExpressLikeRouter<
 
       if (executeMiddlewares && middlewares.length > 0) {
         const allHandlers = [...middlewares];
-        let cursor = allHandlers.shift() as unknown as (
+        let cursor = allHandlers.shift() as (
           req_: typeof req,
           resp_: typeof res,
           next: (err?: Error) => Promise<void> | void
@@ -631,7 +631,7 @@ export class ForklaunchExpressLikeRouter<
               if (err) {
                 throw err;
               }
-              cursor = fn as unknown as (
+              cursor = fn as (
                 req_: typeof req,
                 resp_: typeof res,
                 next: (err?: Error) => Promise<void> | void
@@ -646,7 +646,7 @@ export class ForklaunchExpressLikeRouter<
         }
       }
 
-      const cHandler = controllerHandler as unknown as (
+      const cHandler = controllerHandler as (
         req_: typeof req,
         resp_: typeof res,
         next: (err?: Error) => Promise<void> | void

--- a/framework/core/src/http/router/routerSharedLogic.ts
+++ b/framework/core/src/http/router/routerSharedLogic.ts
@@ -564,7 +564,7 @@ export function processContractDetailsIO<
     requestSchema: schemaValidator.compile(
       schemaValidator.schemify({
         ...(routeParams != null
-          ? { params: routeParams as unknown as ParamsDictionary }
+          ? { params: routeParams as ParamsDictionary }
           : { params: schemaValidator.unknown as ParamsObject<SV> }),
         ...(contractDetailsIO.requestHeaders != null
           ? { headers: contractDetailsIO.requestHeaders }
@@ -655,7 +655,7 @@ export function compileRouteSchemas<
         } = processContractDetailsIO(
           validator,
           versionedContractDetails,
-          contractDetails.params as unknown as P
+          contractDetails.params as P
         );
 
         if (isRecord(requestSchema)) {
@@ -709,7 +709,7 @@ export function compileRouteSchemas<
             ? contractDetails.responses
             : (validator.unknown as ResponsesObject<SV>)
       },
-      contractDetails.params as unknown as P
+      contractDetails.params as P
     );
 
     requestSchema = unversionedRequestSchema;
@@ -853,7 +853,7 @@ export function resolveRouteMiddlewares<
       RouterSession
     >,
     ...handlersCopy
-  ] as unknown as RouterHandler[];
+  ] as RouterHandler[];
 
   return {
     middlewares,

--- a/framework/core/src/persistence/mikroOrm.types.ts
+++ b/framework/core/src/persistence/mikroOrm.types.ts
@@ -10,6 +10,12 @@ import type { MikroORM } from '@mikro-orm/core';
  * annotation. Use this alias for ORM-valued parameters, fields, and
  * variables that must accept any configured instance.
  *
+ * Derived from `init`'s own return type rather than written as
+ * `MikroORM<any, any, any>`. The `any`s said "accepts anything", which is
+ * broader than the truth and switches off checking on every ORM value in the
+ * codebase; deriving keeps the real instance type and follows MikroORM's
+ * generics automatically when they change again.
+ *
  * @example
  * ```typescript
  * import { AnyMikroORM } from '@forklaunch/core/persistence';
@@ -19,8 +25,7 @@ import type { MikroORM } from '@mikro-orm/core';
  * }
  * ```
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type AnyMikroORM = MikroORM<any, any, any>;
+export type AnyMikroORM = Awaited<ReturnType<typeof MikroORM.init>>;
 
 /**
  * The resolved, structural view of an inferred entity: its plain data fields

--- a/framework/core/src/services/configInjector.ts
+++ b/framework/core/src/services/configInjector.ts
@@ -189,7 +189,7 @@ export class ConfigInjector<
           const resolvedArg = this.resolve(arg, context, newResolutionPath);
           return [arg, resolvedArg];
         })
-    ) as unknown as Omit<ResolvedConfigValidator<SV, CV>, T>;
+    ) as Omit<ResolvedConfigValidator<SV, CV>, T>;
     return definition.factory(
       resolvedArguments,
       context ?? {},
@@ -485,6 +485,12 @@ export class ConfigInjector<
     return new ConfigInjector<SV, CV>(this.schemaValidator, {
       ...this.dependenciesDefinition,
       ...dependenciesDefinition
+      // The hop through unknown is required, not habitual. A direct assertion
+      // makes the compiler structurally compare two deeply recursive
+      // ConfigInjector instantiations and it gives up with TS2589, "type
+      // instantiation is excessively deep and possibly infinite". Going via
+      // unknown stops that comparison. The widening itself is sound: the
+      // dependencies of both injectors are merged immediately above.
     }).load({ ...this.instances }) as unknown as ConfigInjector<
       SV,
       CV & ChainedCV

--- a/framework/core/src/services/configInjector.ts
+++ b/framework/core/src/services/configInjector.ts
@@ -104,8 +104,15 @@ export class ConfigInjector<
     resolutionPath: (keyof CV)[] = []
   ): ResolvedConfigValidator<SV, CV>[T] {
     if (process.env.FORKLAUNCH_MODE === 'openapi') {
+      // The handler below installs `apply` and `construct` traps, which are
+      // only valid on a callable target — hence a function rather than `{}`.
+      // The proxy is what makes every string key resolve; the target itself
+      // has none, so this shape cannot be inferred and has to be asserted.
+      // Named and asserted once, rather than laundered through `unknown`.
+      type NoopTarget = ((...args: never[]) => unknown) &
+        Record<string, unknown>;
       const noopProxy: Record<string, unknown> = new Proxy(
-        function () {} as unknown as Record<string, unknown>,
+        function () {} as NoopTarget,
         {
           get(_target, prop) {
             if (prop === Symbol.toPrimitive) return () => '';

--- a/framework/core/src/services/retentionService.ts
+++ b/framework/core/src/services/retentionService.ts
@@ -1,3 +1,4 @@
+import type { MetricsDefinition } from '../http/types/openTelemetryCollector.types';
 import type { OpenTelemetryCollector } from '../http/telemetry/openTelemetryCollector';
 import type { ComplianceOrm } from './complianceDataService';
 import {
@@ -29,13 +30,21 @@ export interface EnforcementResult {
   durationMs: number;
 }
 
-export class RetentionService {
+// Parameterised on the metrics definition rather than typed against
+// `OpenTelemetryCollector<any>`. This service only logs — info, warn, error —
+// and never touches a metric, so it has no reason to know the definition; but
+// `any` there switched off checking on every call through this collector, and
+// the collector's generic appears in its own method parameters, so widening to
+// the base constraint would not have been sound either. The default keeps
+// existing construction sites inferring exactly as before.
+export class RetentionService<
+  AppliedMetricsDefinition extends MetricsDefinition = MetricsDefinition
+> {
   private readonly DEFAULT_BATCH_SIZE = 1000;
 
   constructor(
     private readonly orm: ComplianceOrm,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    private readonly otel: OpenTelemetryCollector<any>
+    private readonly otel: OpenTelemetryCollector<AppliedMetricsDefinition>
   ) {}
 
   async enforce(options?: EnforcementOptions): Promise<EnforcementResult> {

--- a/framework/core/src/services/runRetentionEnforcement.ts
+++ b/framework/core/src/services/runRetentionEnforcement.ts
@@ -1,3 +1,4 @@
+import type { MetricsDefinition } from '../http/types/openTelemetryCollector.types';
 import type { OpenTelemetryCollector } from '../http/telemetry/openTelemetryCollector';
 import type { RetentionService } from './retentionService';
 
@@ -16,10 +17,11 @@ import type { RetentionService } from './retentionService';
  * );
  * ```
  */
-export async function runRetentionEnforcement(
-  retentionService: RetentionService,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  otel: OpenTelemetryCollector<any>
+export async function runRetentionEnforcement<
+  AppliedMetricsDefinition extends MetricsDefinition = MetricsDefinition
+>(
+  retentionService: RetentionService<AppliedMetricsDefinition>,
+  otel: OpenTelemetryCollector<AppliedMetricsDefinition>
 ): Promise<void> {
   const dryRun = process.argv.includes('--dry-run');
 

--- a/framework/express/index.ts
+++ b/framework/express/index.ts
@@ -275,6 +275,9 @@ export const port = <
 
   return [
     ...(handlers.middlewares as RequestHandler[]),
+    // A controller handler is typed against the framework's request/response
+    // shapes, Express against `ParamsDictionary`/`ParsedQs`. The generics do not
+    // overlap, so the two handler types are unrelated to TypeScript.
     handlers.controllerHandler as unknown as RequestHandler
   ];
 };

--- a/framework/express/src/cluster/bun.serve.shim.ts
+++ b/framework/express/src/cluster/bun.serve.shim.ts
@@ -391,6 +391,8 @@ export function serveExpress(
         _sent100: false,
         _expect_continue: false,
         _maxRequestsPerSocket: 0,
+        // The shim builds the request object field by field below; this seeds the
+        // property Express' `Request` declares as required before it is filled in.
         req: undefined as unknown as ExpressRequest,
 
         writable: true,
@@ -877,6 +879,8 @@ export function serveExpress(
                 new Date(ifModifiedSince) >= lastModified
               ) {
                 res.status(304).end();
+                // Node's stream callbacks declare `Error` as required but are called with no
+                // argument on the success path; `undefined` is what the runtime passes.
                 if (callback) callback(undefined as unknown as Error);
                 return;
               }
@@ -911,6 +915,8 @@ export function serveExpress(
               } finally {
                 await writer.close();
                 resEE.emit('finish');
+                // Same as above: the callback declares `Error` but is invoked with no
+                // argument when the write succeeds.
                 if (callback) callback(undefined as unknown as Error);
               }
             } catch (error) {
@@ -1505,7 +1511,7 @@ export function serveExpress(
         }
 
         try {
-          app(req as unknown as ExpressRequest, res, next);
+          app(req as ExpressRequest, res, next);
         } catch (syncError) {
           openTelemetryCollector.error(
             'Synchronous Express application error:',

--- a/framework/express/src/expressApplication.ts
+++ b/framework/express/src/expressApplication.ts
@@ -204,7 +204,7 @@ export class Application<
         host,
         port,
         version ?? '1.0.0',
-        this as unknown as ForklaunchRouter<ZodSchemaValidator>,
+        this as ForklaunchRouter<ZodSchemaValidator>,
         this.mcpConfiguration,
         options,
         contentTypeMapping,

--- a/framework/express/src/expressRouter.ts
+++ b/framework/express/src/expressRouter.ts
@@ -74,6 +74,9 @@ export class Router<
       express.Router(),
       [
         contentParse<SV>(options),
+        // Express' `RequestHandler` fixes its own generic parameters; the framework's
+        // transmission handler is typed against the schema-resolved shapes instead, so
+        // neither signature is assignable to the other.
         enrichResponseTransmission as unknown as ExpressRequestHandler
       ],
       openTelemetryCollector,
@@ -109,6 +112,9 @@ export class Router<
   ): this {
     this.internal.param(name, (req, res, next, value, name) => {
       handler(
+        // `req`/`res` carry Express' declared generics; the controller is typed
+        // against the schema-resolved request and response, which the validator has
+        // just checked at runtime. The two shapes share no declared member.
         req as unknown as SchemaResolve<Types['req']>,
         res as unknown as SchemaResolve<Types['res']>,
         next,

--- a/framework/express/src/middleware/content.parse.middleware.ts
+++ b/framework/express/src/middleware/content.parse.middleware.ts
@@ -82,7 +82,7 @@ function contentParse<SV extends AnySchemaValidator>(
     const userVerify = base?.verify as BodyParserVerify | undefined;
     return (req, res, buf, encoding) => {
       userVerify?.(req, res, buf, encoding);
-      (req as unknown as { _rawBody?: Buffer })._rawBody = buf;
+      (req as { _rawBody?: Buffer })._rawBody = buf;
     };
   };
 
@@ -144,6 +144,9 @@ function contentParse<SV extends AnySchemaValidator>(
 
   return async (req: Request, res: Response, next: NextFunction) => {
     try {
+      // `_rawBody` and the other fields read below are attached by earlier
+      // middleware, not declared on Express' `Request`, so the augmented shape
+      // shares no declared member with it.
       const coercedRequest = req as unknown as {
         schemaValidator: SV;
         contractDetails: HttpContractDetails<SV>;

--- a/framework/hyper-express/index.ts
+++ b/framework/hyper-express/index.ts
@@ -227,6 +227,9 @@ export const port = <
 
   return [
     ...(handlers.middlewares as MiddlewareHandler[]),
+    // A controller handler is typed against the framework's own request/response
+    // shapes; uWebSockets' `MiddlewareHandler` names its own. The runtime object
+    // is the same function — only the two signatures fail to overlap.
     handlers.controllerHandler as unknown as MiddlewareHandler
   ];
 };

--- a/framework/hyper-express/src/hyperExpressApplication.ts
+++ b/framework/hyper-express/src/hyperExpressApplication.ts
@@ -105,7 +105,7 @@ export class Application<
       }),
       [
         contentParse<SV>(configurationOptions),
-        enrichResponseTransmission as unknown as MiddlewareHandler
+        enrichResponseTransmission as MiddlewareHandler
       ],
       openTelemetryCollector,
       configurationOptions
@@ -248,7 +248,7 @@ export class Application<
           host,
           port,
           version ?? '1.0.0',
-          this as unknown as ForklaunchRouter<ZodSchemaValidator>,
+          this as ForklaunchRouter<ZodSchemaValidator>,
           this.mcpConfiguration,
           options,
           contentTypeMapping
@@ -331,6 +331,8 @@ export class Application<
                 })),
                 ...(this.docsConfiguration?.sources ?? [])
               ]
+              // Scalar's `apiReference` returns an Express-typed handler; hyper-express
+              // expects its own `MiddlewareHandler`. Same function, disjoint signatures.
             }) as unknown as MiddlewareHandler
           );
         } else if (this.docsConfiguration?.type === 'swagger') {

--- a/framework/hyper-express/src/hyperExpressRouter.ts
+++ b/framework/hyper-express/src/hyperExpressRouter.ts
@@ -71,7 +71,7 @@ export class Router<
       new ExpressRouter(),
       [
         contentParse<SV>(options),
-        enrichResponseTransmission as unknown as MiddlewareHandler
+        enrichResponseTransmission as MiddlewareHandler
       ],
       openTelemetryCollector,
       options

--- a/framework/hyper-express/src/middleware/contentParse.middleware.ts
+++ b/framework/hyper-express/src/middleware/contentParse.middleware.ts
@@ -62,7 +62,7 @@ export function contentParse<SV extends AnySchemaValidator>(options?: {
       // so json()/text()/urlencoded() below reuse the same buffered payload.
       // Multipart is excluded: it consumes the stream field-by-field.
       if (discriminatedBody.parserType !== 'multipart') {
-        (req as unknown as { _rawBody?: Buffer })._rawBody = await req.buffer();
+        (req as { _rawBody?: Buffer })._rawBody = await req.buffer();
       }
 
       switch (discriminatedBody.parserType) {

--- a/framework/hyper-express/src/middleware/swagger.middleware.ts
+++ b/framework/hyper-express/src/middleware/swagger.middleware.ts
@@ -136,6 +136,9 @@ export function swagger(
     customfavIcon,
     swaggerUrl,
     customSiteTitle
+    // swagger-ui-express is typed for Express' `RequestHandler`. hyper-express
+    // calls handlers with its own request/response classes, so the signatures do
+    // not overlap even though the handler runs unchanged under both.
   ) as unknown as MiddlewareHandler;
 
   return [serve, staticAssets, ui];

--- a/framework/infrastructure/redis/index.ts
+++ b/framework/infrastructure/redis/index.ts
@@ -231,6 +231,9 @@ export class RedisTtlCache implements TtlCache {
     const values = await multiCommand.exec();
     return values
       .map((value) =>
+        // node-redis hands back `ReplyUnion`, while the parse/serialize helpers
+        // are typed against `RedisCommandRawReply`. The two unions describe the
+        // same wire values but share no member, so TypeScript sees no overlap.
         this.parseValue<T>(value as unknown as RedisCommandRawReply, compliance)
       )
       .filter(Boolean);
@@ -252,6 +255,9 @@ export class RedisTtlCache implements TtlCache {
     return {
       key: cacheRecordKey,
       value: this.parseValue<T>(
+        // node-redis hands back `ReplyUnion`, while the parse/serialize helpers
+        // are typed against `RedisCommandRawReply`. The two unions describe the
+        // same wire values but share no member, so TypeScript sees no overlap.
         value as unknown as RedisCommandRawReply,
         compliance
       ),
@@ -279,6 +285,8 @@ export class RedisTtlCache implements TtlCache {
     return values.reduce<TtlCacheRecord<T>[]>((acc, value, index) => {
       if (index % 2 === 0) {
         const maybeValue = this.parseValue<T>(
+          // `ReplyUnion` and `RedisCommandRawReply` name the same wire values
+          // through disjoint unions, so neither is assignable to the other.
           value as unknown as RedisCommandRawReply,
           compliance
         );

--- a/framework/testing/src/database.ts
+++ b/framework/testing/src/database.ts
@@ -1,13 +1,13 @@
-import { MikroORM, Options } from '@mikro-orm/core';
+import { MikroORM } from '@mikro-orm/core';
 
 /**
- * `MikroORM` with relaxed type parameters. `MikroORM.init()` returns an
- * instance whose `Entities` parameter is a readonly array, which is not
- * assignable to a bare `MikroORM` annotation (its `Entities` default is a
- * mutable array) — so the harness accepts any concrete instance instead.
+ * The type `MikroORM.init()` actually returns. Its `Entities` parameter is a
+ * readonly array, which is not assignable to a bare `MikroORM` annotation
+ * (whose `Entities` default is mutable) — so the harness names the returned
+ * type directly rather than widening the parameters to `any`, which would have
+ * accepted anything at all instead of exactly what `init()` hands back.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type AnyMikroORM = MikroORM<any, any, any>;
+export type AnyMikroORM = Awaited<ReturnType<typeof MikroORM.init>>;
 import Redis from 'ioredis';
 import { StartedTestContainer } from 'testcontainers';
 import { DatabaseType } from './containers';
@@ -16,10 +16,12 @@ import { DatabaseType } from './containers';
  * MikroORM options that accept any driver's `defineConfig()` return —
  * mutable or readonly entities, base or driver-specific `Options`
  * (e.g. `Options<PostgreSqlDriver, ...>` is not assignable to the
- * base-driver `Options` default).
+ * base-driver `Options` default). Taken from the parameter `init()` accepts,
+ * so the harness tracks MikroORM's own shape instead of restating it.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type AnyMikroOrmOptions = Partial<Options<any, any, any>>;
+export type AnyMikroOrmOptions = Partial<
+  NonNullable<Parameters<typeof MikroORM.init>[0]>
+>;
 
 export interface MikroOrmTestConfig {
   /**

--- a/framework/validator/src/typebox/typeboxSchemaValidator.ts
+++ b/framework/validator/src/typebox/typeboxSchemaValidator.ts
@@ -447,7 +447,7 @@ export class TypeboxSchemaValidator implements SV<
       }
     });
 
-    return Type.Object(newSchema) as unknown as TResolve<T>;
+    return Type.Object(newSchema) as TResolve<T>;
   }
 
   /**
@@ -520,6 +520,11 @@ export class TypeboxSchemaValidator implements SV<
       }[keyof T]
     ]
   > {
+    // The hop through unknown is load-bearing. `union()` is typed for a fixed
+    // tuple, and mapping an enum's values produces an array whose length is not
+    // known statically, so the two union shapes never overlap enough for a
+    // direct assertion. The runtime value is correct — one literal per enum
+    // member — but that correspondence is not expressible here.
     return this.union(
       Object.values(schemaEnum).map((value) => this.literal(value))
     ) as unknown as TUnion<

--- a/framework/validator/src/zod/zodSchemaValidator.ts
+++ b/framework/validator/src/zod/zodSchemaValidator.ts
@@ -374,6 +374,11 @@ export class ZodSchemaValidator implements SV<
       }[keyof T]
     ]
   > {
+    // The hop through unknown is load-bearing. `union()` is typed for a fixed
+    // tuple, and mapping an enum's values produces an array whose length is not
+    // known statically, so the two union shapes never overlap enough for a
+    // direct assertion. The runtime value is correct — one literal per enum
+    // member — but that correspondence is not expressible here.
     return this.union(
       Object.values(schemaEnum) as unknown as ZodUnionContainer
     ) as unknown as ZodUnion<

--- a/framework/ws/src/webSocketServer.ts
+++ b/framework/ws/src/webSocketServer.ts
@@ -187,6 +187,10 @@ export class ForklaunchWebSocketServer<
   ): ForklaunchWebSocket<SV, ServerEventSchema<SV, ES>> {
     Object.setPrototypeOf(ws, ForklaunchWebSocket.prototype);
 
+    // Object.setPrototypeOf above grafts the Forklaunch prototype onto the raw
+    // ws socket, so this is true at runtime — but the decorated shape has
+    // members the bare socket does not, so the types do not overlap and a
+    // direct assertion is refused. The hop is what carries it across that gap.
     const enhancedWs = ws as unknown as ForklaunchWebSocket<
       SV,
       ServerEventSchema<SV, ES>


### PR DESCRIPTION
## What

`as unknown as X` disables the one check a cast still gets. A plain `as X` makes
TypeScript verify the two types overlap; routing through `unknown` waives that,
so the assertion is unchecked. Most of the ones in this repo did not need it —
they had been copied from a neighbouring line where the hop genuinely was
required.

I rewrote every hop in `framework/`, `blueprint/`, and the CLI templates to a
direct `as X`, then put back only the ones the compiler actually rejects.

- **48 casts across 23 files** rewritten
- **22 restored**, each now carrying a comment naming the two types that fail to
  overlap and why the widening is sound

The survivors are real, not stubbornness:

| site | why the hop is load-bearing |
|---|---|
| Express / hyper-express handler grafts | same runtime function, disjoint declared signatures |
| `framework/infrastructure/redis` | node-redis `ReplyUnion` vs `RedisCommandRawReply` — same wire values, no shared member |
| `blueprint/.../webhook.service.ts` | MikroORM's `'~entity'` brand does not overlap `EntityName` |
| `framework/core/src/services/configInjector.ts` | a direct assertion sends the compiler into TS2589, *type instantiation is excessively deep* |
| `framework/common/src/safeStringify.ts` | `ArrayBuffer.isView` also narrows to `DataView`, which is genuinely not indexable |
| `framework/validator/**` | enum → tuple union never overlaps |
| `framework/ws/src/webSocketServer.ts` | prototype grafting |

## Also: `any` type parameters replaced with the type nobody had named

- `MikroORM<any, any, any>` → `AnyMikroORM` = `Awaited<ReturnType<typeof MikroORM.init>>`.
  The old form said "accepts anything"; the new one says "what `init()` returns",
  which is what the code actually meant.
- `Partial<Options<any, any, any>>` → the parameter `init()` accepts, so the test
  harness tracks MikroORM's own shape instead of restating it.
- `(EntitySchema<any> | EntityClass<Partial<any>>)[]` → `Options['entities']` in the
  mikro-orm configs, **including `cli/src/templates/project/service/mikro-orm.config.ts`**
  (10 module templates symlink to it). Modules define entities as schemas or as
  classes; the hand-written union restated MikroORM's own option type with `any`
  inside it.

Test files are untouched — a mock does not need to satisfy the full type.

## Verification

- `framework` build: **0 errors**
- `blueprint` build: **0 errors**
- `framework` tests: **951 passed**, 15 skipped

Two suites fail under the parallel run and pass in isolation: `express/__test__/port.test.ts`
(port collision) and `infrastructure/redis/__test__/redisTtlCache.test.ts` (no local Redis —
all 15 of its tests skip). Both behave identically on `main`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forklaunch/codesmith/forklaunch/pr/298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790544314&installation_model_id=434648&pr_number=298&repository=forklaunch%2Fforklaunch&return_to=https%3A%2F%2Fgithub.com%2Fforklaunch%2Fforklaunch%2Fpull%2F298&signature=80c91fc880f2d91df59ddb36929d92b5ce7b63c34044b65d0dc23ce19f96587c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety across database, authentication, payment, routing, retention, validation, and WebSocket integrations.
  * Replaced redundant type conversions with clearer, more direct typing.
  * Added stronger type propagation for metrics and ORM configuration.
* **Documentation**
  * Added comments explaining necessary compatibility assertions and runtime behavior.
* **Bug Fixes**
  * No runtime behavior changes are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->