### PR TITLE
feat(compliance): audit flags Better Auth reading encrypted columns without a tenant context

### DIFF
--- a/cli/src/compliance/checks.rs
+++ b/cli/src/compliance/checks.rs
@@ -48,6 +48,45 @@ const TENANT_GATES: &[(&str, &str)] = &[
     ),
 ];
 
+/// Better Auth handles `/api/auth/*` itself and reads the database through
+/// whatever ORM it was handed at construction. If that ORM is the raw one while
+/// the project's own EntityManager goes through `wrapEmWithTenantContext`, the
+/// two sides derive different encryption keys: `FieldEncryptor` derives per
+/// tenant via HKDF, and Better Auth reads with no tenant at all.
+///
+/// The rows are written under the tenant key and read back under the empty one,
+/// which fails with "ciphertext is corrupted or the wrong key was used" — as a
+/// 500 from sign-in or sign-up, and with nothing in the logs, because Better
+/// Auth swallows its own errors. It is invisible in a single-tenant deployment,
+/// where both sides agree on the empty context, and appears the first time a
+/// tenant id is supplied.
+const BETTER_AUTH_CONFIG_MARKERS: &[&str] = &["betterAuthConfig(", "betterAuth("];
+const ENCRYPTION_AWARE_ORM_MARKERS: &[&str] = &[
+    "createEncryptionAwareOrm(",
+    "createTenantAwareBetterAuthOrmProxy(",
+];
+
+/// Files that can legitimately hold either half of the Better Auth wiring.
+/// The blueprint wraps the ORM at the registration site; forklaunch-platform
+/// wraps it inside `auth.ts` instead. Reading only one of the two would flag a
+/// correctly-wired service, so both are searched together.
+const BETTER_AUTH_WIRING_FILES: &[&str] = &["registrations.ts", "auth.ts"];
+
+/// True when the project wires Better Auth against an ORM that was not made
+/// encryption-aware. Returns false when Better Auth is not used at all.
+fn better_auth_orm_is_unwrapped(sources: &str) -> bool {
+    let wires_better_auth = BETTER_AUTH_CONFIG_MARKERS
+        .iter()
+        .any(|marker| sources.contains(marker));
+    if !wires_better_auth {
+        return false;
+    }
+
+    !ENCRYPTION_AWARE_ORM_MARKERS
+        .iter()
+        .any(|marker| sources.contains(marker))
+}
+
 /// Field-name words that suggest a classification stronger than `none`.
 /// Matching is done on lowercased words split from camelCase / snake_case,
 /// including joined adjacent pairs (`first_name` -> `firstname`), to keep
@@ -207,8 +246,8 @@ pub(crate) fn run_local_checks(modules_path: &Path) -> Result<Vec<LocalFinding>>
                     .values()
                     .any(|classification| classification != "none")
             });
-            let registrations = fs::read_to_string(project_path.join("registrations.ts"))
-                .unwrap_or_default();
+            let registrations =
+                fs::read_to_string(project_path.join("registrations.ts")).unwrap_or_default();
             if has_retention && !registrations.contains("RetentionService") {
                 findings.push(LocalFinding {
                     severity: Severity::Warning,
@@ -228,7 +267,23 @@ pub(crate) fn run_local_checks(modules_path: &Path) -> Result<Vec<LocalFinding>>
                 });
             }
 
