### PR TITLE
feat(core,cli): degrade unreadable encrypted columns instead of 500ing

### DIFF
--- a/cli/src/compliance/checks.rs
+++ b/cli/src/compliance/checks.rs
@@ -133,6 +133,22 @@ const TENANT_BINDING_MARKERS: &[&str] = &[
     "setEncryptionTenantId(",
 ];
 
+/// An EntityManager factory that sets the tenant QUERY FILTER but never the
+/// tenant ENCRYPTION context.
+///
+/// `wrapEmWithTenantContext(em, tenantId)` does three things: sets the filter
+/// params, sets the encryption tenant, and wraps the EM so the context survives
+/// the pg connection pool. A factory that only calls `setFilterParams('tenant',
+/// ..)` does the first and skips the rest, so every call site that passes a
+/// tenant id gets row filtering, reasonably believes it is tenant-scoped, and
+/// still decrypts with the no-tenant key.
+///
+/// Not hypothetical: it took down sign-up, the onboarding /me call and an
+/// invitation lookup in one week on a service whose factory had drifted this
+/// way, while the generated blueprints — which all use the helper — were fine.
+const TENANT_FILTER_ONLY_MARKER: &str = "setFilterParams('tenant'";
+const TENANT_CONTEXT_HELPER: &str = "wrapEmWithTenantContext(";
+
 /// Where the encryptor is registered. Without it `EncryptedType` does not fail
 /// loudly on write — it falls through to `this.serialize(value)` and stores
 /// PLAINTEXT in a column declared `pii`/`pci`/`phi`. The read side does throw
@@ -373,6 +389,21 @@ pub(crate) fn run_local_checks(modules_path: &Path) -> Result<Vec<LocalFinding>>
                         check: "tenant-em-wiring".to_string(),
                         subject: "registrations.ts".to_string(),
                         message: "entities hold classified data but no encryption tenant is ever bound — encrypted columns can only use the no-tenant key, and will stop decrypting if a tenant is introduced later. Note this is about the ENCRYPTION context specifically: setFilterParams('tenant', ..) scopes queries but does not set it".to_string(),
+                    });
+                }
+
+                // The factory binds the tenant FILTER but not the tenant
+                // ENCRYPTION context — the divergence that makes every later
+                // read in the service fragile.
+                if sources.contains(TENANT_FILTER_ONLY_MARKER)
+                    && !sources.contains(TENANT_CONTEXT_HELPER)
+                {
+                    findings.push(LocalFinding {
+                        severity: Severity::Warning,
+                        project: project.clone(),
+                        check: "tenant-context-half-wired".to_string(),
+                        subject: "registrations.ts".to_string(),
+                        message: "the EntityManager factory calls setFilterParams('tenant', ..) but never wrapEmWithTenantContext — callers get row filtering and believe they are tenant-scoped, while encrypted columns still decrypt with the no-tenant key".to_string(),
                     });
                 }
             }
@@ -618,6 +649,54 @@ mod fs_tests {
         // A deliberately single-tenant service is not broken, so this must not
         // be a warning — the helper no-ops when the tenant id is undefined.
         assert!(matches!(f.severity, Severity::Info));
+    }
+
+    #[test]
+    fn test_flags_factory_that_filters_without_binding_encryption() {
+        // The exact drift that took down sign-up, /me and an invitation lookup
+        // in one week: filter params set, encryption tenant never bound.
+        let dir = std::env::temp_dir().join("fl-checks-half-wired");
+        let proj = dir.join("iam");
+        let _ = std::fs::remove_dir_all(&dir);
+        write_project_with_classified_entity(
+            &proj,
+            "registerEncryptor(enc); em.setFilterParams('tenant', { tenantId });",
+        );
+
+        let findings = run_local_checks(&dir).unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+
+        assert!(
+            findings
+                .iter()
+                .any(|f| f.check == "tenant-context-half-wired"),
+            "expected the half-wired finding, got: {:?}",
+            findings
+        );
+    }
+
+    #[test]
+    fn test_factory_using_the_helper_is_not_flagged() {
+        // What every generated blueprint does, and what the drifted services
+        // should return to. Both markers present must NOT flag.
+        let dir = std::env::temp_dir().join("fl-checks-fully-wired");
+        let proj = dir.join("iam");
+        let _ = std::fs::remove_dir_all(&dir);
+        write_project_with_classified_entity(
+            &proj,
+            "registerEncryptor(enc); wrapEmWithTenantContext(Orm.em.fork(), context?.tenantId);",
+        );
+
+        let findings = run_local_checks(&dir).unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+
+        assert!(
+            !findings
+                .iter()
+                .any(|f| f.check == "tenant-context-half-wired"),
+            "a factory using the helper must not be flagged, got: {:?}",
+            findings
+        );
     }
 
     #[test]

