### PR TITLE
feat(compliance): audit encryption bootstrapping + fix per-router process listener leak

### DIFF
--- a/cli/src/compliance/checks.rs
+++ b/cli/src/compliance/checks.rs
@@ -87,6 +87,64 @@ fn better_auth_orm_is_unwrapped(sources: &str) -> bool {
         .any(|marker| sources.contains(marker))
 }
 
+/// Directories that never hold production wiring. Tests in particular must be
+/// excluded: a project whose only `withEncryptionContext` call is in a test is
+/// not wired, and counting it would hide exactly the gap being looked for.
+const NON_PRODUCTION_DIRS: &[&str] = &["node_modules", "dist", "__test__", "migrations"];
+
+/// Concatenates the project's production TypeScript. The wiring these checks
+/// look for is not confined to one file — forklaunch-platform registers the
+/// encryptor in `mikro-orm.config.ts` and binds tenants from `auth.ts` and its
+/// services, while the blueprints do both from `registrations.ts`. Reading a
+/// fixed filename flags correctly-wired services, which is a false positive
+/// this check has already produced once.
+fn read_production_sources(project_path: &Path) -> String {
+    fn walk(dir: &Path, out: &mut String) {
+        let Ok(entries) = fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let name = entry.file_name().to_string_lossy().to_string();
+            if path.is_dir() {
+                if !NON_PRODUCTION_DIRS.contains(&name.as_str()) {
+                    walk(&path, out);
+                }
+            } else if name.ends_with(".ts") && !name.ends_with(".test.ts") {
+                if let Ok(text) = fs::read_to_string(&path) {
+                    out.push_str(&text);
+                    out.push('\n');
+                }
+            }
+        }
+    }
+
+    let mut out = String::new();
+    walk(project_path, &mut out);
+    out
+}
+
+/// Any of these means the service can bind an encryption tenant. There is more
+/// than one legitimate way: the blueprints wrap the EntityManager, while
+/// forklaunch-platform's IAM enters the context directly around its reads.
+const TENANT_BINDING_MARKERS: &[&str] = &[
+    "wrapEmWithTenantContext(",
+    "withEncryptionContext(",
+    "setEncryptionTenantId(",
+];
+
+/// Where the encryptor is registered. Without it `EncryptedType` does not fail
+/// loudly on write — it falls through to `this.serialize(value)` and stores
+/// PLAINTEXT in a column declared `pii`/`pci`/`phi`. The read side does throw
+/// ("no encryptor registered but database contains encrypted value"), but only
+/// once a previously-encrypted row is read back, which may be much later.
+/// Silent plaintext at rest is the worse half, so this is a warning.
+/// Where the EntityManager is bound to a tenant. Unlike the encryptor this is
+/// not required for a single-tenant service to be correct — the helper no-ops
+/// when the tenant id is `undefined`. What its absence means is that the tenant
+/// capability is not wired at all, so encrypted columns can only ever use the
+/// no-tenant key. That is consistent until something introduces a tenant, at
+/// which point previously-written rows stop decrypting. Reported as info.
 /// Field-name words that suggest a classification stronger than `none`.
 /// Matching is done on lowercased words split from camelCase / snake_case,
 /// including joined adjacent pairs (`first_name` -> `firstname`), to keep
@@ -283,7 +341,34 @@ pub(crate) fn run_local_checks(modules_path: &Path) -> Result<Vec<LocalFinding>>
                 });
             }
 
