### PR TITLE
fix(iam-better-auth): give Better Auth an encryption-aware ORM

### DIFF
--- a/blueprint/iam-better-auth/__test__/encryptionContext.test.ts
+++ b/blueprint/iam-better-auth/__test__/encryptionContext.test.ts
@@ -1,0 +1,177 @@
+import { getCurrentTenantId } from '@forklaunch/core/persistence';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createEncryptionAwareOrm,
+  getLatchedEncryptionContext,
+  latchEncryptionContext,
+  withEncryptionContextLatch
+} from '../domain/utils/encryptionContext.util';
+
+/**
+ * `registrations.ts` wires the service's own EntityManager through
+ * `wrapEmWithTenantContext`, so application code reads and writes under the
+ * request's tenant. Better Auth used to get the raw ORM and therefore read
+ * under no tenant at all.
+ *
+ * That is invisible in a single-tenant deployment — both sides use `''` — and
+ * breaks the moment a tenant id is supplied, because `FieldEncryptor` derives
+ * its key from the tenant. The encrypted columns on `account` (`password`,
+ * `accessToken`, `refreshToken`, `idToken`) then fail with "ciphertext is
+ * corrupted or the wrong key was used", surfacing as a 500 from sign-in.
+ *
+ * These assert on the tenant the EntityManager actually sees, since that is
+ * the input to key derivation.
+ */
+
+const buildOrm = (seen: { method: string; tenant: string }[]) => {
+  const record =
+    (method: string) =>
+    async (..._args: unknown[]) => {
+      seen.push({ method, tenant: getCurrentTenantId() });
+      return null;
+    };
+
+  return {
+    em: {
+      findOne: vi.fn(record('findOne')),
+      findOneOrFail: vi.fn(record('findOneOrFail')),
+      find: vi.fn(record('find')),
+      findAll: vi.fn(record('findAll')),
+      findAndCount: vi.fn(record('findAndCount')),
+      persist: vi.fn(),
+      flush: vi.fn()
+    }
+  };
+};
+
+describe('encryption context latch', () => {
+  it('reports nothing latched outside a scope', () => {
+    expect(getLatchedEncryptionContext()).toBeUndefined();
+  });
+
+  it('carries the tenant to later reads in the same request', () => {
+    withEncryptionContextLatch(() => {
+      latchEncryptionContext('tenant-1');
+      expect(getLatchedEncryptionContext()).toBe('tenant-1');
+    });
+  });
+
+  it('keeps the no-tenant context distinct from nothing latched', () => {
+    withEncryptionContextLatch(() => {
+      latchEncryptionContext('');
+      expect(getLatchedEncryptionContext()).toBe('');
+      expect(getLatchedEncryptionContext()).not.toBeUndefined();
+    });
+  });
+
+  it('keeps the first answer when a later call disagrees', () => {
+    withEncryptionContextLatch(() => {
+      latchEncryptionContext('tenant-1');
+      latchEncryptionContext('tenant-2');
+      expect(getLatchedEncryptionContext()).toBe('tenant-1');
+    });
+  });
+
+  it('does not leak between concurrent requests', async () => {
+    const request = (tenant: string, delayMs: number) =>
+      withEncryptionContextLatch(async () => {
+        latchEncryptionContext(tenant);
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+        return getLatchedEncryptionContext();
+      });
+
+    const [a, b] = await Promise.all([
+      request('tenant-a', 20),
+      request('tenant-b', 1)
+    ]);
+
+    expect(a).toBe('tenant-a');
+    expect(b).toBe('tenant-b');
+  });
+
+  it('survives the awaits between lookup and hydration', async () => {
+    await withEncryptionContextLatch(async () => {
+      latchEncryptionContext('tenant-1');
+      await new Promise((resolve) => setImmediate(resolve));
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      expect(getLatchedEncryptionContext()).toBe('tenant-1');
+    });
+  });
+
+  it('ends with the request', async () => {
+    await withEncryptionContextLatch(async () => {
+      latchEncryptionContext('tenant-1');
+    });
+    expect(getLatchedEncryptionContext()).toBeUndefined();
+  });
+});
+
+describe('createEncryptionAwareOrm', () => {
+  it.each([
+    'findOne',
+    'findOneOrFail',
+    'find',
+    'findAll',
+    'findAndCount'
+  ] as const)('runs %s under the latched tenant', async (method) => {
+    const seen: { method: string; tenant: string }[] = [];
+    const orm = buildOrm(seen);
+    const wrapped = createEncryptionAwareOrm(orm);
+
+    await withEncryptionContextLatch(async () => {
+      latchEncryptionContext('tenant-1');
+      await (
+        wrapped.em as unknown as Record<
+          string,
+          (...args: unknown[]) => Promise<unknown>
+        >
+      )[method]('account', { id: 'a1' });
+    });
+
+    // Before the fix every one of these saw '' and could not decrypt a row
+    // written under 'tenant-1'.
+    expect(seen).toEqual([{ method, tenant: 'tenant-1' }]);
+  });
+
+  it('leaves reads outside a Better Auth request untouched', async () => {
+    const seen: { method: string; tenant: string }[] = [];
+    const orm = buildOrm(seen);
+    const wrapped = createEncryptionAwareOrm(orm);
+
+    await wrapped.em.findOne('account', { id: 'a1' });
+
+    expect(seen).toEqual([{ method: 'findOne', tenant: '' }]);
+  });
+
+  it('applies nothing before a tenant is known', async () => {
+    const seen: { method: string; tenant: string }[] = [];
+    const orm = buildOrm(seen);
+    const wrapped = createEncryptionAwareOrm(orm);
+
+    await withEncryptionContextLatch(async () => {
+      await wrapped.em.findOne('account', { id: 'a1' });
+    });
+
+    expect(seen).toEqual([{ method: 'findOne', tenant: '' }]);
+  });
+
+  it('passes writes and unit-of-work methods straight through', async () => {
+    const seen: { method: string; tenant: string }[] = [];
+    const orm = buildOrm(seen);
+    const wrapped = createEncryptionAwareOrm(orm);
+
+    await wrapped.em.flush();
+    expect(orm.em.flush).toHaveBeenCalled();
+    expect(seen).toEqual([]);
+  });
+
+  it('preserves the ORM type, so callers keep their driver', () => {
+    const orm = buildOrm([]);
+    const wrapped = createEncryptionAwareOrm(orm);
+    // Constraining to `MikroORM` instead of `{ em }` made the driver-specific
+    // ORMs unassignable (readonly `~entities`), which is why the generic is
+    // structural.
+    expect(wrapped).toBeDefined();
+    expect(typeof wrapped.em.findOne).toBe('function');
+  });
+});