--- a/framework/core/__test__/forgivingDecryptionEm.test.ts
+++ b/framework/core/__test__/forgivingDecryptionEm.test.ts
@@ -1,0 +1,206 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { registerEntityCompliance } from '../src/persistence/complianceTypes';
+import { wrapEmWithForgivingDecryption } from '../src/persistence/forgivingDecryptionEm';
+
+/**
+ * The failure being softened: reading an entity whose encrypted columns were
+ * written under a different tenant throws, and the endpoint 500s. Three
+ * separate endpoints hit it in one week because the mistake is invisible until
+ * a tenant id is actually in play.
+ *
+ * The retry re-issues the read with the encrypted columns excluded, rather than
+ * nulling them during hydration. That distinction is not cosmetic: returning
+ * `undefined` from the Type was measured against a real database to write NULL
+ * over the ciphertext on the next flush, because MikroORM treats a hydrated
+ * `undefined` as the loaded value. A `fields` selection is never hydrated at
+ * all, so the column is excluded from the UPDATE.
+ */
+
+const DECRYPT_ERROR = new Error(
+  'Failed to decrypt encrypted column value: Decryption failed: ciphertext is corrupted or the wrong key was used'
+);
+
+const logger = () => ({ warn: vi.fn() });
+
+/** An EM that fails a full read and succeeds once given a `fields` selection. */
+const buildEm = (opts: { failWithout?: boolean } = { failWithout: true }) => {
+  const calls: { method: string; options?: Record<string, unknown> }[] = [];
+  const make =
+    (method: string) =>
+    async (
+      _entity: unknown,
+      _where: unknown,
+      options?: Record<string, unknown>
+    ) => {
+      calls.push({ method, options });
+      if (opts.failWithout && !options?.fields) throw DECRYPT_ERROR;
+      return { id: 'row-1', organization: 'org-1' };
+    };
+
+  return {
+    calls,
+    em: {
+      findOne: vi.fn(make('findOne')),
+      find: vi.fn(make('find')),
+      findOneOrFail: vi.fn(make('findOneOrFail')),
+      findAll: vi.fn(make('findAll')),
+      findAndCount: vi.fn(make('findAndCount')),
+      flush: vi.fn(async () => undefined),
+      persist: vi.fn(),
+      getMetadata: () => ({
+        find: (_n: string) => ({
+          props: {
+            id: {},
+            organization: {},
+            memberEmail: {},
+            memberName: {}
+          }
+        })
+      })
+    }
+  };
+};
+
+beforeEach(() => {
+  registerEntityCompliance(
+    'Membership',
+    new Map([
+      ['id', 'none'],
+      ['organization', 'none'],
+      ['memberEmail', 'pii'],
+      ['memberName', 'pii']
+    ])
+  );
+});
+
+describe('wrapEmWithForgivingDecryption', () => {
+  it('retries without the encrypted columns instead of throwing', async () => {
+    const { em, calls } = buildEm();
+    const log = logger();
+    const wrapped = wrapEmWithForgivingDecryption(em, log);
+
+    const row = await wrapped.findOne('Membership', { id: 'row-1' });
+
+    expect(row).toEqual({ id: 'row-1', organization: 'org-1' });
+    expect(calls).toHaveLength(2);
+    expect(calls[0].options?.fields).toBeUndefined();
+    // The retry must select the complement, never the encrypted columns.
+    expect(calls[1].options?.fields).toEqual(['id', 'organization']);
+  });
+
+  it('never selects an encrypted column on the retry', async () => {
+    const { em, calls } = buildEm();
+    const wrapped = wrapEmWithForgivingDecryption(em, logger());
+
+    await wrapped.findOne('Membership', { id: 'row-1' });
+
+    const fields = calls[1].options?.fields as string[];
+    expect(fields).not.toContain('memberEmail');
+    expect(fields).not.toContain('memberName');
+  });
+
+  it('logs a warning that names the entity, the dropped columns, and both fixes', async () => {
+    const { em } = buildEm();
+    const log = logger();
+    const wrapped = wrapEmWithForgivingDecryption(em, log);
+
+    await wrapped.findOne('Membership', { id: 'row-1' });
+
+    expect(log.warn).toHaveBeenCalledTimes(1);
+    const [message, meta] = log.warn.mock.calls[0];
+    expect(message).toContain('Membership');
+    expect(message).toContain('memberEmail');
+    // Both remedies, so the reader does not have to guess which applies.
+    expect(message).toContain('wrapEmWithTenantContext');
+    expect(message).toContain('fields');
+    // And the corruption case, which looks identical to a wrong tenant.
+    expect(message).toContain('corruption');
+    expect(meta).toMatchObject({
+      entity: 'Membership',
+      droppedColumns: ['memberEmail', 'memberName']
+    });
+  });
+
+  it('says the row was not modified, since that is the first worry on seeing this', async () => {
+    const { em } = buildEm();
+    const log = logger();
+    await wrapEmWithForgivingDecryption(em, log).findOne('Membership', {});
+    expect(log.warn.mock.calls[0][0]).toContain('NOT modified');
+  });
+
+  it.each([
+    'findOne',
+    'findOneOrFail',
+    'find',
+    'findAll',
+    'findAndCount'
+  ] as const)('covers %s', async (method) => {
+    const { em, calls } = buildEm();
+    const wrapped = wrapEmWithForgivingDecryption(em, logger());
+
+    await (
+      wrapped as unknown as Record<
+        string,
+        (...a: unknown[]) => Promise<unknown>
+      >
+    )[method]('Membership', {});
+
+    expect(calls).toHaveLength(2);
+    expect(calls[1].options?.fields).toEqual(['id', 'organization']);
+  });
+
+  it('costs nothing when the read succeeds', async () => {
+    const { em, calls } = buildEm({ failWithout: false });
+    const log = logger();
+    const wrapped = wrapEmWithForgivingDecryption(em, log);
+
+    await wrapped.findOne('Membership', {});
+
+    expect(calls).toHaveLength(1);
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it('rethrows errors that are not decryption failures', async () => {
+    const em = {
+      findOne: vi.fn(async (_entity: unknown, _where: unknown) => {
+        throw new Error('connection terminated unexpectedly');
+      }),
+      getMetadata: () => ({ find: () => ({ props: {} }) })
+    };
+    const wrapped = wrapEmWithForgivingDecryption(em, logger());
+
+    await expect(wrapped.findOne('Membership', {})).rejects.toThrow(
+      'connection terminated'
+    );
+  });
+
+  it('rethrows when the entity has no encrypted columns, since a retry would be identical', async () => {
+    registerEntityCompliance('Plain', new Map([['label', 'none']]));
+    const { em } = buildEm();
+    const wrapped = wrapEmWithForgivingDecryption(em, logger());
+
+    await expect(wrapped.findOne('Plain', {})).rejects.toThrow(
+      'Failed to decrypt'
+    );
+  });
+
+  it('passes non-read members straight through', async () => {
+    const { em } = buildEm();
+    const wrapped = wrapEmWithForgivingDecryption(em, logger());
+
+    await wrapped.flush();
+    expect(em.flush).toHaveBeenCalled();
+  });
+
+  it('preserves the caller’s other options on the retry', async () => {
+    const { em, calls } = buildEm();
+    const wrapped = wrapEmWithForgivingDecryption(em, logger());
+
+    await wrapped.findOne('Membership', {}, { orderBy: { id: 'ASC' } });
+
+    expect(calls[1].options).toMatchObject({
+      orderBy: { id: 'ASC' },
+      fields: ['id', 'organization']
+    });
+  });
+});

--- a/framework/core/src/persistence/forgivingDecryptionEm.ts
+++ b/framework/core/src/persistence/forgivingDecryptionEm.ts
@@ -1,0 +1,175 @@
+import {
+  getEntityComplianceFields,
+  type ComplianceLevel
+} from './complianceTypes';
+
+/**
+ * Turns a read that cannot decrypt into a read that returns everything it CAN
+ * decrypt, and says exactly how to fix it.
+ *
+ * Without this, a read of an entity whose encrypted columns were written under
+ * a different tenant throws:
+ *
+ *   Failed to decrypt encrypted column value: Decryption failed: ciphertext is
+ *   corrupted or the wrong key was used
+ *
+ * which surfaces as a 500. Three separate endpoints hit it in one week —
+ * sign-up, the onboarding /me call, and an invitation lookup — because the
+ * mistake is invisible until a tenant id is actually in play.
+ *
+ * ## Why this retries rather than nulling the fields
+ *
+ * The obvious implementation is for `EncryptedType.convertToJSValue` to return
+ * `undefined` instead of throwing. That DESTROYS DATA, verified against a real
+ * database: MikroORM hydrates the property as `undefined`, and the next flush
+ * of any unrelated field writes NULL over the ciphertext. A `Type` only ever
+ * sees a value — it has no handle on the entity, so it cannot mark a property
+ * as not-loaded, and anything it returns is treated as the loaded value.
+ *
+ * A `fields` selection is different: MikroORM never hydrates the omitted
+ * columns, knows they are absent, and leaves them out of the UPDATE. Also
+ * verified — the ciphertext survives a flush untouched. So the retry re-issues
+ * the same query with the encrypted columns excluded, which is the one
+ * mechanism that both degrades and preserves the data.
+ *
+ * The cost is one extra query, and only on the failing path.
+ *
+ * ## What it does not hide
+ *
+ * Genuine ciphertext corruption produces the same error as a wrong tenant —
+ * AES-GCM cannot tell them apart. Degrading silently would therefore hide real
+ * data damage, so every degraded read logs a warning naming the entity, the
+ * columns that were dropped, and the two ways to fix it properly.
+ */
+
+/** Classifications whose columns are encrypted at rest. */
+const ENCRYPTED_LEVELS: ReadonlySet<ComplianceLevel> = new Set([
+  'pii',
+  'phi',
+  'pci'
+]);
+
+/** Reads that hydrate entities, and so can hit a decryption failure. */
+const HYDRATING_READS = new Set([
+  'findOne',
+  'findOneOrFail',
+  'find',
+  'findAll',
+  'findAndCount'
+]);
+
+const isDecryptionFailure = (error: unknown): boolean =>
+  error instanceof Error &&
+  (error.message.includes('Failed to decrypt encrypted column value') ||
+    error.message.includes(
+      'Decryption failed: ciphertext is corrupted or the wrong key was used'
+    ));
+
+/** Best-effort entity name from whatever a caller passed as the first argument. */
+const resolveEntityName = (entity: unknown): string | undefined => {
+  if (typeof entity === 'string') return entity;
+  if (entity == null) return undefined;
+  if (typeof entity === 'object') {
+    const named = entity as { name?: unknown; className?: unknown };
+    if (typeof named.name === 'string') return named.name;
+    if (typeof named.className === 'string') return named.className;
+  }
+  if (typeof entity === 'function') {
+    return (entity as { name?: string }).name;
+  }
+  return undefined;
+};
+
+/** The encrypted-at-rest column names registered for an entity. */
+const encryptedColumnsOf = (entityName: string): string[] => {
+  const fields = getEntityComplianceFields(entityName);
+  if (!fields) return [];
+  return [...fields.entries()]
+    .filter(([, level]) => ENCRYPTED_LEVELS.has(level))
+    .map(([field]) => field);
+};
+
+/** Minimal logger shape, so this does not depend on the telemetry package. */
+export interface ForgivingDecryptionLogger {
+  warn(message: string, meta?: Record<string, unknown>): void;
+}
+
+const buildWarning = (
+  entityName: string,
+  dropped: string[]
+): [string, Record<string, unknown>] => [
+  `[encryption] Read of '${entityName}' could not decrypt ${dropped.length} ` +
+    `column(s) and returned without them: ${dropped.join(', ')}. ` +
+    'The row was NOT modified. Fix this properly by either (a) binding the ' +
+    'owning tenant — wrapEmWithTenantContext(em, tenantId), or withEncryptionContext(tenantId, ...) — ' +
+    'before the read, or (b) if the tenant genuinely is not known yet, because ' +
+    'this read is what discovers it, selecting only the columns you need: ' +
+    `findOne(${entityName}, where, { fields: [...] }). ` +
+    'If the tenant WAS bound correctly, this is not a context problem — ' +
+    'suspect real ciphertext corruption and investigate the row.',
+  { entity: entityName, droppedColumns: dropped }
+];
+
+/**
+ * Wraps an EntityManager so hydrating reads degrade instead of throwing.
+ *
+ * Returns a Proxy; every non-read member passes through untouched. Reads that
+ * succeed are unaffected and pay nothing.
+ */
+export function wrapEmWithForgivingDecryption<TEntityManager extends object>(
+  em: TEntityManager,
+  logger: ForgivingDecryptionLogger
+): TEntityManager {
+  return new Proxy(em, {
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver);
+
+      if (typeof prop !== 'string' || !HYDRATING_READS.has(prop)) {
+        return typeof value === 'function' ? value.bind(target) : value;
+      }
+      if (typeof value !== 'function') return value;
+
+      const read = value as (...args: unknown[]) => Promise<unknown>;
+
+      return async (...args: unknown[]) => {
+        try {
+          return await read.apply(target, args);
+        } catch (error) {
+          if (!isDecryptionFailure(error)) throw error;
+
+          const entityName = resolveEntityName(args[0]);
+          const dropped = entityName ? encryptedColumnsOf(entityName) : [];
+
+          // Nothing known to drop means the retry would be identical, so the
+          // original error is the honest outcome.
+          if (!entityName || dropped.length === 0) throw error;
+
+          const metadata = (
+            target as { getMetadata?: () => { find?: (n: string) => unknown } }
+          ).getMetadata?.();
+          const meta = metadata?.find?.(entityName) as
+            { props?: Record<string, unknown> } | undefined;
+          const allProps = meta?.props ? Object.keys(meta.props) : [];
+          const safeFields = allProps.filter((p) => !dropped.includes(p));
+
+          // Without metadata there is no way to name the complement, and a
+          // guess could omit something the caller needs. Surface the original.
+          if (safeFields.length === 0) throw error;
+
+          const [message, meta_] = buildWarning(entityName, dropped);
+          logger.warn(message, meta_);
+
+          const [entity, where, options] = args as [
+            unknown,
+            unknown,
+            Record<string, unknown> | undefined
+          ];
+          return await read.call(target, entity, where, {
+            ...(options ?? {}),
+            fields: safeFields
+          });
+        }
+      };
+    }
+  });
+}