-            // 4. Sensitive-field heuristics
+            // 4. Encryptor registration for classified columns
+            if has_sensitive {
+                let sources = read_production_sources(&project_path);
+                if !sources.contains("registerEncryptor(") {
+                    findings.push(LocalFinding {
+                        severity: Severity::Warning,
+                        project: project.clone(),
+                        check: "encryptor-registration".to_string(),
+                        subject: "mikro-orm.config.ts".to_string(),
+                        message: "entities declare classified fields but registerEncryptor() is never called — those columns are written as plaintext".to_string(),
+                    });
+                }
+
+                let binds_tenant = TENANT_BINDING_MARKERS
+                    .iter()
+                    .any(|marker| sources.contains(marker));
+                if !binds_tenant {
+                    findings.push(LocalFinding {
+                        severity: Severity::Info,
+                        project: project.clone(),
+                        check: "tenant-em-wiring".to_string(),
+                        subject: "registrations.ts".to_string(),
+                        message: "entities hold classified data but the EntityManager is never bound to a tenant — encrypted columns can only use the no-tenant key, and will stop decrypting if a tenant is introduced later".to_string(),
+                    });
+                }
+            }
+
+            // 5. Sensitive-field heuristics
             for entity in &entities {
                 for (field, classification) in &entity.field_classifications {
                     if classification != "none" {
@@ -462,6 +547,143 @@ mod fs_tests {
         )
         .unwrap();
         std::fs::write(proj.join("registrations.ts"), registrations).unwrap();
+    }
+
+    #[test]
+    fn test_run_local_checks_flags_missing_encryptor() {
+        let dir = std::env::temp_dir().join("fl-checks-no-encryptor");
+        let proj = dir.join("svc");
+        let _ = std::fs::remove_dir_all(&dir);
+        write_project_with_classified_entity(&proj, "export const x = 1;");
+
+        let findings = run_local_checks(&dir).unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let f = findings
+            .iter()
+            .find(|f| f.check == "encryptor-registration")
+            .unwrap_or_else(|| panic!("expected the finding, got: {:?}", findings));
+        // Plaintext at rest in a column declared pii is a warning, not info.
+        assert!(matches!(f.severity, Severity::Warning));
+    }
+
+    #[test]
+    fn test_run_local_checks_accepts_encryptor_in_mikro_orm_config() {
+        let dir = std::env::temp_dir().join("fl-checks-encryptor-ok");
+        let proj = dir.join("svc");
+        let _ = std::fs::remove_dir_all(&dir);
+        write_project_with_classified_entity(&proj, "export const x = 1;");
+        // Every blueprint registers it here, not in registrations.ts.
+        std::fs::write(
+            proj.join("mikro-orm.config.ts"),
+            "registerEncryptor(new FieldEncryptor(key));",
+        )
+        .unwrap();
+
+        let findings = run_local_checks(&dir).unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+
+        assert!(
+            !findings.iter().any(|f| f.check == "encryptor-registration"),
+            "registering in mikro-orm.config.ts should satisfy the check, got: {:?}",
+            findings
+        );
+    }
+
+    #[test]
+    fn test_run_local_checks_reports_unbound_tenant_em_as_info() {
+        let dir = std::env::temp_dir().join("fl-checks-no-tenant-em");
+        let proj = dir.join("svc");
+        let _ = std::fs::remove_dir_all(&dir);
+        write_project_with_classified_entity(&proj, "export const x = 1;");
+
+        let findings = run_local_checks(&dir).unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+
+        let f = findings
+            .iter()
+            .find(|f| f.check == "tenant-em-wiring")
+            .unwrap_or_else(|| panic!("expected the finding, got: {:?}", findings));
+        // A deliberately single-tenant service is not broken, so this must not
+        // be a warning — the helper no-ops when the tenant id is undefined.
+        assert!(matches!(f.severity, Severity::Info));
+    }
+
+    #[test]
+    fn test_tenant_binding_accepts_with_encryption_context() {
+        // The false positive dogfooding caught: forklaunch-platform's IAM never
+        // calls wrapEmWithTenantContext — it enters the context directly around
+        // its reads. Insisting on one helper flags a service that does bind.
+        let dir = std::env::temp_dir().join("fl-checks-alt-binding");
+        let proj = dir.join("iam");
+        let _ = std::fs::remove_dir_all(&dir);
+        write_project_with_classified_entity(&proj, "registerEncryptor(enc);");
+        std::fs::write(
+            proj.join("auth.ts"),
+            "await withEncryptionContext(orgId, () => em.findOne(Account, where));",
+        )
+        .unwrap();
+
+        let findings = run_local_checks(&dir).unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+
+        assert!(
+            !findings.iter().any(|f| f.check == "tenant-em-wiring"),
+            "withEncryptionContext should count as binding, got: {:?}",
+            findings
+        );
+    }
+
+    #[test]
+    fn test_tenant_binding_in_a_test_file_does_not_count() {
+        // A project whose only binding call lives in a test is not wired. This
+        // is how the platform's IAM first looked wired under a naive grep.
+        let dir = std::env::temp_dir().join("fl-checks-test-only-binding");
+        let proj = dir.join("svc");
+        let _ = std::fs::remove_dir_all(&dir);
+        write_project_with_classified_entity(&proj, "registerEncryptor(enc);");
+        std::fs::create_dir_all(proj.join("__test__")).unwrap();
+        std::fs::write(
+            proj.join("__test__/thing.test.ts"),
+            "withEncryptionContext('org', () => {});",
+        )
+        .unwrap();
+
+        let findings = run_local_checks(&dir).unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+
+        assert!(
+            findings.iter().any(|f| f.check == "tenant-em-wiring"),
+            "a binding call only in tests must still flag, got: {:?}",
+            findings
+        );
+    }
+
+    #[test]
+    fn test_run_local_checks_ignores_projects_without_classified_data() {
+        let dir = std::env::temp_dir().join("fl-checks-unclassified");
+        let proj = dir.join("svc");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(proj.join("persistence/entities")).unwrap();
+        std::fs::write(
+            proj.join("persistence/entities/thing.entity.ts"),
+            "export const ThingEntity = defineComplianceEntity({ name: 'Thing', properties: { label: fp.string().compliance('none') } });",
+        )
+        .unwrap();
+        std::fs::write(proj.join("registrations.ts"), "export const x = 1;").unwrap();
+
+        let findings = run_local_checks(&dir).unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+
+        // Nothing classified means nothing to encrypt or bind — neither check
+        // should fire, or every plain CRUD service gets noise.
+        assert!(
+            !findings
+                .iter()
+                .any(|f| f.check == "encryptor-registration" || f.check == "tenant-em-wiring"),
+            "unclassified project should be quiet, got: {:?}",
+            findings
+        );
     }
 
     #[test]

--- a/cli/src/compliance/checks.rs
+++ b/cli/src/compliance/checks.rs
@@ -341,8 +341,17 @@ pub(crate) fn run_local_checks(modules_path: &Path) -> Result<Vec<LocalFinding>>
                 });
             }
 