-            // 3. Sensitive-field heuristics
+            // 3. Better Auth reading encrypted columns without a tenant context
+            let better_auth_sources = BETTER_AUTH_WIRING_FILES
+                .iter()
+                .map(|file| fs::read_to_string(project_path.join(file)).unwrap_or_default())
+                .collect::<Vec<_>>()
+                .join("\n");
+            if has_sensitive && better_auth_orm_is_unwrapped(&better_auth_sources) {
+                findings.push(LocalFinding {
+                    severity: Severity::Warning,
+                    project: project.clone(),
+                    check: "better-auth-encryption-context".to_string(),
+                    subject: "registrations.ts".to_string(),
+                    message: "entities hold classified data but Better Auth is wired to the raw ORM — its reads run with no tenant encryption context and will fail to decrypt once a tenant id is used".to_string(),
+                });
+            }
+
+            // 4. Sensitive-field heuristics
             for entity in &entities {
                 for (field, classification) in &entity.field_classifications {
                     if classification != "none" {
@@ -253,12 +308,8 @@ pub(crate) fn run_local_checks(modules_path: &Path) -> Result<Vec<LocalFinding>>
 
     // Deterministic output for --json / snapshots
     findings.sort_by(|a, b| {
-        (&a.project, &a.check, &a.subject, &a.message).cmp(&(
-            &b.project,
-            &b.check,
-            &b.subject,
-            &b.message,
-        ))
+        (&a.project, &a.check, &a.subject, &a.message)
+            .cmp(&(&b.project, &b.check, &b.subject, &b.message))
     });
     Ok(findings)
 }
@@ -281,6 +332,63 @@ mod tests {
             setupRls(orm, { logger });
         "#;
         assert!(missing_tenant_gates(source).is_empty());
+    }
+
+    #[test]
+    fn test_better_auth_orm_unwrapped_is_flagged() {
+        // The shape that took production down: Better Auth handed `Orm`
+        // directly while the service's own EntityManager is tenant-wrapped.
+        let registrations = r#"
+            EntityManager: { factory: ({ Orm }, context) =>
+                wrapEmWithTenantContext(Orm.em.fork(), context?.tenantId) },
+            BetterAuth: { factory: ({ Orm }) =>
+                betterAuth(betterAuthConfig({ orm: Orm })) }
+        "#;
+        assert!(better_auth_orm_is_unwrapped(registrations));
+    }
+
+    #[test]
+    fn test_better_auth_orm_wrapped_passes() {
+        let registrations = r#"
+            BetterAuth: { factory: ({ Orm }) =>
+                betterAuth(betterAuthConfig({ orm: createEncryptionAwareOrm(Orm) })) }
+        "#;
+        assert!(!better_auth_orm_is_unwrapped(registrations));
+    }
+
+    #[test]
+    fn test_better_auth_platform_proxy_also_counts_as_wrapped() {
+        // forklaunch-platform wraps via its own proxy rather than the
+        // blueprint helper; both make the reads encryption-aware.
+        let registrations = r#"
+            orm: createTenantAwareBetterAuthOrmProxy(Orm)
+        "#;
+        assert!(!better_auth_orm_is_unwrapped(registrations));
+    }
+
+    #[test]
+    fn test_wrapper_in_auth_ts_counts_even_when_registrations_looks_raw() {
+        // The exact false positive dogfooding caught: forklaunch-platform
+        // passes `orm: Orm` at the registration site and applies the proxy
+        // inside auth.ts. Searching registrations.ts alone flags a service
+        // that is correctly wired.
+        let registrations = "betterAuth(betterAuthConfig({ orm: Orm }))";
+        let auth = "const betterAuthOrm = createTenantAwareBetterAuthOrmProxy(orm);";
+        let combined = format!("{}\n{}", registrations, auth);
+
+        assert!(better_auth_orm_is_unwrapped(registrations));
+        assert!(!better_auth_orm_is_unwrapped(&combined));
+    }
+
+    #[test]
+    fn test_project_without_better_auth_is_not_flagged() {
+        // A service that never wires Better Auth has nothing to answer for —
+        // the check must not fire on every project that owns entities.
+        let registrations = r#"
+            EntityManager: { factory: ({ Orm }, context) =>
+                wrapEmWithTenantContext(Orm.em.fork(), context?.tenantId) }
+        "#;
+        assert!(!better_auth_orm_is_unwrapped(registrations));
     }
 
     #[test]
@@ -323,7 +431,80 @@ mod fs_tests {
         std::fs::write(proj.join("server.ts"), "const app = express();").unwrap();
         let findings = run_local_checks(&dir).unwrap();
         let _ = std::fs::remove_dir_all(&dir);
-        assert_eq!(findings.len(), 2, "expected 2 wiring findings, got: {:?}", findings);
-        assert!(findings.iter().all(|f| f.check == "tenant-isolation-wiring"));
+        assert_eq!(
+            findings.len(),
+            2,
+            "expected 2 wiring findings, got: {:?}",
+            findings
+        );
+        assert!(
+            findings
+                .iter()
+                .all(|f| f.check == "tenant-isolation-wiring")
+        );
+    }
+
+    /// Builds a project whose entity holds classified data, so the
+    /// encryption-context check has something to fire on.
+    fn write_project_with_classified_entity(proj: &std::path::Path, registrations: &str) {
+        std::fs::create_dir_all(proj.join("persistence/entities")).unwrap();
+        std::fs::write(
+            proj.join("persistence/entities/account.entity.ts"),
+            r#"
+            export const AccountEntity = defineComplianceEntity({
+              name: 'Account',
+              properties: {
+                accountId: fp.string().compliance('none'),
+                password: fp.string().nullable().compliance('pii')
+              }
+            });
+            "#,
+        )
+        .unwrap();
+        std::fs::write(proj.join("registrations.ts"), registrations).unwrap();
+    }
+
+    #[test]
+    fn test_run_local_checks_flags_better_auth_raw_orm() {
+        let dir = std::env::temp_dir().join("fl-checks-ba-raw");
+        let proj = dir.join("iam");
+        let _ = std::fs::remove_dir_all(&dir);
+        write_project_with_classified_entity(
+            &proj,
+            "BetterAuth: betterAuth(betterAuthConfig({ orm: Orm }))",
+        );
+
+        let findings = run_local_checks(&dir).unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.check == "better-auth-encryption-context"),
+            "expected the encryption-context finding, got: {:?}",
+            findings
+        );
+    }
+
+    #[test]
+    fn test_run_local_checks_passes_encryption_aware_better_auth() {
+        let dir = std::env::temp_dir().join("fl-checks-ba-wrapped");
+        let proj = dir.join("iam");
+        let _ = std::fs::remove_dir_all(&dir);
+        write_project_with_classified_entity(
+            &proj,
+            "BetterAuth: betterAuth(betterAuthConfig({ orm: createEncryptionAwareOrm(Orm) }))",
+        );
+
+        let findings = run_local_checks(&dir).unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+
+        assert!(
+            !findings
+                .iter()
+                .any(|f| f.check == "better-auth-encryption-context"),
+            "wrapped ORM should not be flagged, got: {:?}",
+            findings
+        );
     }
 }