--- a/framework/core/src/persistence/index.ts
+++ b/framework/core/src/persistence/index.ts
@@ -23,6 +23,10 @@ export {
   type SelectionAvoidsEncryptedColumns
 } from './complianceTypes';
 export {
+  wrapEmWithForgivingDecryption,
+  type ForgivingDecryptionLogger
+} from './forgivingDecryptionEm';
+export {
   asEncryptionSafe,
   type ContextFreeKeysOfSchema,
   type ContextFreeReadOptions,


### PR DESCRIPTION
## The failure

Reading an entity whose encrypted columns were written under a **different tenant** throws, and the endpoint 500s:

```
Failed to decrypt encrypted column value: Decryption failed: ciphertext is
corrupted or the wrong key was used
```

Three separate endpoints hit this in one week — sign-up, the onboarding `/me` call, and an invitation lookup. The mistake is invisible until a tenant id is actually in play, so it ships fine and fails in production.

## What this does

`wrapEmWithForgivingDecryption(em, logger)` wraps an EntityManager so the five hydrating reads (`findOne`, `findOneOrFail`, `find`, `findAll`, `findAndCount`) degrade instead of throwing: on a decryption failure it re-issues the query with the encrypted columns excluded and returns everything it *can* read.

Successful reads are untouched and pay nothing — the extra query only happens on the failing path.

## Why a retry, and not just nulling the field

The obvious implementation is for `EncryptedType.convertToJSValue` to return `undefined` instead of throwing. **That destroys data**, verified against a real database: MikroORM hydrates the property as `undefined`, and the next `flush()` of any unrelated field writes `NULL` over the ciphertext. A `Type` only ever sees a value — it has no handle on the entity, so it cannot mark a property as not-loaded, and anything it returns is treated as the loaded value.

A `fields` selection is different: the omitted columns are never hydrated, MikroORM knows they are absent, and they are excluded from the `UPDATE`. Also verified — the ciphertext survives a flush untouched.

## It does not hide corruption

AES-GCM cannot distinguish *wrong key* from *damaged ciphertext* — the two produce the same error. Degrading silently would therefore mask real data damage, so every degraded read logs a warning naming the entity, the dropped columns, and both proper fixes:

> `[encryption] Read of 'Membership' could not decrypt 2 column(s) and returned without them: memberEmail, memberName. The row was NOT modified. Fix this properly by either (a) binding the owning tenant — wrapEmWithTenantContext(em, tenantId) … or (b) if the tenant genuinely is not known yet, because this read is what discovers it, selecting only the columns you need … If the tenant WAS bound correctly, this is not a context problem — suspect real ciphertext corruption and investigate the row.`

## The audit check for the upstream cause

`tenant-context-half-wired` (Warning) catches the actual root cause: a factory that calls `setFilterParams('tenant', ..)` but never `wrapEmWithTenantContext`. That combination is the trap — callers get row filtering and reasonably conclude they are tenant-scoped, while encrypted columns still decrypt with the no-tenant key.

Dogfooded against `forklaunch-platform`, it flags exactly the three drifted services and passes the two that are wired correctly:

| module | verdict |
|---|---|
| billing | flagged |
| iam | flagged |
| observability-api | flagged |
| managed-apps | ok |
| platform-management | ok |

All nine blueprints and the CLI service template already use the helper, so none are flagged — the drift is in hand-written services, which is exactly what the check is for.

## Tests

- `framework/core/__test__/forgivingDecryptionEm.test.ts` — 14 tests: retry excludes the encrypted columns and never selects one, warning names the entity / columns / both fixes / corruption caveat, all five read methods, no cost on success, rethrows non-decryption errors and the no-encrypted-columns case, preserves the caller's other options.
- `cli` — 22 compliance-check tests (20 existing + 2 new: flags the half-wired factory, passes the helper).

Framework builds with 0 errors; blueprint builds clean; `cargo build --release` warning-free.

## Follow-up, not in this PR

Applying the wrapper to the three drifted platform services needs a published `@forklaunch/core` first, so that lands separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UDKRm9cMDurLvhvodioUnE

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forklaunch/codesmith/forklaunch/pr/307"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790828191&installation_model_id=434648&pr_number=307&repository=forklaunch%2Fforklaunch&return_to=https%3A%2F%2Fgithub.com%2Fforklaunch%2Fforklaunch%2Fpull%2F307&signature=1712f38b25a6fc0cb9bc0906f00b5106279a8b7f8d5ed33704b75b5d384cf329"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a forgiving data-read mode that retries failed reads without encrypted fields when decryption is unavailable.
  - Degraded reads now provide warning messages and remediation details while preserving normal behavior for successful reads and non-read operations.

- **Bug Fixes**
  - Unrelated errors continue to surface normally, and reads without encrypted fields are handled safely.

- **Compliance**
  - Added a warning for tenant configurations that apply tenant filters without fully establishing the tenant encryption context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->