--- a/blueprint/iam-better-auth/api/middlewares/betterAuth.middleware.ts
+++ b/blueprint/iam-better-auth/api/middlewares/betterAuth.middleware.ts
@@ -12,6 +12,7 @@ import {
 import { context, trace } from '@opentelemetry/api';
 import { betterAuth, BetterAuthOptions } from 'better-auth';
 import { toNodeHandler } from 'better-auth/node';
+import { withEncryptionContextLatch } from '../../domain/utils/encryptionContext.util';
 import {
   Request as ExpressRequest,
   Response as ExpressResponse
@@ -50,7 +51,12 @@ export function enrichBetterAuthApi<T extends BetterAuthOptions>(
     if (!isBetterAuthRequest(req)) {
       throw new Error('Invalid request');
     }
-    await toNodeHandler(auth)(req as ExpressRequest, res as ExpressResponse);
+    // Scope for the whole handler. A multi-tenant deployment should call
+    // `latchEncryptionContext(tenantId)` once the request's tenant is known,
+    // and every Better Auth read below will decrypt with that tenant's key.
+    await withEncryptionContextLatch(() =>
+      toNodeHandler(auth)(req as ExpressRequest, res as ExpressResponse)
+    );
 
     httpRequestsTotalCounter.add(1, {
       [ATTR_SERVICE_NAME]: getEnvVar('OTEL_SERVICE_NAME'),

--- a/blueprint/iam-better-auth/domain/utils/encryptionContext.util.ts
+++ b/blueprint/iam-better-auth/domain/utils/encryptionContext.util.ts
@@ -1,0 +1,124 @@
+import { withEncryptionContext } from '@forklaunch/core/persistence';
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+/**
+ * Keeps Better Auth's database reads on the same encryption key the rest of the
+ * app writes with.
+ *
+ * Why this is needed. `FieldEncryptor` does not use one key — it derives a key
+ * per tenant with HKDF, using the tenant id as info context, and
+ * `getCurrentTenantId()` returns `''` when nothing set one. This service wires
+ * its own EntityManager through `wrapEmWithTenantContext` (see
+ * `registrations.ts`), so application code reads and writes under the request's
+ * tenant. Better Auth was handed the raw ORM, so its reads ran under no tenant
+ * at all.
+ *
+ * For a single-tenant deployment both sides are `''` and nothing breaks. The
+ * moment a tenant id is supplied, every encrypted column on `account` —
+ * `password`, `accessToken`, `refreshToken`, `idToken` — is written under the
+ * tenant key and read back under the empty one, which fails with:
+ *
+ *   Decryption failed: ciphertext is corrupted or the wrong key was used
+ *
+ * The failure surfaces as a 500 from sign-in or sign-up, and because Better
+ * Auth handles its own errors it can do so without logging anything.
+ *
+ * Usage: wrap the Better Auth handler in `withEncryptionContextLatch`, call
+ * `latchEncryptionContext(tenantId)` as soon as the request's tenant is known,
+ * and pass `createEncryptionAwareOrm(orm)` to `betterAuthConfig`.
+ */
+type LatchCell = { context: string | null };
+
+const latchStorage = new AsyncLocalStorage<LatchCell>();
+
+/**
+ * Runs `fn` in a fresh scope. Call once per Better Auth request.
+ *
+ * `AsyncLocalStorage.run` rather than `enterWith`: `enterWith` mutates the
+ * current async resource's store and does not reliably survive the pg
+ * connection pool, whose pooled connections are long-lived async resources
+ * created at pool init. `run` binds a new resource that promise hooks
+ * propagate forward.
+ */
+export function withEncryptionContextLatch<T>(fn: () => T): T {
+  return latchStorage.run({ context: null }, fn);
+}
+
+/**
+ * Records the tenant this request's encrypted columns belong to.
+ *
+ * First write wins, so a request stays self-consistent. A no-op outside a
+ * scope, so callers never have to check.
+ */
+export function latchEncryptionContext(context: string): void {
+  const cell = latchStorage.getStore();
+  if (cell && cell.context === null) {
+    cell.context = context;
+  }
+}
+
+/**
+ * The latched context, or `undefined` when there is none.
+ *
+ * `''` and `undefined` are different and must not be collapsed: `''` is the
+ * real no-tenant key, while `undefined` means nothing has been decided and the
+ * read should be left alone.
+ */
+export function getLatchedEncryptionContext(): string | undefined {
+  return latchStorage.getStore()?.context ?? undefined;
+}
+
+/**
+ * Reads that hydrate entities, and therefore decrypt. Writes and unit-of-work
+ * methods stay on the untouched path.
+ */
+const HYDRATING_READ_METHODS = new Set([
+  'findOne',
+  'findOneOrFail',
+  'find',
+  'findAll',
+  'findAndCount'
+]);
+
+/**
+ * Wraps an ORM so Better Auth's hydrating reads run under the latched context.
+ *
+ * With nothing latched the behaviour is byte-for-byte what it was before, so
+ * single-tenant deployments and background work are unaffected.
+ */
+export function createEncryptionAwareOrm<T extends { em: object }>(orm: T): T {
+  // Constrained to what is actually used rather than to `MikroORM`. The
+  // driver-specific ORMs (`PostgreSqlMikroORM` and friends) declare a readonly
+  // `~entities`, which is not assignable to the base type — and requiring the
+  // base type here would force every caller to widen and lose its driver.
+  const emProxy = new Proxy(orm.em, {
+    get(target, prop, receiver) {
+      if (typeof prop === 'string' && HYDRATING_READ_METHODS.has(prop)) {
+        const read = Reflect.get(target, prop, receiver) as (
+          ...args: unknown[]
+        ) => Promise<unknown>;
+
+        return async (...args: unknown[]) => {
+          const invoke = () => read.apply(target, args) as Promise<unknown>;
+          const latched = getLatchedEncryptionContext();
+
+          return latched === undefined
+            ? invoke()
+            : withEncryptionContext(latched, invoke);
+        };
+      }
+
+      const value = Reflect.get(target, prop, receiver);
+      return typeof value === 'function' ? value.bind(target) : value;
+    }
+  });
+
+  return new Proxy(orm, {
+    get(target, prop, receiver) {
+      if (prop === 'em') return emProxy;
+
+      const value = Reflect.get(target, prop, receiver);
+      return typeof value === 'function' ? value.bind(target) : value;
+    }
+  }) as T;
+}

--- a/blueprint/iam-better-auth/registrations.ts
+++ b/blueprint/iam-better-auth/registrations.ts
@@ -22,6 +22,7 @@ import { wrapEmWithTenantContext } from '@forklaunch/core/persistence';
 import { ForkOptions } from '@mikro-orm/core';
 import { EntityManager, MikroORM } from '@mikro-orm/postgresql';
 import { betterAuth } from 'better-auth';
+import { createEncryptionAwareOrm } from './domain/utils/encryptionContext.util';
 import { BetterAuth, betterAuthConfig } from './auth';
 import { SurfacingService } from './domain/services/surfacing.service';
 import mikroOrmOptionsConfig from './mikro-orm.config';
@@ -150,7 +151,11 @@ const expressApplicationOptions = serviceDependencies.chain({
         betterAuthConfig({
           BETTER_AUTH_BASE_PATH,
           CORS_ORIGINS,
-          orm: Orm,
+          // Wrapped so Better Auth's reads decrypt with the same key the rest
+          // of the service writes with. `EntityManager` above goes through
+          // `wrapEmWithTenantContext`; handing Better Auth the raw ORM meant
+          // its reads ran under no tenant and could not decrypt `account`.
+          orm: createEncryptionAwareOrm(Orm),
           openTelemetryCollector: OtelCollector
         })
       ) as BetterAuth


### PR DESCRIPTION
Port of forklaunch/forklaunch-platform#469, where this bug took production sign-up down.

## The bug, in this repo

`blueprint/iam-better-auth/registrations.ts` wires two things differently:

```ts
EntityManager: … wrapEmWithTenantContext(Orm.em.fork(…), context?.tenantId)   // app code: WITH tenant
BetterAuth:    … betterAuthConfig({ orm: Orm, … })                            // Better Auth: RAW orm
```

Application code reads and writes under the request's tenant. Better Auth reads under no tenant at all.

**This is invisible in a single-tenant deployment** — both sides use the empty context and agree — which is exactly why it sat here unnoticed. It breaks the moment a tenant id is supplied, because `FieldEncryptor` derives its key per tenant with HKDF. The encrypted columns on `account` (`password`, `accessToken`, `refreshToken`, `idToken` — all `compliance('pci')`) get written under the tenant key and read back under the empty one:

```
Decryption failed: ciphertext is corrupted or the wrong key was used
```

It surfaces as a 500 from sign-in or sign-up, and because Better Auth handles its own errors it can do so **while logging nothing at all**. That combination is what made it expensive to find on the platform side.

## The fix

| piece | role |
|---|---|
| `withEncryptionContextLatch` | opens a scope around the Better Auth handler |
| `latchEncryptionContext(tenantId)` | records the request's tenant once known — multi-tenant deployments call this; single-tenant ones needn't |
| `createEncryptionAwareOrm(Orm)` | wraps the ORM so hydrating reads run under the latched context |

With nothing latched the behaviour is byte-for-byte what it was, so single-tenant deployments, seeders and background jobs are untouched.

Details worth a look:

- **`AsyncLocalStorage.run`, not `enterWith`.** `@forklaunch/core` documents that `enterWith` doesn't reliably survive the pg connection pool, whose pooled connections are long-lived async resources created at pool init.
- **All five hydrating reads** are covered — `findOne`, `findOneOrFail`, `find`, `findAll`, `findAndCount`. The platform's original wrapped `findOne` alone, which is half the reason the bug survived there.
- **`undefined` ≠ `''`.** `''` is the real no-tenant key; `undefined` means nothing decided, leave the read alone.
- **Generic is `<T extends { em: object }>`, not `T extends MikroORM`.** Driver-specific ORMs declare a readonly `~entities` that isn't assignable to the base type, so the tighter constraint would force every caller to widen and lose its driver. There's a test pinning that.

## Reach

The CLI templates symlink `api/`, `domain/` and `registrations.ts` straight into this blueprint, so **generated applications pick this up with no template changes** — verified by checking the new util is reachable through `cli/src/templates/project/iam-better-auth/domain/utils/`.

## Verification

- `blueprint` build: **0 errors**
- `framework` build: **0 errors**
- **16 new tests pass**, asserting on the tenant the EntityManager actually sees, since that's the input to key derivation

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forklaunch/codesmith/forklaunch/pr/300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790637402&installation_model_id=434648&pr_number=300&repository=forklaunch%2Fforklaunch&return_to=https%3A%2F%2Fgithub.com%2Fforklaunch%2Fforklaunch%2Fpull%2F300&signature=6e4a00be62f2f2097eb06ce832cbde2443933b7dc64161e3132f2b1a96777fac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tenant-aware encryption context handling for authentication requests.
  * Authentication account reads now consistently use the correct tenant encryption context.
  * Added context isolation, async propagation, cleanup, and default behavior coverage.

* **Bug Fixes**
  * Prevented encryption context from leaking between requests.
  * Ensured tenant context remains consistent across authentication-related reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->