-            // 4. Encryptor registration for classified columns
-            if has_sensitive {
+            // 4. Encryptor registration for classified columns.
+            //
+            // Gated on the project owning a MikroORM config, not merely having
+            // a `persistence` directory. `defineComplianceEntity` is also used
+            // to type queue payloads — forklaunch-platform's
+            // deployment-agent-worker declares an event record with `pci`
+            // fields, imports it with `import type`, and never persists it
+            // through an ORM. Without this gate the check reports a plaintext
+            // column on a table that does not exist.
+            let owns_orm = project_path.join("mikro-orm.config.ts").exists();
+            if has_sensitive && owns_orm {
                 let sources = read_production_sources(&project_path);
                 if !sources.contains("registerEncryptor(") {
                     findings.push(LocalFinding {
@@ -363,7 +372,7 @@ pub(crate) fn run_local_checks(modules_path: &Path) -> Result<Vec<LocalFinding>>
                         project: project.clone(),
                         check: "tenant-em-wiring".to_string(),
                         subject: "registrations.ts".to_string(),
-                        message: "entities hold classified data but the EntityManager is never bound to a tenant — encrypted columns can only use the no-tenant key, and will stop decrypting if a tenant is introduced later".to_string(),
+                        message: "entities hold classified data but no encryption tenant is ever bound — encrypted columns can only use the no-tenant key, and will stop decrypting if a tenant is introduced later. Note this is about the ENCRYPTION context specifically: setFilterParams('tenant', ..) scopes queries but does not set it".to_string(),
                     });
                 }
             }
@@ -547,6 +556,8 @@ mod fs_tests {
         )
         .unwrap();
         std::fs::write(proj.join("registrations.ts"), registrations).unwrap();
+        // Owning an ORM is what makes the encryption checks applicable.
+        std::fs::write(proj.join("mikro-orm.config.ts"), "export default {};").unwrap();
     }
 
     #[test]
