### PR TITLE
feat(config): add `config unset`, and warn when `config set` names a variable nothing reads

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -3,6 +3,7 @@ use clap::{ArgMatches, Command};
 use pull::PullCommand;
 use push::PushCommand;
 use set::SetCommand;
+use unset::UnsetCommand;
 
 use crate::{CliCommand, core::command::command};
 
@@ -10,12 +11,14 @@ mod declared;
 mod pull;
 mod push;
 mod set;
+mod unset;
 
 #[derive(Debug)]
 pub(crate) struct ConfigCommand {
     pull: PullCommand,
     push: PushCommand,
     set: SetCommand,
+    unset: UnsetCommand,
 }
 
 impl ConfigCommand {
@@ -24,6 +27,7 @@ impl ConfigCommand {
             pull: PullCommand::new(),
             push: PushCommand::new(),
             set: SetCommand::new(),
+            unset: UnsetCommand::new(),
         }
     }
 }
@@ -32,12 +36,13 @@ impl CliCommand for ConfigCommand {
     fn command(&self) -> Command {
         command(
             "config",
-            "Pull and push environment configuration for an application",
+            "Read and write environment configuration for an application",
         )
         .subcommand_required(true)
         .subcommand(self.pull.command())
         .subcommand(self.push.command())
         .subcommand(self.set.command())
+        .subcommand(self.unset.command())
     }
 
     fn handler(&self, matches: &ArgMatches) -> Result<()> {
@@ -45,6 +50,7 @@ impl CliCommand for ConfigCommand {
             Some(("pull", matches)) => self.pull.handler(matches),
             Some(("push", matches)) => self.push.handler(matches),
             Some(("set", matches)) => self.set.handler(matches),
+            Some(("unset", matches)) => self.unset.handler(matches),
             _ => unreachable!(),
         }
     }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -6,6 +6,7 @@ use set::SetCommand;
 
 use crate::{CliCommand, core::command::command};
 
+mod declared;
 mod pull;
 mod push;
 mod set;

--- a/cli/src/config/declared.rs
+++ b/cli/src/config/declared.rs
@@ -1,0 +1,306 @@
+//! Guard against setting a variable that nothing in the application reads.
+//!
+//! The failure this exists for: three `config set` calls in a single session
+//! each stored a live credential under a name no component declares
+//! (`TWILIO_ACCOUNT_TOKEN` for `TWILIO_AUTH_TOKEN`, `TWILIO_AUTH_SID` for
+//! `TWILIO_ACCOUNT_SID`). Every one was accepted silently; the only signal was
+//! the word "Added" instead of "Updated" in the success line.
+//!
+//! Two sources are unioned to decide whether a name is known, because either
+//! one alone produces false alarms:
+//!
+//! * the config the platform just returned — it carries both the variables
+//!   that already hold values and, as bare `KEY=` lines, the required
+//!   variables from the deployed release manifest;
+//! * an AST scan of the local workspace — the same scan whose output becomes
+//!   `requiredEnvironmentVariables` in the release manifest, so it also covers
+//!   variables declared `optional(...)` that the platform does not emit.
+//!
+//! Neither source is authoritative on its own: the platform's view lags a
+//! working tree that has not been released yet, and the working tree lags a
+//! release cut from a different checkout. So an unrecognised name is reported
+//! as a warning, never as a hard failure.
+
+use std::{
+    collections::HashSet,
+    io::{IsTerminal, Write},
+    path::Path,
+};
+
+use anyhow::{Result, bail};
+use dialoguer::{Confirm, theme::ColorfulTheme};
+use termcolor::{StandardStream, WriteColor};
+
+use crate::core::{
+    ast::infrastructure::env::find_all_env_vars,
+    env::{find_workspace_root, get_modules_path, parse_env_items_from_str},
+    rendered_template::RenderedTemplatesCache,
+    string::closest_matches,
+};
+
+/// How many "did you mean" candidates to offer. Both typos from the incident
+/// sat the same edit distance from two different real names, so offering a
+/// single guess would have been a coin flip.
+const MAX_SUGGESTIONS: usize = 3;
+
+/// Every variable name appearing anywhere in `config pull` output, across all
+/// scopes. Section headers are ignored, so a name found under one service
+/// counts as known when setting it on another — a variable that exists
+/// somewhere in the application is not a typo.
+pub(crate) fn names_in_pulled_config(content: &str) -> HashSet<String> {
+    parse_env_items_from_str(content)
+        .into_iter()
+        .filter_map(|item| match item {
+            crate::core::env::EnvFileItem::KeyValue(key, _) => Some(key),
+            crate::core::env::EnvFileItem::SectionHeader(_) => None,
+        })
+        .collect()
+}
+
+/// Every variable name declared by a component in the local workspace.
+///
+/// `None` means the workspace could not be scanned — no modules directory, no
+/// `registrations.ts` anywhere, or a parse failure. That is "we cannot tell",
+/// which must never be reported as "this variable is undeclared".
+pub(crate) fn names_declared_in_workspace(app_root: &Path) -> Option<HashSet<String>> {
+    let workspace_root = find_workspace_root(app_root).ok()?;
+    let modules_path = get_modules_path(&workspace_root).ok()?;
+    let rendered_templates_cache = RenderedTemplatesCache::new();
+    let project_env_vars = find_all_env_vars(&modules_path, &rendered_templates_cache).ok()?;
+
+    if project_env_vars.is_empty() {
+        return None;
+    }
+
+    Some(
+        project_env_vars
+            .values()
+            .flatten()
+            .map(|usage| usage.var_name.clone())
+            .collect(),
+    )
+}
+
+/// Decide whether `key` is a name something is known to read, given the two
+/// sources above. `None` for `declared` means the workspace scan was
+/// unavailable, in which case only the platform's view is consulted and an
+/// unknown name is treated as known.
+pub(crate) fn is_known_name(
+    key: &str,
+    in_config: &HashSet<String>,
+    declared: Option<&HashSet<String>>,
+) -> bool {
+    if in_config.contains(key) {
+        return true;
+    }
+    match declared {
+        Some(declared) => declared.contains(key),
+        None => true,
+    }
+}
+
+/// Build the "did you mean" line from both name sources combined.
+pub(crate) fn suggestions_for(
+    key: &str,
+    in_config: &HashSet<String>,
+    declared: Option<&HashSet<String>>,
+) -> Vec<String> {
+    let mut candidates: Vec<String> = in_config
+        .iter()
+        .chain(declared.into_iter().flatten())
+        .cloned()
+        .collect();
+    candidates.sort();
+    candidates.dedup();
+
+    closest_matches(key, &candidates, MAX_SUGGESTIONS)
+}
+
+/// Format suggestions as `'A', 'B' or 'C'`.
+pub(crate) fn format_suggestions(suggestions: &[String]) -> String {
+    let quoted: Vec<String> = suggestions.iter().map(|s| format!("'{}'", s)).collect();
+    match quoted.split_last() {
+        None => String::new(),
+        Some((last, [])) => last.clone(),
+        Some((last, rest)) => format!("{} or {}", rest.join(", "), last),
+    }
+}
+
+/// Warn when `key` is a name nothing is known to read, and — on an
+/// interactive terminal without `--force` — ask before writing it.
+///
+/// Returns `Err` only when the operator declines the prompt. A scripted
+/// invocation is never blocked: it gets the warning on the way past, so
+/// existing automation keeps working.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn confirm_if_undeclared(
+    stdout: &mut StandardStream,
+    key: &str,
+    app_root: &Path,
+    pulled_config: &str,
+    environment: &str,
+    region: &str,
+    force: bool,
+) -> Result<()> {
+    let in_config = names_in_pulled_config(pulled_config);
+
+    // The workspace scan parses every TypeScript file under the modules
+    // directory, so it only runs when the cheap check has already failed.
+    if in_config.contains(key) {
+        return Ok(());
+    }
+
+    let declared = names_declared_in_workspace(app_root);
+    if is_known_name(key, &in_config, declared.as_ref()) {
+        return Ok(());
+    }
+
+    log_warn!(
+        stdout,
+        "'{}' is not declared by any component in this application, and no variable by that name exists in {} ({}).",
+        key,
+        environment,
+        region
+    );
+
+    let suggestions = suggestions_for(key, &in_config, declared.as_ref());
+    if !suggestions.is_empty() {
+        log_warn!(
+            stdout,
+            "       Did you mean {}?",
+            format_suggestions(&suggestions)
+        );
+    }
+    log_warn!(
+        stdout,
+        "       Setting it will store the value under a name nothing reads."
+    );
+
+    if force {
+        log_warn!(stdout, "       Continuing because --force was given.");
+        return Ok(());
+    }
+
+    if !std::io::stdin().is_terminal() {
+        log_warn!(
+            stdout,
+            "       Continuing: not an interactive terminal, so there is nobody to ask. Pass --force to silence this."
+        );
+        return Ok(());
+    }
+
+    let confirmed = Confirm::with_theme(&ColorfulTheme::default())
+        .with_prompt(format!("Set '{}' anyway?", key))
+        .default(false)
+        .interact()?;
+
+    if !confirmed {
+        bail!("aborted — nothing was set");
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn set_of(names: &[&str]) -> HashSet<String> {
+        names.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn test_names_in_pulled_config_collects_across_scopes() {
+        let content = "# application\n\
+                       DB_HOST=db.example.com\n\
+                       # payments (svc-123)\n\
+                       STRIPE_API_KEY=sk_live_x\n\
+                       # mailer-worker (wkr-456)\n\
+                       QUEUE_NAME=mail\n";
+
+        let names = names_in_pulled_config(content);
+        assert_eq!(names.len(), 3);
+        assert!(names.contains("DB_HOST"));
+        assert!(names.contains("STRIPE_API_KEY"));
+        assert!(names.contains("QUEUE_NAME"));
+    }
+
+    /// The platform emits declared-but-unset required variables as bare
+    /// `KEY=` lines. Those are declared names and must count as known.
+    #[test]
+    fn test_names_in_pulled_config_includes_valueless_required_vars() {
+        let content = "# application\nDB_HOST=db.example.com\nECS_AGENT_URI=\n";
+        let names = names_in_pulled_config(content);
+        assert!(names.contains("ECS_AGENT_URI"));
+    }
+
+    #[test]
+    fn test_names_in_pulled_config_ignores_headers() {
+        let names = names_in_pulled_config("# application\n# payments (svc-1)\n");
+        assert!(names.is_empty());
+    }
+
+    #[test]
+    fn test_is_known_name_from_platform_config() {
+        let in_config = set_of(&["DB_HOST"]);
+        let declared = set_of(&["REDIS_URL"]);
+        assert!(is_known_name("DB_HOST", &in_config, Some(&declared)));
+    }
+
+    #[test]
+    fn test_is_known_name_from_workspace_declaration() {
+        let in_config = set_of(&["DB_HOST"]);
+        let declared = set_of(&["REDIS_URL"]);
+        assert!(is_known_name("REDIS_URL", &in_config, Some(&declared)));
+    }
+
+    #[test]
+    fn test_unknown_name_is_flagged() {
+        let in_config = set_of(&["DB_HOST"]);
+        let declared = set_of(&["REDIS_URL"]);
+        assert!(!is_known_name(
+            "TWILIO_ACCOUNT_TOKEN",
+            &in_config,
+            Some(&declared)
+        ));
+    }
+
+    /// No workspace scan means no evidence, and no evidence must not read as
+    /// evidence of absence.
+    #[test]
+    fn test_unscannable_workspace_never_flags() {
+        let in_config = set_of(&["DB_HOST"]);
+        assert!(is_known_name("ANYTHING_AT_ALL", &in_config, None));
+    }
+
+    #[test]
+    fn test_suggestions_draw_from_both_sources() {
+        let in_config = set_of(&["TWILIO_ACCOUNT_SID"]);
+        let declared = set_of(&["TWILIO_AUTH_TOKEN"]);
+
+        let suggestions = suggestions_for("TWILIO_ACCOUNT_TOKEN", &in_config, Some(&declared));
+        assert!(suggestions.contains(&"TWILIO_ACCOUNT_SID".to_string()));
+        assert!(suggestions.contains(&"TWILIO_AUTH_TOKEN".to_string()));
+    }
+
+    #[test]
+    fn test_suggestions_are_capped() {
+        let in_config = set_of(&["DB_HOSTA", "DB_HOSTB", "DB_HOSTC", "DB_HOSTD"]);
+        let suggestions = suggestions_for("DB_HOST", &in_config, None);
+        assert_eq!(suggestions.len(), MAX_SUGGESTIONS);
+    }
+
+    #[test]
+    fn test_format_suggestions_shapes() {
+        assert_eq!(format_suggestions(&[]), "");
+        assert_eq!(format_suggestions(&["A".to_string()]), "'A'");
+        assert_eq!(
+            format_suggestions(&["A".to_string(), "B".to_string()]),
+            "'A' or 'B'"
+        );
+        assert_eq!(
+            format_suggestions(&["A".to_string(), "B".to_string(), "C".to_string()]),
+            "'A', 'B' or 'C'"
+        );
+    }
+}

--- a/cli/src/config/declared.rs
+++ b/cli/src/config/declared.rs
@@ -33,7 +33,7 @@ use termcolor::{StandardStream, WriteColor};
 
 use crate::core::{
     ast::infrastructure::env::find_all_env_vars,
-    env::{find_workspace_root, get_modules_path, parse_env_items_from_str},
+    env::{EnvFileItem, find_workspace_root, get_modules_path, parse_env_items_from_str},
     rendered_template::RenderedTemplatesCache,
     string::closest_matches,
 };
@@ -51,8 +51,8 @@ pub(crate) fn names_in_pulled_config(content: &str) -> HashSet<String> {
     parse_env_items_from_str(content)
         .into_iter()
         .filter_map(|item| match item {
-            crate::core::env::EnvFileItem::KeyValue(key, _) => Some(key),
-            crate::core::env::EnvFileItem::SectionHeader(_) => None,
+            EnvFileItem::KeyValue(key, _) => Some(key),
+            EnvFileItem::SectionHeader(_) => None,
         })
         .collect()
 }

--- a/cli/src/config/set.rs
+++ b/cli/src/config/set.rs
@@ -1,10 +1,10 @@
 use std::io::Write;
 
 use anyhow::{Context, Result, bail};
-use clap::{Arg, ArgMatches, Command};
+use clap::{Arg, ArgAction, ArgMatches, Command};
 use termcolor::{ColorChoice, StandardStream, WriteColor};
 
-use super::{CliCommand, push::reconstruct_env_content};
+use super::{CliCommand, declared::confirm_if_undeclared, push::reconstruct_env_content};
 use crate::{
     constants::{ERROR_FAILED_TO_SEND_REQUEST, get_platform_management_api_url},
     core::{
@@ -34,6 +34,31 @@ fn header_matches_scope(header: &str, scope: &str) -> bool {
         .next()
         .unwrap_or("");
     name == scope
+}
+
+/// Drop valueless entries from a scope that is about to be pushed back, except
+/// the one the operator named.
+///
+/// `config pull` emits two different things as a bare `KEY=` line: a variable
+/// the release manifest declares but nobody has filled in yet, and a variable
+/// already marked unset. Pushing the first kind back creates a record with
+/// `isUnset = true` — the platform reads an empty pushed value as "the
+/// operator asserts this key is deliberately absent", which is exactly what
+/// makes the deploy gate stop demanding it. So a `config set` of one unrelated
+/// key would quietly switch off the gate for every unfilled variable sharing
+/// its scope.
+///
+/// Leaving those lines out is safe in both directions: a key with no record
+/// yet stays absent, and a key that already has one is untouched by the push,
+/// which only clears records for keys it knows about.
+fn drop_valueless_entries(items: Vec<EnvFileItem>, keep: &str) -> Vec<EnvFileItem> {
+    items
+        .into_iter()
+        .filter(|item| match item {
+            EnvFileItem::KeyValue(k, v) => k == keep || !v.trim().is_empty(),
+            EnvFileItem::SectionHeader(_) => true,
+        })
+        .collect()
 }
 
 impl CliCommand for SetCommand {
@@ -68,6 +93,13 @@ impl CliCommand for SetCommand {
                 .help("Scope to a specific service/worker (defaults to application scope)"),
         )
         .arg(
+            Arg::new("force")
+                .long("force")
+                .short('f')
+                .help("Set the variable even when no component declares it")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
             Arg::new("base_path")
                 .long("path")
                 .short('p')
@@ -77,7 +109,7 @@ impl CliCommand for SetCommand {
 
     fn handler(&self, matches: &ArgMatches) -> Result<()> {
         let _token = require_auth()?;
-        let (_app_root, manifest) = require_manifest(matches)?;
+        let (app_root, manifest) = require_manifest(matches)?;
         let app = require_integration(&manifest)?;
         let mut stdout = StandardStream::stdout(ColorChoice::Always);
 
@@ -130,6 +162,20 @@ impl CliCommand for SetCommand {
             );
         }
         let current = pull_response.text()?;
+
+        // Checked before anything is written, because the damage in the
+        // incident this guards against was done the moment the credential
+        // landed under the wrong name.
+        confirm_if_undeclared(
+            &mut stdout,
+            key,
+            &app_root,
+            &current,
+            environment,
+            region,
+            matches.get_flag("force"),
+        )?;
+
         let items = parse_env_items_from_str(&current);
 
         // Extract just the target scope's items, applying the set.
@@ -171,7 +217,7 @@ impl CliCommand for SetCommand {
             scoped.push(EnvFileItem::KeyValue(key.to_string(), value.to_string()));
         }
 
-        let content = reconstruct_env_content(scoped);
+        let content = reconstruct_env_content(drop_valueless_entries(scoped, key));
         let push_url = format!("{}/config/push", get_platform_management_api_url());
         let body = serde_json::json!({
             "applicationId": app,
@@ -183,15 +229,35 @@ impl CliCommand for SetCommand {
             http_client::post(&push_url, body).with_context(|| ERROR_FAILED_TO_SEND_REQUEST)?;
 
         if response.status().is_success() {
-            log_ok!(
-                stdout,
-                "{} {} in scope '{}' for {} ({})",
-                if replaced { "Updated" } else { "Added" },
-                key,
-                scope,
-                environment,
-                region
-            );
+            // "Added" versus "Updated" is the only signal that a name was
+            // never seen before, and it was easy to miss as one word in one
+            // line. Each outcome now says what it means on its own line.
+            if replaced {
+                log_ok!(
+                    stdout,
+                    "UPDATED {} in scope '{}' for {} ({})",
+                    key,
+                    scope,
+                    environment,
+                    region
+                );
+                log_info!(stdout, "The previous value of {} was replaced.", key);
+            } else {
+                log_ok!(
+                    stdout,
+                    "ADDED {} in scope '{}' for {} ({})",
+                    key,
+                    scope,
+                    environment,
+                    region
+                );
+                log_info!(
+                    stdout,
+                    "This created a new variable — scope '{}' had nothing named {} before.",
+                    scope,
+                    key
+                );
+            }
             log_info!(
                 stdout,
                 "Running tasks keep their existing environment — redeploy to apply."
@@ -201,5 +267,87 @@ impl CliCommand for SetCommand {
             let err_text = response.text()?;
             bail!("Failed to set variable: {}", err_text);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn kv(key: &str, value: &str) -> EnvFileItem {
+        EnvFileItem::KeyValue(key.to_string(), value.to_string())
+    }
+
+    fn header(text: &str) -> EnvFileItem {
+        EnvFileItem::SectionHeader(text.to_string())
+    }
+
+    fn keys(items: &[EnvFileItem]) -> Vec<String> {
+        items
+            .iter()
+            .filter_map(|item| match item {
+                EnvFileItem::KeyValue(k, _) => Some(k.clone()),
+                EnvFileItem::SectionHeader(_) => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_header_matches_scope_application() {
+        assert!(header_matches_scope("# application", "application"));
+        assert!(!header_matches_scope("# payments (svc-1)", "application"));
+    }
+
+    #[test]
+    fn test_header_matches_scope_named_component() {
+        assert!(header_matches_scope("# payments (svc-1)", "payments"));
+        assert!(!header_matches_scope("# payments-api (svc-1)", "payments"));
+    }
+
+    /// The whole point: a `config set` of one key must not sweep the unfilled
+    /// required variables sharing its scope into unset tombstones.
+    #[test]
+    fn test_drop_valueless_entries_removes_unfilled_required_vars() {
+        let scoped = vec![
+            header("# application"),
+            kv("DB_HOST", "db.example.com"),
+            kv("ECS_AGENT_URI", ""),
+            kv("STRIPE_API_KEY", ""),
+        ];
+
+        let kept = drop_valueless_entries(scoped, "DB_HOST");
+        assert_eq!(keys(&kept), vec!["DB_HOST".to_string()]);
+    }
+
+    #[test]
+    fn test_drop_valueless_entries_keeps_the_targeted_key() {
+        // `config set KEY=` still reaches the platform as an empty value, so
+        // its existing meaning is preserved exactly.
+        let scoped = vec![header("# application"), kv("DB_HOST", "")];
+
+        let kept = drop_valueless_entries(scoped, "DB_HOST");
+        assert_eq!(keys(&kept), vec!["DB_HOST".to_string()]);
+    }
+
+    #[test]
+    fn test_drop_valueless_entries_treats_whitespace_as_valueless() {
+        let scoped = vec![kv("A", "   "), kv("B", "value")];
+        let kept = drop_valueless_entries(scoped, "B");
+        assert_eq!(keys(&kept), vec!["B".to_string()]);
+    }
+
+    #[test]
+    fn test_drop_valueless_entries_preserves_section_headers() {
+        let scoped = vec![header("# payments (svc-1)"), kv("A", "")];
+        let kept = drop_valueless_entries(scoped, "OTHER");
+        assert_eq!(kept.len(), 1);
+        assert!(matches!(kept[0], EnvFileItem::SectionHeader(_)));
+    }
+
+    #[test]
+    fn test_drop_valueless_entries_keeps_every_valued_key() {
+        let scoped = vec![kv("A", "1"), kv("B", "2"), kv("C", "3")];
+        let kept = drop_valueless_entries(scoped, "A");
+        assert_eq!(keys(&kept), vec!["A", "B", "C"]);
     }
 }

--- a/cli/src/config/set.rs
+++ b/cli/src/config/set.rs
@@ -48,9 +48,11 @@ fn header_matches_scope(header: &str, scope: &str) -> bool {
 /// key would quietly switch off the gate for every unfilled variable sharing
 /// its scope.
 ///
-/// Leaving those lines out is safe in both directions: a key with no record
-/// yet stays absent, and a key that already has one is untouched by the push,
-/// which only clears records for keys it knows about.
+/// Dropping them loses nothing. Only entries with no value are dropped, so
+/// nothing that has a value to lose ever leaves the payload. A dropped key
+/// with no record yet stays absent instead of gaining a tombstone, and a
+/// dropped key that already has one is swept to unset by the push — the same
+/// state an empty pushed value would have produced anyway.
 fn drop_valueless_entries(items: Vec<EnvFileItem>, keep: &str) -> Vec<EnvFileItem> {
     items
         .into_iter()

--- a/cli/src/config/unset.rs
+++ b/cli/src/config/unset.rs
@@ -1,0 +1,599 @@
+//! Mark a variable as deliberately absent.
+//!
+//! The platform treats an "unset" record as a tombstone: the operator
+//! asserting that this application does not need the variable, which is what
+//! stops the deploy gate demanding a value for it. `ECS_AGENT_URI` is the
+//! motivating case — the ECS agent injects it per task at runtime, so it must
+//! never be given a value, but the gate has no way to know that.
+//!
+//! Until now the only route to that state from the CLI was a whole-file
+//! `config push`, because the push endpoint reads "key absent from the pushed
+//! scope" as "unset". That is a sharp tool: it acts on every key the file
+//! happens to omit, and it zeroes each one's stored value on the way. This
+//! command instead names a single key against the per-component variable
+//! endpoints the deploy flow already uses, which upsert only the keys they are
+//! given and never sweep.
+
+use std::io::{IsTerminal, Write};
+
+use anyhow::{Context, Result, bail};
+use clap::{Arg, ArgAction, ArgMatches, Command};
+use dialoguer::{Confirm, theme::ColorfulTheme};
+use termcolor::{ColorChoice, StandardStream, WriteColor};
+
+use super::CliCommand;
+use crate::{
+    constants::{ERROR_FAILED_TO_SEND_REQUEST, get_platform_management_api_url},
+    core::{
+        command::command,
+        env::{EnvFileItem, parse_env_items_from_str},
+        http_client,
+        manifest::{ProjectEntry, ProjectType},
+        validate::{require_auth, require_integration, require_manifest},
+    },
+};
+
+/// Which platform endpoint a scope's variables live behind.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ScopeTarget {
+    Application,
+    Service(String),
+    Worker(String),
+}
+
+/// What the pulled configuration says about a key inside one scope.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum KeyState {
+    /// Not mentioned in this scope at all.
+    Absent,
+    /// Present with no value — either already unset, or declared by the
+    /// release manifest and never filled in.
+    Valueless,
+    /// Present and holding a value, which unsetting will destroy.
+    Valued,
+}
+
+#[derive(Debug)]
+pub(crate) struct UnsetCommand;
+
+impl UnsetCommand {
+    pub(crate) fn new() -> Self {
+        Self {}
+    }
+}
+
+/// Pull the component id out of a `# name (id)` section header, when the
+/// header names `scope`.
+pub(crate) fn scope_id_from_header(header: &str, scope: &str) -> Option<String> {
+    let body = header.trim_start_matches('#').trim();
+    let (name, rest) = body.split_once(' ')?;
+    if name != scope {
+        return None;
+    }
+    let id = rest.trim().strip_prefix('(')?.strip_suffix(')')?.trim();
+    if id.is_empty() { None } else { Some(id.to_string()) }
+}
+
+/// Find the platform id of a named scope in `config pull` output.
+pub(crate) fn find_scope_id(content: &str, scope: &str) -> Option<String> {
+    parse_env_items_from_str(content)
+        .into_iter()
+        .find_map(|item| match item {
+            EnvFileItem::SectionHeader(header) => scope_id_from_header(&header, scope),
+            EnvFileItem::KeyValue(_, _) => None,
+        })
+}
+
+/// Decide whether a named scope is a service or a worker.
+///
+/// Pull output cannot answer this: a service section and a worker section are
+/// both rendered as `# name (id)`, with nothing to tell them apart. The local
+/// manifest can, because the platform names a worker component after its
+/// project with a `-worker` suffix.
+pub(crate) fn classify_scope(
+    projects: &[ProjectEntry],
+    scope: &str,
+    scope_id: String,
+) -> Option<ScopeTarget> {
+    for project in projects {
+        match project.r#type {
+            ProjectType::Service if project.name == scope => {
+                return Some(ScopeTarget::Service(scope_id));
+            }
+            ProjectType::Worker
+                if project.name == scope || scope == format!("{}-worker", project.name) =>
+            {
+                return Some(ScopeTarget::Worker(scope_id));
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Report what the pulled configuration currently holds for `key` in `scope`.
+pub(crate) fn key_state(content: &str, scope: &str, key: &str) -> KeyState {
+    let mut in_scope = scope == "application";
+    let mut state = KeyState::Absent;
+
+    for item in parse_env_items_from_str(content) {
+        match item {
+            EnvFileItem::SectionHeader(header) => {
+                let name = header
+                    .trim_start_matches('#')
+                    .trim()
+                    .split(' ')
+                    .next()
+                    .unwrap_or("")
+                    .to_string();
+                in_scope = name == scope;
+            }
+            EnvFileItem::KeyValue(k, v) => {
+                if in_scope && k == key {
+                    // A later valued entry wins over an earlier blank one, so
+                    // the destructive case is never under-reported.
+                    if !v.trim().is_empty() {
+                        return KeyState::Valued;
+                    }
+                    state = KeyState::Valueless;
+                }
+            }
+        }
+    }
+
+    state
+}
+
+/// The endpoint and body for unsetting one key, given the resolved scope.
+pub(crate) fn unset_request(
+    target: &ScopeTarget,
+    application_id: &str,
+    environment: &str,
+    region: &str,
+    key: &str,
+) -> (String, serde_json::Value) {
+    let api = get_platform_management_api_url();
+    match target {
+        ScopeTarget::Application => (
+            format!(
+                "{}/applications/{}/environments/{}/variables",
+                api, application_id, environment
+            ),
+            serde_json::json!({
+                "region": region,
+                "variables": [{
+                    "key": key,
+                    "value": "",
+                    "source": "application",
+                    "required": false,
+                    "hasValue": false,
+                    "isUnset": true
+                }]
+            }),
+        ),
+        ScopeTarget::Service(id) => (
+            format!("{}/services/{}/environments/{}/variables", api, id, environment),
+            serde_json::json!({
+                "region": region,
+                "variables": [{ "key": key, "value": "", "isUnset": true }]
+            }),
+        ),
+        ScopeTarget::Worker(id) => (
+            format!("{}/workers/{}/environments/{}/variables", api, id, environment),
+            serde_json::json!({
+                "region": region,
+                "variables": [{ "key": key, "value": "", "isUnset": true }]
+            }),
+        ),
+    }
+}
+
+impl CliCommand for UnsetCommand {
+    fn command(&self) -> Command {
+        command(
+            "unset",
+            "Mark a variable as deliberately absent so the deploy gate stops requiring it",
+        )
+        .arg(
+            Arg::new("key")
+                .required(true)
+                .help("Name of the variable to mark unset"),
+        )
+        .arg(
+            Arg::new("region")
+                .short('r')
+                .long("region")
+                .required(true)
+                .help("Region (e.g. us-east-1)"),
+        )
+        .arg(
+            Arg::new("environment")
+                .short('e')
+                .long("environment")
+                .required(true)
+                .help("Environment name (e.g. production, staging)"),
+        )
+        .arg(
+            Arg::new("service")
+                .short('s')
+                .long("service")
+                .help("Scope to a specific service/worker (defaults to application scope)"),
+        )
+        .arg(
+            Arg::new("yes")
+                .long("yes")
+                .short('y')
+                .help("Skip the confirmation prompt (for CI/scripted use) — the stored value is destroyed")
+                .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("base_path")
+                .long("path")
+                .short('p')
+                .help("Path to application root (optional)"),
+        )
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        let _token = require_auth()?;
+        let (_app_root, manifest) = require_manifest(matches)?;
+        let app = require_integration(&manifest)?;
+        let mut stdout = StandardStream::stdout(ColorChoice::Always);
+
+        let key = matches.get_one::<String>("key").expect("key required");
+        if let Some((name, _)) = key.split_once('=') {
+            bail!(
+                "Expected a variable name, got the assignment '{}'. Use `forklaunch config unset {}` to mark it unset, or `forklaunch config set` to give it a value.",
+                key,
+                name
+            );
+        }
+        let key = key.trim();
+        if key.is_empty() {
+            bail!("Variable name cannot be empty");
+        }
+
+        let region = matches.get_one::<String>("region").expect("required");
+        let environment = matches.get_one::<String>("environment").expect("required");
+        let scope = matches
+            .get_one::<String>("service")
+            .cloned()
+            .unwrap_or_else(|| "application".to_string());
+        let skip_confirm = matches.get_flag("yes");
+
+        // Read-only: used to resolve the component id behind a named scope and
+        // to find out whether a value is about to be destroyed. Nothing from
+        // this response is written back.
+        let pull_url = format!(
+            "{}/config/pull?applicationId={}&region={}&environment={}",
+            get_platform_management_api_url(),
+            app,
+            region,
+            environment
+        );
+        let pull_response =
+            http_client::get(&pull_url).with_context(|| ERROR_FAILED_TO_SEND_REQUEST)?;
+        if !pull_response.status().is_success() {
+            bail!(
+                "Failed to pull current config: {}",
+                pull_response.text().unwrap_or_default()
+            );
+        }
+        let current = pull_response.text()?;
+
+        let target = if scope == "application" {
+            ScopeTarget::Application
+        } else {
+            let scope_id = find_scope_id(&current, &scope).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Scope '{}' not found in the current configuration. Known scopes appear as '# <name> (id)' section headers in `forklaunch config pull` output.",
+                    scope
+                )
+            })?;
+            classify_scope(&manifest.projects, &scope, scope_id).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Scope '{}' is not a service or worker in this application's manifest, so there is no way to tell which endpoint owns it.",
+                    scope
+                )
+            })?
+        };
+
+        let state = key_state(&current, &scope, key);
+        match state {
+            KeyState::Valued => {
+                log_warn!(
+                    stdout,
+                    "{} currently holds a value in scope '{}'. Marking it unset DESTROYS that value — the platform stores an empty string, and it cannot be recovered from here or from the dashboard.",
+                    key,
+                    scope
+                );
+
+                if !skip_confirm {
+                    if !std::io::stdin().is_terminal() {
+                        bail!(
+                            "refusing to destroy the stored value of {} without confirmation — re-run with --yes if that is intended",
+                            key
+                        );
+                    }
+
+                    let confirmed = Confirm::with_theme(&ColorfulTheme::default())
+                        .with_prompt(format!("Destroy the stored value of {} and mark it unset?", key))
+                        .default(false)
+                        .interact()?;
+
+                    if !confirmed {
+                        bail!("aborted — nothing was changed");
+                    }
+                }
+            }
+            KeyState::Valueless => {
+                log_info!(
+                    stdout,
+                    "{} holds no value in scope '{}', so nothing is destroyed.",
+                    key,
+                    scope
+                );
+            }
+            KeyState::Absent => {
+                log_info!(
+                    stdout,
+                    "{} does not currently appear in scope '{}'. Marking it unset records that this application deliberately does not need it.",
+                    key,
+                    scope
+                );
+            }
+        }
+
+        let (url, body) = unset_request(&target, &app, environment, region, key);
+        let response =
+            http_client::put(&url, body).with_context(|| ERROR_FAILED_TO_SEND_REQUEST)?;
+
+        if !response.status().is_success() {
+            let err_text = response.text()?;
+            bail!("Failed to unset variable: {}", err_text);
+        }
+
+        log_ok!(
+            stdout,
+            "UNSET {} in scope '{}' for {} ({})",
+            key,
+            scope,
+            environment,
+            region
+        );
+        if state == KeyState::Valued {
+            log_info!(stdout, "The stored value of {} was destroyed.", key);
+        }
+        log_info!(
+            stdout,
+            "The deploy gate will no longer require a value for {}.",
+            key
+        );
+        log_info!(
+            stdout,
+            "Running tasks keep their existing environment — redeploy to apply."
+        );
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_scope_id_from_header_matching_scope() {
+        assert_eq!(
+            scope_id_from_header("# payments (svc-123)", "payments"),
+            Some("svc-123".to_string())
+        );
+    }
+
+    #[test]
+    fn test_scope_id_from_header_rejects_other_scopes() {
+        assert_eq!(scope_id_from_header("# payments (svc-123)", "billing"), None);
+        assert_eq!(scope_id_from_header("# application", "application"), None);
+    }
+
+    #[test]
+    fn test_find_scope_id_across_sections() {
+        let content = "# application\n\
+                       DB_HOST=db\n\
+                       # payments (svc-123)\n\
+                       STRIPE_API_KEY=sk\n\
+                       # mailer-worker (wkr-456)\n\
+                       QUEUE_NAME=mail\n";
+
+        assert_eq!(find_scope_id(content, "payments"), Some("svc-123".into()));
+        assert_eq!(
+            find_scope_id(content, "mailer-worker"),
+            Some("wkr-456".into())
+        );
+        assert_eq!(find_scope_id(content, "nope"), None);
+    }
+
+    #[test]
+    fn test_key_state_in_application_scope() {
+        let content = "# application\nDB_HOST=db\nECS_AGENT_URI=\n";
+        assert_eq!(key_state(content, "application", "DB_HOST"), KeyState::Valued);
+        assert_eq!(
+            key_state(content, "application", "ECS_AGENT_URI"),
+            KeyState::Valueless
+        );
+        assert_eq!(
+            key_state(content, "application", "NOT_THERE"),
+            KeyState::Absent
+        );
+    }
+
+    /// A key with a value under one component must not make it look valued
+    /// under another — that would demand a confirmation for a no-op, or worse,
+    /// hide one that is needed.
+    #[test]
+    fn test_key_state_is_scoped() {
+        let content = "# application\nSHARED=\n# payments (svc-1)\nSHARED=real\n";
+        assert_eq!(key_state(content, "application", "SHARED"), KeyState::Valueless);
+        assert_eq!(key_state(content, "payments", "SHARED"), KeyState::Valued);
+    }
+
+    #[test]
+    fn test_key_state_treats_whitespace_as_valueless() {
+        let content = "# application\nBLANK=   \n";
+        assert_eq!(key_state(content, "application", "BLANK"), KeyState::Valueless);
+    }
+
+    #[test]
+    fn test_unset_request_targets_the_application_endpoint() {
+        let (url, body) = unset_request(
+            &ScopeTarget::Application,
+            "app-1",
+            "production",
+            "us-east-1",
+            "ECS_AGENT_URI",
+        );
+
+        assert!(url.ends_with("/applications/app-1/environments/production/variables"));
+        assert_eq!(body["region"], "us-east-1");
+        assert_eq!(body["variables"][0]["key"], "ECS_AGENT_URI");
+        assert_eq!(body["variables"][0]["isUnset"], true);
+        assert_eq!(body["variables"][0]["hasValue"], false);
+        assert_eq!(body["variables"][0]["value"], "");
+        // Exactly one key is named, so nothing else in the scope is touched.
+        assert_eq!(body["variables"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_unset_request_targets_the_service_endpoint() {
+        let (url, body) = unset_request(
+            &ScopeTarget::Service("svc-9".into()),
+            "app-1",
+            "production",
+            "us-east-1",
+            "ECS_AGENT_URI",
+        );
+
+        assert!(url.ends_with("/services/svc-9/environments/production/variables"));
+        assert_eq!(body["variables"][0]["isUnset"], true);
+    }
+
+    #[test]
+    fn test_unset_request_targets_the_worker_endpoint() {
+        let (url, _) = unset_request(
+            &ScopeTarget::Worker("wkr-9".into()),
+            "app-1",
+            "production",
+            "us-east-1",
+            "ECS_AGENT_URI",
+        );
+
+        assert!(url.ends_with("/workers/wkr-9/environments/production/variables"));
+    }
+
+    fn project(name: &str, r#type: ProjectType) -> ProjectEntry {
+        ProjectEntry {
+            r#type,
+            name: name.to_string(),
+            description: String::new(),
+            variant: None,
+            resources: None,
+            routers: None,
+            metadata: None,
+        }
+    }
+
+    #[test]
+    fn test_classify_scope_finds_a_service() {
+        let projects = vec![
+            project("payments", ProjectType::Service),
+            project("mailer", ProjectType::Worker),
+        ];
+
+        assert_eq!(
+            classify_scope(&projects, "payments", "svc-1".into()),
+            Some(ScopeTarget::Service("svc-1".into()))
+        );
+    }
+
+    /// The platform names a worker component `<project>-worker`, which is what
+    /// shows up in the pull section header.
+    #[test]
+    fn test_classify_scope_finds_a_worker_by_suffixed_name() {
+        let projects = vec![project("mailer", ProjectType::Worker)];
+
+        assert_eq!(
+            classify_scope(&projects, "mailer-worker", "wkr-1".into()),
+            Some(ScopeTarget::Worker("wkr-1".into()))
+        );
+        assert_eq!(
+            classify_scope(&projects, "mailer", "wkr-1".into()),
+            Some(ScopeTarget::Worker("wkr-1".into()))
+        );
+    }
+
+    #[test]
+    fn test_classify_scope_ignores_libraries_and_unknowns() {
+        let projects = vec![
+            project("shared", ProjectType::Library),
+            project("payments", ProjectType::Service),
+        ];
+
+        assert_eq!(classify_scope(&projects, "shared", "x".into()), None);
+        assert_eq!(classify_scope(&projects, "ghost", "x".into()), None);
+    }
+
+    fn unset_cmd() -> Command {
+        UnsetCommand::new().command().version("0.0.0-test")
+    }
+
+    #[test]
+    fn test_command_definition_is_valid() {
+        unset_cmd().debug_assert();
+    }
+
+    #[test]
+    fn test_key_region_and_environment_are_required() {
+        assert!(unset_cmd().try_get_matches_from(["unset"]).is_err());
+        assert!(
+            unset_cmd()
+                .try_get_matches_from(["unset", "ECS_AGENT_URI"])
+                .is_err()
+        );
+    }
+
+    /// `config unset` must take the same option shape as `config set`.
+    #[test]
+    fn test_accepts_the_same_option_shape_as_set() {
+        let matches = unset_cmd()
+            .try_get_matches_from([
+                "unset",
+                "ECS_AGENT_URI",
+                "-r",
+                "us-east-1",
+                "-e",
+                "production",
+                "-s",
+                "payments",
+                "-y",
+            ])
+            .expect("should parse");
+
+        assert_eq!(
+            matches.get_one::<String>("key"),
+            Some(&"ECS_AGENT_URI".to_string())
+        );
+        assert_eq!(
+            matches.get_one::<String>("region"),
+            Some(&"us-east-1".to_string())
+        );
+        assert_eq!(
+            matches.get_one::<String>("environment"),
+            Some(&"production".to_string())
+        );
+        assert_eq!(
+            matches.get_one::<String>("service"),
+            Some(&"payments".to_string())
+        );
+        assert!(matches.get_flag("yes"));
+    }
+}

--- a/cli/src/core/string.rs
+++ b/cli/src/core/string.rs
@@ -21,6 +21,82 @@ pub(crate) fn split_preserve_spaces(input: &str) -> Vec<String> {
     result
 }
 
+/// Levenshtein edit distance, compared case-insensitively.
+///
+/// Only two rows of the matrix are kept, so this stays cheap enough to run
+/// against every declared environment variable name in a workspace.
+pub(crate) fn levenshtein(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().flat_map(|c| c.to_lowercase()).collect();
+    let b: Vec<char> = b.chars().flat_map(|c| c.to_lowercase()).collect();
+
+    if a.is_empty() {
+        return b.len();
+    }
+    if b.is_empty() {
+        return a.len();
+    }
+
+    let mut previous: Vec<usize> = (0..=b.len()).collect();
+    let mut current: Vec<usize> = vec![0; b.len() + 1];
+
+    for (i, a_char) in a.iter().enumerate() {
+        current[0] = i + 1;
+        for (j, b_char) in b.iter().enumerate() {
+            let substitution = previous[j] + if a_char == b_char { 0 } else { 1 };
+            let deletion = previous[j + 1] + 1;
+            let insertion = current[j] + 1;
+            current[j + 1] = substitution.min(deletion).min(insertion);
+        }
+        std::mem::swap(&mut previous, &mut current);
+    }
+
+    previous[b.len()]
+}
+
+/// Minimum similarity, on a 0..1 scale, for a candidate to be worth
+/// suggesting. 0.6 keeps one-word-off typos like `TWILIO_ACCOUNT_TOKEN` vs
+/// `TWILIO_AUTH_TOKEN` (0.75) while dropping unrelated names.
+const SUGGESTION_SIMILARITY_THRESHOLD: f64 = 0.6;
+
+/// Rank `candidates` by how close they are to `input` and return at most
+/// `limit` of them, nearest first.
+///
+/// Candidates that are not plausibly a typo of `input` are dropped entirely,
+/// so an empty result means "no suggestion worth making" rather than "no
+/// candidates".
+pub(crate) fn closest_matches(input: &str, candidates: &[String], limit: usize) -> Vec<String> {
+    let mut scored: Vec<(usize, &String)> = candidates
+        .iter()
+        .filter(|candidate| candidate.as_str() != input)
+        .filter_map(|candidate| {
+            let distance = levenshtein(input, candidate);
+            let longest = input.chars().count().max(candidate.chars().count());
+            if longest == 0 {
+                return None;
+            }
+            let similarity = 1.0 - (distance as f64 / longest as f64);
+            // Very short names never clear a ratio test, so allow a one or two
+            // character slip on them regardless.
+            if similarity >= SUGGESTION_SIMILARITY_THRESHOLD || distance <= 2 {
+                Some((distance, candidate))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    // Ties are broken by name so the output is stable between runs.
+    scored.sort_by(|(a_distance, a_name), (b_distance, b_name)| {
+        a_distance.cmp(b_distance).then_with(|| a_name.cmp(b_name))
+    });
+
+    scored
+        .into_iter()
+        .take(limit)
+        .map(|(_, name)| name.clone())
+        .collect()
+}
+
 pub(crate) fn short_circuit_replacement(
     content: &str,
     replacements: &Vec<(String, String)>,
@@ -37,4 +113,89 @@ pub(crate) fn short_circuit_replacement(
         })
         .collect::<Vec<_>>()
         .join("")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn names(list: &[&str]) -> Vec<String> {
+        list.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn test_levenshtein_identical_is_zero() {
+        assert_eq!(levenshtein("DB_HOST", "DB_HOST"), 0);
+    }
+
+    #[test]
+    fn test_levenshtein_is_case_insensitive() {
+        assert_eq!(levenshtein("DB_HOST", "db_host"), 0);
+    }
+
+    #[test]
+    fn test_levenshtein_empty_operand() {
+        assert_eq!(levenshtein("", "ABC"), 3);
+        assert_eq!(levenshtein("ABC", ""), 3);
+        assert_eq!(levenshtein("", ""), 0);
+    }
+
+    #[test]
+    fn test_levenshtein_single_character_slip() {
+        assert_eq!(levenshtein("DB_HOST", "DB_HOSTT"), 1);
+        assert_eq!(levenshtein("DB_HOST", "DB_HST"), 1);
+        assert_eq!(levenshtein("DB_HOST", "DB_HOSR"), 1);
+    }
+
+    /// The two real typos from the incident this exists for.
+    #[test]
+    fn test_closest_matches_surfaces_the_real_twilio_names() {
+        let declared = names(&[
+            "TWILIO_ACCOUNT_SID",
+            "TWILIO_AUTH_TOKEN",
+            "TWILIO_FROM_NUMBER",
+            "STRIPE_API_KEY",
+            "DB_HOST",
+        ]);
+
+        let suggestions = closest_matches("TWILIO_ACCOUNT_TOKEN", &declared, 3);
+        assert!(suggestions.contains(&"TWILIO_AUTH_TOKEN".to_string()));
+        assert!(suggestions.contains(&"TWILIO_ACCOUNT_SID".to_string()));
+
+        let suggestions = closest_matches("TWILIO_AUTH_SID", &declared, 3);
+        assert!(suggestions.contains(&"TWILIO_ACCOUNT_SID".to_string()));
+        assert!(suggestions.contains(&"TWILIO_AUTH_TOKEN".to_string()));
+    }
+
+    #[test]
+    fn test_closest_matches_drops_unrelated_names() {
+        let declared = names(&["DB_HOST", "DB_PORT", "REDIS_URL"]);
+        assert!(closest_matches("STRIPE_WEBHOOK_SECRET", &declared, 3).is_empty());
+    }
+
+    #[test]
+    fn test_closest_matches_excludes_exact_input() {
+        let declared = names(&["DB_HOST", "DB_PORT"]);
+        let suggestions = closest_matches("DB_HOST", &declared, 3);
+        assert!(!suggestions.contains(&"DB_HOST".to_string()));
+    }
+
+    #[test]
+    fn test_closest_matches_orders_by_distance_then_name() {
+        let declared = names(&["DB_HOSTS", "DB_HOST_NAME", "DB_HOSA"]);
+        let suggestions = closest_matches("DB_HOST", &declared, 3);
+        assert_eq!(suggestions[0], "DB_HOSA");
+        assert_eq!(suggestions[1], "DB_HOSTS");
+    }
+
+    #[test]
+    fn test_closest_matches_respects_limit() {
+        let declared = names(&["DB_HOSTS", "DB_HOSA", "DB_HOSB", "DB_HOSC"]);
+        assert_eq!(closest_matches("DB_HOST", &declared, 2).len(), 2);
+    }
+
+    #[test]
+    fn test_closest_matches_empty_candidates() {
+        assert!(closest_matches("DB_HOST", &[], 3).is_empty());
+    }
 }

--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -6,9 +6,10 @@ description: Learn how to use the forklaunch config command.
 
 ## Overview
 
-THIS COMMAND IS CURRENTLY UNDER DEVELOPMENT AND IS NOT YET AVAILABLE.
-
 The `config` command manages application configuration between your local environment and the ForkLaunch platform. You must be authenticated to use this command.
+
+`pull` and `push` move a whole `.env` file at a time; `set` and `unset` act on one
+variable.
 
 ## Usage
 
@@ -22,6 +23,8 @@ forklaunch config [COMMAND]
 | :------ | :----------------------------------- |
 | `pull`  | Pull environment configuration from platform |
 | `push`  | Push environment configuration to platform   |
+| `set`   | Set a single variable without touching the rest of the scope |
+| `unset` | Mark a variable as deliberately absent so the deploy gate stops requiring it |
 
 ### pull
 
@@ -52,6 +55,74 @@ forklaunch config push --region <region> --environment <env> [options]
 - `-i, --input <file>` - Input file path (defaults to `<environment>.env`)
 - `-p, --path <path>` - Path to application root
 
+> Push is authoritative per scope. Any variable that exists on the platform in a
+> scope the file touches, but is missing from the file, is marked unset **and its
+> stored value is erased**. Use `config unset` to retire a single variable.
+
+### set
+
+```bash
+forklaunch config set KEY=VALUE --region <region> --environment <env> [options]
+```
+
+Sets one variable, leaving every other variable in the scope alone.
+
+**Required:**
+- `KEY=VALUE` - The variable to set (quote values containing spaces)
+- `-r, --region <region>` - Region (e.g., `us-east-1`)
+- `-e, --environment <env>` - Environment name (e.g., `production`, `staging`)
+
+**Optional:**
+- `-s, --service <name>` - Scope to a service or worker (defaults to application scope)
+- `-f, --force` - Set the variable even when no component declares it
+- `-p, --path <path>` - Path to application root
+
+The output distinguishes `ADDED` (the name did not exist in this scope) from
+`UPDATED` (an existing value was replaced). If the name is one that no component
+declares and that the platform has never seen, `set` warns, suggests the closest
+declared names, and asks for confirmation before writing:
+
+```
+[WARN] 'TWILIO_ACCOUNT_TOKEN' is not declared by any component in this application, and no variable by that name exists in production (us-east-1).
+[WARN]        Did you mean 'TWILIO_ACCOUNT_SID' or 'TWILIO_AUTH_TOKEN'?
+[WARN]        Setting it will store the value under a name nothing reads.
+? Set 'TWILIO_ACCOUNT_TOKEN' anyway? (y/N)
+```
+
+The declared names come from the config the platform returns plus a scan of the
+local workspace. Neither is a complete picture on its own, so this is a warning
+rather than a refusal — a scripted run prints the warning and proceeds, and
+`--force` skips the prompt.
+
+### unset
+
+```bash
+forklaunch config unset KEY --region <region> --environment <env> [options]
+```
+
+Marks a variable as deliberately absent. The deploy gate stops requiring a value
+for it. Use this for variables that are injected at runtime and must never hold a
+value — `ECS_AGENT_URI`, which the ECS agent supplies per task, is the canonical
+case.
+
+**Required:**
+- `KEY` - Name of the variable to mark unset
+- `-r, --region <region>` - Region (e.g., `us-east-1`)
+- `-e, --environment <env>` - Environment name (e.g., `production`, `staging`)
+
+**Optional:**
+- `-s, --service <name>` - Scope to a service or worker (defaults to application scope)
+- `-y, --yes` - Skip the confirmation prompt (for CI/scripted use)
+- `-p, --path <path>` - Path to application root
+
+Unsetting a variable that currently holds a value **destroys that value** — the
+platform stores an empty string, and it cannot be recovered from the CLI or the
+dashboard. When that is the case, `unset` says so and asks for confirmation.
+Without a terminal to ask on, it refuses unless `--yes` is given. A variable that
+holds no value is unset with no prompt.
+
+Unlike `config push`, this touches only the key you name.
+
 ### Examples
 
 ```bash
@@ -69,6 +140,15 @@ forklaunch config push --region us-east-1 --environment staging
 
 # Push configuration from a specific file
 forklaunch config push --region us-east-1 --environment production --input ./config/.env.prod
+
+# Set one variable at application scope
+forklaunch config set STRIPE_API_KEY=sk_live_xxx --region us-east-1 --environment production
+
+# Set one variable on a single service
+forklaunch config set QUEUE_NAME=orders --region us-east-1 --environment production --service payments
+
+# Mark a runtime-injected variable as deliberately absent
+forklaunch config unset ECS_AGENT_URI --region us-east-1 --environment production
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
Two gaps in `forklaunch config`, both from incidents today.

## What this does, in plain terms

**1. You can now retire a variable without a whole-file round trip.**

The platform lets you mark a variable "this app doesn't need one", and the
deploy gate then stops demanding it. There was no CLI command for that, so the
only way was to pull the whole `.env`, delete a line, and push it back — and the
push endpoint treats *every* line you happened to drop the same way, erasing
each one's stored value. `forklaunch config unset KEY` now names exactly one key.

**2. `config set` no longer silently accepts a name nothing reads.**

Three `config set` calls in one session each stored a live credential under a
name no component declares: `TWILIO_ACCOUNT_TOKEN` (real name
`TWILIO_AUTH_TOKEN`), `TWILIO_AUTH_SID` (real name `TWILIO_ACCOUNT_SID`), and
the SID pasted into the token field. Every one was accepted. `config set` now
recognises an unknown name, offers the closest real ones, and asks before
writing.

---

## `unset` — how it reaches the platform

**No platform-side change is needed.** The brief assumed `config push` was the
only path; it is not. Three endpoints already accept `isUnset` per variable, and
`fl deploy` already posts to them with `isUnset: true`:

```
PUT /applications/:id/environments/:env/variables
PUT /services/:id/environments/:env/variables
PUT /workers/:id/environments/:env/variables
```

They are pure upserts over the keys in the body — verified in
`application.service.ts` (`updateEnvironmentVariables`) and
`component-environment-config.service.ts`
(`updateComponentEnvironmentVariables`, whose own doc comment reads *"Additively
update … for CLI use"*). Neither sweeps absent keys; only `/config/push` does.
Both create a row with `isUnset: true` when the key has none.

So `config unset` is a single `PUT` naming a single key. Nothing else in the
scope is touched, and no value other than the named key's is at risk.

Resolving `-s <name>` needs a component id and a service-or-worker answer. The
id comes from the `# name (id)` header in pull output. The type comes from the
local manifest — a service section and a worker section are rendered
identically, so the header alone cannot say which endpoint owns the scope.

**Confirmation.** Unsetting a variable that holds a value destroys it. That case
prints what will be lost, prompts, and — with no terminal to prompt on — refuses
unless `--yes` is given. A variable holding no value (the `ECS_AGENT_URI` case)
is unset with no prompt, because nothing is destroyed.

```bash
forklaunch config unset ECS_AGENT_URI -r us-east-1 -e production
```

## `config set` — warn, not refuse

**Where the declared list comes from:** two existing sources, unioned, no new
endpoint.

1. The `config pull` response `config set` *already fetches*. It carries the
   variables that hold values and, as bare `KEY=` lines, the required variables
   from the deployed release manifest. Zero extra network calls.
2. An AST scan of the local workspace — the same `find_all_env_vars` +
   `determine_env_var_scopes` pass whose output becomes
   `requiredEnvironmentVariables` in the release manifest at `fl release create`
   time. This is what covers variables declared `optional(...)`, which the
   platform does not emit as blank lines.

**Warn, with a confirmation prompt — not a refusal.** Reasoning:

- Each source is an approximation of the other. The platform's view lags a
  working tree that has not been released; the working tree lags a release cut
  from a different checkout. Hard-refusing on that evidence means a stale
  checkout can block an emergency production fix — which is the exact situation
  that produced this brief.
- Legitimately-undeclared variables exist: dynamic `process.env[name]` reads,
  variables consumed by an entrypoint script, components not in the local
  checkout.
- A warning printed *after* the write does not un-store a secret, so the
  intervention has to happen before it. An interactive confirmation is that
  intervention, and it is where the incident actually happened.
- Scripts are unaffected: a non-interactive run prints the warning and proceeds.
  `--force` skips the prompt.

The net effect is a soft block where a human is present and a loud warning where
one is not, which matches how soft the evidence is.

**Did-you-mean** ranks candidates by Levenshtein distance and shows up to three.
Three matters: both of today's typos sat the *same* distance from two different
real names, so a single guess would have been a coin flip.

```
[WARN] 'TWILIO_ACCOUNT_TOKEN' is not declared by any component in this application, and no variable by that name exists in production (us-east-1).
[WARN]        Did you mean 'TWILIO_ACCOUNT_SID' or 'TWILIO_AUTH_TOKEN'?
[WARN]        Setting it will store the value under a name nothing reads.
? Set 'TWILIO_ACCOUNT_TOKEN' anyway? (y/N)
```

**Added vs Updated** now gets its own explanatory line either way:

```
[OK] ADDED TWILIO_AUTH_TOKEN in scope 'application' for production (us-east-1)
[INFO] This created a new variable — scope 'application' had nothing named TWILIO_AUTH_TOKEN before.
```

## A bug found while verifying, fixed here

`config set` round-trips the whole scope through `config push`, and `config
pull` renders a declared-but-unfilled required variable as `KEY=`. The push
endpoint reads an empty pushed value as "the operator asserts this key is
deliberately absent" and **creates an `isUnset` record** — the exact state that
stops the deploy gate demanding a value.

So `forklaunch config set ANYTHING=x` quietly switched the deploy gate off for
every unfilled required variable sharing that scope. Valueless entries are now
dropped from the pushed payload, except the key the operator named, which keeps
`config set KEY=` behaving exactly as it does today. (`config.controller.ts`
L379-421 for the create path; `config-pull-formatter.util.ts` L210-300 for the
blank-line injection.)

## Things in the brief that turned out otherwise

- **"There is no CLI command for it … the only path today is the dashboard."**
  Also reachable, accidentally, via `config set KEY=` — which goes through the
  sweeping push endpoint and carries the collateral damage above.
- **"Look for a per-variable endpoint … If none exists, say so."** There is no
  single-variable resource (`/variables/:key`), but the batch endpoints above
  are addressable by key and do not sweep, which is functionally what was
  wanted. No new platform endpoint is needed.
- **`docs/cli/config.md` said "THIS COMMAND IS CURRENTLY UNDER DEVELOPMENT AND
  IS NOT YET AVAILABLE"** while `config set` was being used on production
  credentials. Removed, and `set`/`unset` documented.

## Not done

- No platform-side change is proposed, because none is needed.
- The declared-name check compares against the application's whole declared set
  rather than per-scope. Scope-specific checking would flag a variable that one
  component declares and another does not, which is common and legitimate.

## Testing

`cargo test` — 585 passing, 0 failing (baseline 538 + 47 new). `cargo fmt` was
not run: the repo carries ~617 pre-existing fmt diffs and no fmt/clippy CI gate,
so the new code matches surrounding style instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SfdmaStU9HfVzbYDgofYxf

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forklaunch/codesmith/forklaunch/pr/309"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790829477&installation_model_id=434648&pr_number=309&repository=forklaunch%2Fforklaunch&return_to=https%3A%2F%2Fgithub.com%2Fforklaunch%2Fforklaunch%2Fpull%2F309&signature=9efde723705b11cfa0dd80f8bd880fa45362569280933749a041108cb2ac3194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->