### PR DESCRIPTION
Adds to `forklaunch compliance audit` the check that would have caught the bug which took forklaunch-platform's production sign-up down today.

## Why this belongs here

`checks.rs` already tests the shape *"you declared X but didn't wire the thing that makes X work"*:

- tenant filters and RLS in every runtime entrypoint
- `RetentionService` when entities declare retention policies
- `ComplianceDataService` when entities hold classified data

This is the same shape: **entities declare encrypted fields, and Better Auth is handed an ORM that can't decrypt them.**

## The failure it catches

Better Auth owns `/api/auth/*` and reads through whatever ORM it was constructed with. When that's the raw ORM while the service's own EntityManager goes through `wrapEmWithTenantContext`, the two sides derive different keys — `FieldEncryptor` derives per tenant via HKDF, Better Auth reads with no tenant. Rows written under the tenant key, read back under the empty one:

```
Decryption failed: ciphertext is corrupted or the wrong key was used
```

Three properties make this worth a static check rather than trusting tests:

1. It surfaces as a **500 with nothing in the logs**, because Better Auth swallows its own errors.
2. It's **invisible in a single-tenant deployment** — both sides agree on the empty context.
3. It therefore appears the first time a tenant id is used, long after the code was written.

The check fires when a project has entities classified other than `none` **and** wires Better Auth without an encryption-aware ORM.

## Dogfooding caught a false positive

The first version searched `registrations.ts`, like the checks around it. Run against the real repositories it flagged **forklaunch-platform, which is correctly wired** — the platform applies its proxy inside `auth.ts:807` while passing `orm: Orm` at the registration site; the blueprint wraps at the registration site itself. Both layouts are legitimate, so the check now reads `registrations.ts` and `auth.ts` together. There's a test pinning that exact false positive.

## Verified against real code, not only fixtures

| target | flagged | correct? |
|---|---|---|
| `blueprint/iam-better-auth` **before** the fix | yes | ✅ catches the real bug |
| `blueprint/iam-better-auth` **after** the fix | no | ✅ no false positive |
| `forklaunch-platform` `src/modules/iam` | no | ✅ recognises the other layout |

## Verification

- **13 tests pass** — four new unit tests, two new filesystem-level tests exercising `run_local_checks` end to end
- `cargo build --release`: clean, **no new warnings**
- Only `cli/src/compliance/checks.rs` is touched. `cargo fmt` wanted to reformat 620 pre-existing diffs across the crate; I reverted all of them and confirmed my file needs none.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forklaunch/codesmith/forklaunch/pr/301"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790645050&installation_model_id=434648&pr_number=301&repository=forklaunch%2Fforklaunch&return_to=https%3A%2F%2Fgithub.com%2Fforklaunch%2Fforklaunch%2Fpull%2F301&signature=bfa5c3d949da281b8baa6920dad8b0da8016445f41f0fb37d87b82e4726d1b92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a compliance check for Better Auth encryption contexts.
  * Projects with classified entity fields now receive a warning when Better Auth uses an unwrapped ORM.
  * Recognizes supported encryption-aware wrappers and configurations across registration and authentication setups.
* **Bug Fixes**
  * Improved detection for wrapped, proxy-wrapped, and missing Better Auth configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->