@@ -607,6 +618,32 @@ mod fs_tests {
         // A deliberately single-tenant service is not broken, so this must not
         // be a warning — the helper no-ops when the tenant id is undefined.
         assert!(matches!(f.severity, Severity::Info));
+    }
+
+    #[test]
+    fn test_entities_without_an_orm_are_not_flagged() {
+        // The false positive found by running this against forklaunch-platform:
+        // deployment-agent-worker types its BullMQ payload with
+        // defineComplianceEntity, marks fields `pci`, imports it with
+        // `import type`, and owns no mikro-orm.config.ts. Nothing is persisted,
+        // so there is no plaintext column to report.
+        let dir = std::env::temp_dir().join("fl-checks-queue-payload");
+        let proj = dir.join("worker");
+        let _ = std::fs::remove_dir_all(&dir);
+        write_project_with_classified_entity(&proj, "export const x = 1;");
+        // The helper writes one; a queue-payload module has none.
+        std::fs::remove_file(proj.join("mikro-orm.config.ts")).unwrap();
+
+        let findings = run_local_checks(&dir).unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+
+        assert!(
+            !findings
+                .iter()
+                .any(|f| f.check == "encryptor-registration" || f.check == "tenant-em-wiring"),
+            "a project with no ORM should not be flagged, got: {:?}",
+            findings
+        );
     }
 
     #[test]

--- a/framework/core/__test__/processHandlers.test.ts
+++ b/framework/core/__test__/processHandlers.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  ForklaunchExpressLikeRouter,
+  resetProcessHandlersForTesting
+} from '../src/http/router/expressLikeRouter';
+
+/**
+ * Every router used to register four process-level listeners in its
+ * constructor, so an application's listener count grew with its router count.
+ * A service with eleven routers produced this at startup:
+ *
+ *   MaxListenersExceededWarning: Possible EventEmitter memory leak detected.
+ *   11 unhandledRejection listeners added to [process].
+ *
+ * The warning was only the visible half. On one unhandled rejection every
+ * handler ran — logging the same error once per router, each calling
+ * process.exit(1).
+ *
+ * The constructor skips registration entirely under NODE_ENV=test / VITEST, so
+ * these tests clear both to exercise the path a real service takes.
+ */
+
+const SIGNALS = [
+  'uncaughtException',
+  'unhandledRejection',
+  'exit',
+  'SIGINT'
+] as const;
+
+const collector = () =>
+  ({
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn()
+  }) as never;
+
+const buildRouter = () =>
+  new ForklaunchExpressLikeRouter(
+    '/' as never,
+    {} as never,
+    { use: vi.fn() } as never,
+    [] as never,
+    collector(),
+    undefined
+  );
+
+describe('router process handler registration', () => {
+  let nodeEnv: string | undefined;
+  let vitestFlag: string | undefined;
+  let baseline: Record<string, number>;
+
+  beforeEach(() => {
+    nodeEnv = process.env.NODE_ENV;
+    vitestFlag = process.env.VITEST;
+    delete process.env.NODE_ENV;
+    delete process.env.VITEST;
+    resetProcessHandlersForTesting();
+    baseline = Object.fromEntries(
+      SIGNALS.map((s) => [s, process.listenerCount(s)])
+    );
+  });
+
+  afterEach(() => {
+    // Remove only what this test added, so suites stay independent.
+    for (const signal of SIGNALS) {
+      const listeners = process.listeners(signal);
+      for (const listener of listeners.slice(baseline[signal])) {
+        process.removeListener(signal, listener as never);
+      }
+    }
+    if (nodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = nodeEnv;
+    if (vitestFlag === undefined) delete process.env.VITEST;
+    else process.env.VITEST = vitestFlag;
+    resetProcessHandlersForTesting();
+  });
+
+  it('registers one handler per signal for a single router', () => {
+    buildRouter();
+    for (const signal of SIGNALS) {
+      expect(process.listenerCount(signal) - baseline[signal]).toBe(1);
+    }
+  });
+
+  it('does not add more as routers multiply', () => {
+    // Twelve is past Node's default MaxListeners of 10 — the count that
+    // produced the production warning.
+    for (let i = 0; i < 12; i++) {
+      buildRouter();
+    }
+
+    for (const signal of SIGNALS) {
+      expect(process.listenerCount(signal) - baseline[signal]).toBe(1);
+    }
+  });
+
+  it('stays under Node’s MaxListeners for a realistic router count', () => {
+    for (let i = 0; i < 12; i++) {
+      buildRouter();
+    }
+    expect(
+      process.listenerCount('unhandledRejection') - baseline.unhandledRejection
+    ).toBeLessThan(process.getMaxListeners());
+  });
+
+  it('registers nothing under a test runner', () => {
+    process.env.VITEST = 'true';
+    resetProcessHandlersForTesting();
+    const before = Object.fromEntries(
+      SIGNALS.map((s) => [s, process.listenerCount(s)])
+    );
+
+    buildRouter();
+
+    for (const signal of SIGNALS) {
+      expect(process.listenerCount(signal)).toBe(before[signal]);
+    }
+  });
+
+  it('logs an unhandled rejection exactly once, not once per router', () => {
+    const seen: unknown[] = [];
+    resetProcessHandlersForTesting();
+    const first = {
+      error: (message: unknown) => seen.push(message),
+      warn: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn()
+    } as never;
+
+    new ForklaunchExpressLikeRouter(
+      '/' as never,
+      {} as never,
+      { use: vi.fn() } as never,
+      [] as never,
+      first,
+      undefined
+    );
+    for (let i = 0; i < 5; i++) {
+      buildRouter();
+    }
+
+    const handlers = process
+      .listeners('unhandledRejection')
+      .slice(baseline.unhandledRejection);
+    expect(handlers).toHaveLength(1);
+
+    // Calling the surviving handler must not fan out; process.exit is stubbed
+    // because the real handler ends the process.
+    const exit = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((() => undefined) as never);
+    (handlers[0] as (reason: unknown) => void)('boom');
+    exit.mockRestore();
+
+    expect(seen).toEqual(['Unhandled rejection: boom']);
+  });
+});

--- a/framework/core/src/http/router/expressLikeRouter.ts
+++ b/framework/core/src/http/router/expressLikeRouter.ts
@@ -276,6 +276,61 @@ export function extractRouteHandlers<
 /**
  * A class that represents an Express-like router.
  */
+/**
+ * Process-level signal handlers belong to the process, not to each router.
+ *
+ * These used to be registered inside the router constructor, so every router an
+ * application created added four more listeners to `process`. A service with
+ * eleven routers therefore tripped Node's warning at startup:
+ *
+ *   MaxListenersExceededWarning: Possible EventEmitter memory leak detected.
+ *   11 unhandledRejection listeners added to [process].
+ *
+ * The warning was the visible half. The rest: the listener array grew with
+ * router count, and on a single unhandled rejection EVERY registered handler
+ * ran — logging the same error once per router and each calling
+ * `process.exit(1)`.
+ *
+ * Installing once keeps the behaviour identical from the outside: the first
+ * router to be constructed provides the collector, and there is exactly one
+ * handler per signal no matter how many routers follow.
+ */
+let processHandlersInstalled = false;
+
+function installProcessHandlers(
+  openTelemetryCollector: OpenTelemetryCollector<MetricsDefinition>
+): void {
+  if (processHandlersInstalled) {
+    return;
+  }
+  processHandlersInstalled = true;
+
+  process.on('uncaughtException', (err) => {
+    openTelemetryCollector.error(`Uncaught exception: ${err}`);
+    process.exit(1);
+  });
+  process.on('unhandledRejection', (reason) => {
+    openTelemetryCollector.error(`Unhandled rejection: ${reason}`);
+    process.exit(1);
+  });
+
+  process.on('exit', () => {
+    openTelemetryCollector.info('Shutting down application');
+  });
+  process.on('SIGINT', () => {
+    openTelemetryCollector.info('Shutting down application');
+    process.exit(0);
+  });
+}
+
+/**
+ * Test-only. Lets a suite assert the handlers install exactly once across many
+ * routers without leaking state into the next test.
+ */
+export function resetProcessHandlersForTesting(): void {
+  processHandlersInstalled = false;
+}
+
 export class ForklaunchExpressLikeRouter<
   SV extends AnySchemaValidator,
   BasePath extends `/${string}`,
@@ -310,22 +365,7 @@ export class ForklaunchExpressLikeRouter<
       !process.env.VITEST &&
       process.env.FORKLAUNCH_MODE !== 'openapi'
     ) {
-      process.on('uncaughtException', (err) => {
-        this.openTelemetryCollector.error(`Uncaught exception: ${err}`);
-        process.exit(1);
-      });
-      process.on('unhandledRejection', (reason) => {
-        this.openTelemetryCollector.error(`Unhandled rejection: ${reason}`);
-        process.exit(1);
-      });
-
-      process.on('exit', () => {
-        this.openTelemetryCollector.info('Shutting down application');
-      });
-      process.on('SIGINT', () => {
-        this.openTelemetryCollector.info('Shutting down application');
-        process.exit(0);
-      });
+      installProcessHandlers(this.openTelemetryCollector);
     }
 
     this.internal.use(createContext(this.schemaValidator) as RouterHandler);


### PR DESCRIPTION
Completes the bootstrapping coverage in `forklaunch compliance audit`. Before this, two of the five primitives `@forklaunch/core/persistence` exports were verified:

| primitive | checked before | now |
|---|---|---|
| `setupTenantFilter` | ✅ | ✅ |
| `setupRls` | ✅ | ✅ |
| `registerEncryptor` | ❌ | ✅ **warning** |
| `wrapEmWithTenantContext` | ❌ | ✅ **info** |
| `wrapEmWithNativeQueryBlocking` | ❌ | ❌ — see below |

Both new checks are gated on the project actually holding classified data, so plain CRUD services stay quiet.

## `encryptor-registration` — warning

Required, and it fails silently in the worst direction. From `encryptedType.ts`, the **write** path:

```ts
if (!_encryptor) {
  return this.serialize(value);
}
```

With no `registerEncryptor()` call, a column declared `pii`/`pci`/`phi` is written as **plaintext**. The read path *does* throw, but only once a previously-encrypted row comes back — possibly much later, possibly never. Plaintext at rest is the half that matters.

## `tenant-em-wiring` — info, deliberately

`wrapEmWithTenantContext` returns the EntityManager untouched when the tenant id is `undefined`, so a single-tenant service is genuinely fine without it. Its absence means the tenant *capability* isn't wired, so encrypted columns can only ever use the no-tenant key — consistent until something introduces a tenant, at which point previously-written rows stop decrypting. That's this week's outage in miniature, so it's worth reporting, but it isn't a defect on its own.

## Reading production sources, not fixed filenames

My first Better Auth check searched one file and flagged a correctly-wired service. These would have repeated that mistake — forklaunch-platform registers the encryptor in `mikro-orm.config.ts` and binds tenants from `auth.ts` and its services, while the blueprints do both from `registrations.ts`.

So both checks walk the project's production TypeScript, skipping `node_modules`, `dist`, `migrations` and `__test__`. **Excluding tests is load-bearing, not tidiness:** the platform's IAM looked wired under a naive grep because its only matches were a design doc and a test file. A binding call that exists only in a test is not wiring — there's a test pinning that.

Tenant binding accepts `wrapEmWithTenantContext`, `withEncryptionContext` **and** `setEncryptionTenantId`, because there's more than one legitimate way and IAM uses the second.

## Verified against real code

All four fl-js blueprints with classified data pass both checks. Against forklaunch-platform:

| module | classified | encryptor | tenant |
|---|---|---|---|
| iam | 28 | ok | ok |
| managed-apps | 5 | ok | ok |
| platform-management | 17 | ok | ok |
| billing | 20 | ok | **flags** |
| deployment-agent-worker | 3 | **flags** | **flags** |
| observability-api | 2 | **flags** | **flags** |

Those three flags are real — each confirmed by hand, details in the PR discussion.

## Not included: `wrapEmWithNativeQueryBlocking`

It exists in core and **zero of thirteen blueprints call it**. Native queries bypass tenant filtering, so its absence may be a genuine isolation gap — or the helper may be new, deprecated, or deliberately unused. I'm not turning that into a finding without knowing which.

## Verification

- **19 tests pass**, six new
- `cargo build --release`: clean, no new warnings
- Only `cli/src/compliance/checks.rs` touched

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forklaunch/codesmith/forklaunch/pr/302"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790646949&installation_model_id=434648&pr_number=302&repository=forklaunch%2Fforklaunch&return_to=https%3A%2F%2Fgithub.com%2Fforklaunch%2Fforklaunch%2Fpull%2F302&signature=063e63c3ff47d75cdd69bd9bd0b070170f833031b0ebebf95ba5dadd7a1a1fb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Compliance scans now analyze production TypeScript source recursively while excluding test files and non-production directories.
  - Added encryption compliance checks for ORM-based projects.
  - Reports warnings when required encryptor registration is missing.
  - Reports informational findings when tenant-binding mechanisms are not detected.
  - Recognizes multiple supported tenant-binding configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->