### PR TITLE
feat(cli): score through the analysis API and return a shareable report card

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -40,6 +40,7 @@ wasm-bindgen = "0.2.100"
 uuid = { version = "1.17.0", features = ["serde", "v4", "v5"] }
 fs_extra = "1.3.0"
 walkdir = "2.5.0"
+zip = { version = "2", default-features = false, features = ["deflate"] }
 regex = "1.11.1"
 lazy_static = "1.5.0"
 dialoguer = { version = "0.12.0", features = ["fuzzy-select"] }

--- a/cli/assets/forklaunch-skills/getting-started/SKILL.md
+++ b/cli/assets/forklaunch-skills/getting-started/SKILL.md
@@ -39,9 +39,9 @@ opened a terminal.
   1. PLAN      conversation → agreed plan → SCORE it, close gaps by Q&A
   2. SCAFFOLD  forklaunch init application / init service
   3. PASS      generate or edit code
-  4. CHECK     forklaunch score     ← after EVERY pass
+  4. CHECK     forklaunch score --offline   ← after EVERY pass (free, ~1s)
   5. repeat 3–4 until the plan is delivered
-  6. MILESTONE full analyze, compared against the plan's score, then deploy
+  6. MILESTONE forklaunch score (uploads, agent-scored, shareable link), then deploy
 ```
 
 Steps 3 and 4 are one unit. Never run a pass without the check after it.
@@ -140,11 +140,13 @@ choice and its consequence before you commit to it.
 After **every** codegen or edit pass, run the deterministic analysis:
 
 ```bash
-forklaunch score
+forklaunch score --offline
 ```
 
-Read-only, no network, about a second. It runs the same checks as
-`forklaunch compliance audit` and returns a scored card.
+`--offline` matters here. Without it, `score` uploads the workspace and runs a
+metered agent analysis — minutes and credits per run, which is unaffordable
+per-pass and needs network and a login. Offline is read-only, free, and about a
+second, covering the compliance and security rails from static checks.
 
 Act on it immediately:
 
@@ -179,12 +181,13 @@ and time where the per-pass check costs neither.
 > just the two the fast check covers, and produces a shareable report card."
 
 ```bash
-forklaunch score                  # fast, deterministic, 2 rails
-forklaunch score --min-score 70   # same, as a CI gate
+forklaunch score --offline                 # fast, free, 2 rails — the per-pass check
+forklaunch score --offline --min-score 70  # same, as a CI gate (no credentials needed)
+forklaunch score                           # the real thing: 5 rails + a shareable link
 forklaunch compliance audit --risk-score --dpia   # full compliance surface
 ```
 
-The fast check scores **compliance** and **security** only. Governance,
+The offline check scores **compliance** and **security** only. Governance,
 scalability and observability need judgement a source read cannot supply and
 come back `pending` rather than zero. Quote the card's `caveat` whenever you
 report a number. `/score` covers reading one properly.

--- a/cli/assets/forklaunch-skills/score/SKILL.md
+++ b/cli/assets/forklaunch-skills/score/SKILL.md
@@ -26,13 +26,45 @@ offline, in about a second — and is honest about the part that needs judgement
 forklaunch score
 ```
 
-That is a **read-only** command. It runs the same deterministic checks as
-`forklaunch compliance audit`, presents them on the shared report-card
-contract, and prints JSON. No network, no auth, no writes.
+This scores through the platform's analysis API, so you get a real **five-rail
+agent-scored card** and a shareable link — not a number that vanishes with your
+scrollback.
+
+It packs the workspace, uploads it, polls the job, prints the card, and mints a
+revocable share link:
+
+```
+Enterprise Readiness  72/100
+…
+Report card: https://forklaunch.com/report-card/<token>
+```
+
+**What it costs.** Analysis is metered — a free tier per account, then credits —
+and takes minutes rather than seconds. It needs `forklaunch login`. So this is a
+milestone action, not something to run after every edit.
+
+**What it uploads.** A zip of the workspace. `.gitignore` is honoured, and
+`.git`, `node_modules`, `target`, `dist` and friends are dropped regardless — so
+a repo that forgot to ignore something large or secret does not silently send
+it. Files over 2 MB are skipped.
+
+### The offline escape hatch
+
+```bash
+forklaunch score --offline
+```
+
+No upload, no auth, no cost, about a second. It runs the same deterministic
+checks as `forklaunch compliance audit` and scores **compliance and security
+only** — the other three rails need judgement a source read cannot supply and
+come back `pending`. Use this in the tight edit loop, and in CI where you have
+no credentials.
 
 | flag | what it does |
 |---|---|
-| *(none)* | a readable terminal summary — the default |
+| *(none)* | upload, score, print the summary and a share link |
+| `--offline` | deterministic checks only — no upload, no auth, no cost, two rails |
+| `--no-share` | score but skip minting the link |
 | `--json` | the raw report card, for tooling |
 | `--pretty` | pretty-print the JSON |
 | `--min-score N` | exit non-zero if `overall` is below N — for CI |

--- a/cli/src/constants.rs
+++ b/cli/src/constants.rs
@@ -12,6 +12,7 @@ const DEV_OBSERVABILITY_API_URL: &str = "http://localhost:8007";
 const DEV_IAM_API_URL: &str = "http://localhost:8001";
 const DEV_BILLING_API_URL: &str = "http://localhost:8000";
 const DEV_PLATFORM_UI_URL: &str = "http://localhost:5173";
+const DEV_STUDIO_ORCHESTRATOR_API_URL: &str = "http://localhost:8008";
 const DEV_RESOURCE_MANAGEMENT_API_URL: &str = "http://localhost:8005";
 const DEV_DEVELOPER_TOOLS_API_URL: &str = "http://localhost:8006";
 
@@ -20,6 +21,7 @@ const PROD_OBSERVABILITY_API_URL: &str = "https://observability-api.forklaunch.c
 const PROD_IAM_API_URL: &str = "https://iam.forklaunch.com";
 const PROD_BILLING_API_URL: &str = "https://billing.forklaunch.com";
 const PROD_PLATFORM_UI_URL: &str = "https://forklaunch.com";
+const PROD_STUDIO_ORCHESTRATOR_API_URL: &str = "https://studio-orchestrator.forklaunch.com";
 const PROD_RESOURCE_MANAGEMENT_API_URL: &str = "https://resource-management.forklaunch.com";
 // NOT A STABLE ALIAS, unlike the other services above: developer-tools has
 // no custom domain configured yet, so this is the raw per-deployment
@@ -658,4 +660,18 @@ mod tests {
         assert_eq!(get_service_module_cache(&Module::BaseIam), None);
         assert_eq!(get_service_module_cache(&Module::BetterAuthIam), None);
     }
+}
+
+/// Studio orchestrator, which owns the analysis + report-card endpoints. Mirrors
+/// the client's `STUDIO_API_URL` resolution so the CLI and the dashboard reach
+/// the same service.
+pub(crate) fn get_studio_orchestrator_api_url() -> String {
+    std::env::var("FORKLAUNCH_STUDIO_ORCHESTRATOR_API_URL").unwrap_or_else(|_| {
+        if is_dev_build() {
+            DEV_STUDIO_ORCHESTRATOR_API_URL
+        } else {
+            PROD_STUDIO_ORCHESTRATOR_API_URL
+        }
+        .to_string()
+    })
 }

--- a/cli/src/core.rs
+++ b/cli/src/core.rs
@@ -32,6 +32,7 @@ pub(crate) mod pnpm_workspace;
 pub(crate) mod relative_path;
 pub(crate) mod removal_template;
 pub(crate) mod report_card;
+pub(crate) mod workspace_archive;
 pub(crate) mod rendered_template;
 pub(crate) mod static_analysis;
 pub(crate) mod string;

--- a/cli/src/core/workspace_archive.rs
+++ b/cli/src/core/workspace_archive.rs
@@ -1,0 +1,245 @@
+//! Pack a workspace into a zip for server-side analysis.
+//!
+//! `POST /analysis/zip` wants a base64 `.zip`, and the orchestrator extracts it
+//! by shelling out to `unzip` — so it has to be a real zip archive, not a
+//! tar.gz.
+//!
+//! # What gets excluded, and why it matters
+//!
+//! This uploads a copy of someone's source to a remote service, so what goes in
+//! is a privacy decision rather than a size optimisation. Three layers:
+//!
+//! 1. `.gitignore` is honoured (via the `ignore` crate, the same walker
+//!    ripgrep uses). Anything the repo already declines to track — `.env`,
+//!    local certs, credential dumps — stays local.
+//! 2. `ALWAYS_EXCLUDE` covers directories that are enormous, regenerable, or
+//!    secret-bearing regardless of what `.gitignore` says. A repo that forgot
+//!    to ignore `node_modules` should not silently upload it, and `.git` holds
+//!    every secret ever committed and later removed.
+//! 3. `MAX_FILE_BYTES` skips individual large files. Analysis reads source; a
+//!    50MB fixture or binary contributes nothing and inflates the payload.
+//!
+//! The archive is held in memory because it then has to be base64'd into a JSON
+//! body anyway. `MAX_ARCHIVE_BYTES` is what stops that being unbounded.
+
+use std::io::{Cursor, Read, Write};
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use ignore::WalkBuilder;
+use zip::write::SimpleFileOptions;
+
+/// Excluded whatever `.gitignore` says. Regenerable, enormous, or secret-bearing.
+const ALWAYS_EXCLUDE: &[&str] = &[
+    ".git",
+    "node_modules",
+    "target",
+    "dist",
+    "build",
+    ".next",
+    ".turbo",
+    ".venv",
+    "__pycache__",
+    ".pnpm-store",
+    "coverage",
+    ".DS_Store",
+];
+
+/// Per-file ceiling. Analysis reads source; anything this large is a fixture,
+/// a binary, or a lockfile-shaped blob that adds payload without adding signal.
+const MAX_FILE_BYTES: u64 = 2 * 1024 * 1024;
+
+/// Whole-archive ceiling. Beyond this the base64 body becomes unreasonable and
+/// the caller deserves a clear error rather than a timeout or a 413.
+const MAX_ARCHIVE_BYTES: usize = 48 * 1024 * 1024;
+
+#[derive(Debug)]
+pub(crate) struct ArchiveSummary {
+    pub(crate) bytes: usize,
+    pub(crate) files: usize,
+    pub(crate) skipped_large: usize,
+}
+
+fn is_excluded(relative: &Path) -> bool {
+    relative
+        .components()
+        .any(|c| ALWAYS_EXCLUDE.contains(&c.as_os_str().to_string_lossy().as_ref()))
+}
+
+/// Zip `root` into memory, returning the bytes and what went in.
+pub(crate) fn pack_workspace(root: &Path) -> Result<(Vec<u8>, ArchiveSummary)> {
+    let mut buffer = Vec::new();
+    let mut files = 0usize;
+    let mut skipped_large = 0usize;
+
+    {
+        let mut writer = zip::ZipWriter::new(Cursor::new(&mut buffer));
+        let options =
+            SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+
+        // `ignore` honours .gitignore/.ignore and skips hidden files by
+        // default; hidden(false) lets through the dotfiles that carry real
+        // configuration (.forklaunch, .github) without overriding .gitignore.
+        let walker = WalkBuilder::new(root)
+            .hidden(false)
+            .git_ignore(true)
+            .git_global(true)
+            .parents(true)
+            .build();
+
+        for entry in walker {
+            let entry = match entry {
+                Ok(e) => e,
+                // An unreadable path is not worth failing the whole analysis
+                // over; the card is built from what could be read.
+                Err(_) => continue,
+            };
+            if !entry.file_type().is_some_and(|t| t.is_file()) {
+                continue;
+            }
+
+            let path = entry.path();
+            let relative = match path.strip_prefix(root) {
+                Ok(r) => r,
+                Err(_) => continue,
+            };
+            if is_excluded(relative) {
+                continue;
+            }
+
+            let size = entry.metadata().map(|m| m.len()).unwrap_or(0);
+            if size > MAX_FILE_BYTES {
+                skipped_large += 1;
+                continue;
+            }
+
+            let mut contents = Vec::new();
+            if std::fs::File::open(path)
+                .and_then(|mut f| f.read_to_end(&mut contents))
+                .is_err()
+            {
+                continue;
+            }
+
+            writer
+                .start_file(relative.to_string_lossy().replace('\\', "/"), options)
+                .with_context(|| format!("failed to add {} to the archive", relative.display()))?;
+            writer.write_all(&contents)?;
+            files += 1;
+        }
+
+        writer.finish().context("failed to finalise the archive")?;
+    }
+
+    if buffer.len() > MAX_ARCHIVE_BYTES {
+        anyhow::bail!(
+            "workspace archive is {:.1} MB, over the {} MB limit — exclude large directories \
+             or analyse a narrower path with --path",
+            buffer.len() as f64 / (1024.0 * 1024.0),
+            MAX_ARCHIVE_BYTES / (1024 * 1024)
+        );
+    }
+
+    if files == 0 {
+        anyhow::bail!(
+            "nothing to analyse under {} — every file was ignored or excluded",
+            root.display()
+        );
+    }
+
+    let bytes = buffer.len();
+    Ok((
+        buffer,
+        ArchiveSummary {
+            bytes,
+            files,
+            skipped_large,
+        },
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn workspace() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        fs::write(root.join("index.ts"), "export const a = 1;").unwrap();
+        fs::write(root.join(".gitignore"), ".env\nsecrets/\n").unwrap();
+        fs::write(root.join(".env"), "API_KEY=super-secret").unwrap();
+        fs::create_dir_all(root.join("secrets")).unwrap();
+        fs::write(root.join("secrets/key.pem"), "-----BEGIN PRIVATE KEY-----").unwrap();
+        fs::create_dir_all(root.join("node_modules/left-pad")).unwrap();
+        fs::write(root.join("node_modules/left-pad/index.js"), "module.exports=1").unwrap();
+        fs::create_dir_all(root.join(".git")).unwrap();
+        fs::write(root.join(".git/config"), "[remote]").unwrap();
+        dir
+    }
+
+    fn entries(bytes: &[u8]) -> Vec<String> {
+        let mut archive = zip::ZipArchive::new(Cursor::new(bytes)).unwrap();
+        (0..archive.len())
+            .map(|i| archive.by_index(i).unwrap().name().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn includes_source() {
+        let dir = workspace();
+        let (bytes, summary) = pack_workspace(dir.path()).unwrap();
+        assert!(entries(&bytes).contains(&"index.ts".to_string()));
+        assert!(summary.files >= 1);
+    }
+
+    #[test]
+    fn honours_gitignore_so_secrets_stay_local() {
+        // The whole reason .gitignore is consulted: this uploads source to a
+        // remote service, and a repo that declines to track a file has already
+        // said it should not leave the machine.
+        let dir = workspace();
+        let (bytes, _) = pack_workspace(dir.path()).unwrap();
+        let names = entries(&bytes);
+        assert!(!names.iter().any(|n| n == ".env"), "{names:?}");
+        assert!(
+            !names.iter().any(|n| n.starts_with("secrets/")),
+            "{names:?}"
+        );
+    }
+
+    #[test]
+    fn excludes_git_and_node_modules_even_if_not_gitignored() {
+        // Neither is in this fixture's .gitignore. `.git` carries every secret
+        // ever committed and later removed; node_modules is enormous and
+        // regenerable. Both must go regardless.
+        let dir = workspace();
+        let (bytes, _) = pack_workspace(dir.path()).unwrap();
+        let names = entries(&bytes);
+        assert!(!names.iter().any(|n| n.starts_with(".git/")), "{names:?}");
+        assert!(
+            !names.iter().any(|n| n.starts_with("node_modules/")),
+            "{names:?}"
+        );
+    }
+
+    #[test]
+    fn skips_oversized_files_and_reports_how_many() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("small.ts"), "export const a = 1;").unwrap();
+        fs::write(dir.path().join("huge.bin"), vec![0u8; (MAX_FILE_BYTES + 1) as usize]).unwrap();
+
+        let (bytes, summary) = pack_workspace(dir.path()).unwrap();
+        assert_eq!(summary.skipped_large, 1);
+        assert!(!entries(&bytes).contains(&"huge.bin".to_string()));
+    }
+
+    #[test]
+    fn an_empty_workspace_is_an_error_not_an_empty_upload() {
+        // Uploading an empty archive would produce a confident, meaningless
+        // score. Better to say nothing was found.
+        let dir = tempfile::tempdir().unwrap();
+        let err = pack_workspace(dir.path()).unwrap_err().to_string();
+        assert!(err.contains("nothing to analyse"), "{err}");
+    }
+}

--- a/cli/src/score.rs
+++ b/cli/src/score.rs
@@ -1,24 +1,52 @@
-//! `forklaunch score` — Enterprise-Readiness Report Card from deterministic checks.
+//! `forklaunch score` — Enterprise-Readiness Report Card for this workspace.
 //!
-//! Deliberately its own top-level command rather than a flag on `analyze`.
-//! `analyze` answers "what is in this workspace" and emits a structural
-//! snapshot; this answers "how ready is it" and emits a scored card. Two
-//! questions, two commands — a flag would have hidden the second behind the
-//! first, and "score my app" is the thing people actually want to type.
+//! Scores through the platform's analysis API, so the result is a real
+//! five-rail agent-scored card and a shareable asset rather than a number that
+//! disappears with the terminal scrollback.
+//!
+//! # Why it uploads
+//!
+//! `POST /analysis/repo` takes a `workspaceRoot` — a path on the orchestrator's
+//! own disk. It cannot see a laptop. The only route from a local checkout is
+//! `POST /analysis/zip`, so the workspace is packed and uploaded. What goes
+//! into that archive is a privacy decision, handled in `workspace_archive`:
+//! `.gitignore` is honoured, and `.git`/`node_modules` are dropped regardless.
+//!
+//! # What that costs
+//!
+//! Analysis is metered — a free tier per account, then credits — and returns a
+//! job to poll rather than an answer. So this is a milestone action, not
+//! something to run after every edit. `--offline` keeps the old behaviour for
+//! the tight loop: deterministic checks only, no network, no auth, no cost, and
+//! only the two rails static analysis can actually decide.
 
-use anyhow::Result;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use base64::Engine;
 use clap::{Arg, ArgMatches, Command};
-use serde_json::json;
+use serde_json::{Value, json};
 
 use crate::{
     CliCommand,
     compliance::checks::run_local_checks,
+    constants::{get_platform_ui_url, get_studio_orchestrator_api_url},
     core::{
         command::command,
-        report_card::{ReportCard, build_local_report_card},
+        hmac::AuthMode,
+        http_client::{get_with_auth, post_with_auth},
+        report_card::{ReportCard, build_local_report_card, iso8601_now},
         validate::require_manifest,
+        workspace_archive::pack_workspace,
     },
 };
+
+/// How long to wait for a job before giving up. Scoring runs several models;
+/// minutes is normal, and a caller who hits this wants the job id rather than
+/// a hang.
+const POLL_TIMEOUT: Duration = Duration::from_secs(15 * 60);
+const POLL_INTERVAL: Duration = Duration::from_secs(3);
 
 #[derive(Debug)]
 pub(crate) struct ScoreCommand;
@@ -33,13 +61,29 @@ impl CliCommand for ScoreCommand {
     fn command(&self) -> Command {
         command(
             "score",
-            "Score this workspace's enterprise readiness from deterministic checks. Read-only, offline.",
+            "Score this workspace's enterprise readiness and get a shareable report card.",
         )
         .arg(
             Arg::new("base_path")
                 .short('p')
                 .long("path")
                 .help("Application root path (defaults to the current directory's manifest)"),
+        )
+        .arg(
+            Arg::new("offline")
+                .long("offline")
+                .help(
+                    "Score from deterministic checks only — no upload, no auth, no cost. Covers \
+                     compliance and security; the other three rails need an agent and come back \
+                     unassessed.",
+                )
+                .action(clap::ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("no_share")
+                .long("no-share")
+                .help("Skip minting the share link (the card is still scored and printed)")
+                .action(clap::ArgAction::SetTrue),
         )
         .arg(
             Arg::new("json")
@@ -63,95 +107,275 @@ impl CliCommand for ScoreCommand {
 
     fn handler(&self, matches: &ArgMatches) -> Result<()> {
         let (app_root, manifest) = require_manifest(matches)?;
-        let modules_root = app_root.join(&manifest.modules_path);
-        let findings = run_local_checks(&modules_root)?;
+        let json_out = matches.get_flag("json");
+        let pretty = matches.get_flag("pretty");
 
-        // Count what run_local_checks actually walked, not what the manifest
-        // lists -- the two differ, and a headline that names a number the scan
-        // did not cover is a small lie in a report about correctness.
-        let module_count = std::fs::read_dir(&modules_root)
-            .map(|entries| {
-                entries
-                    .filter_map(|e| e.ok())
-                    .filter(|e| e.path().is_dir())
-                    .count()
-            })
-            .unwrap_or(0);
-        let card = build_local_report_card(
-            &manifest.app_name,
-            module_count,
-            &findings,
-            crate::core::report_card::iso8601_now(),
-        );
+        let (card_json, share_url) = if matches.get_flag("offline") {
+            (offline_card(&app_root, &manifest.app_name, &manifest.modules_path)?, None)
+        } else {
+            score_via_api(
+                &app_root,
+                &manifest.app_name,
+                !matches.get_flag("no_share"),
+                json_out,
+            )?
+        };
 
-        if matches.get_flag("json") {
-            let serialized = if matches.get_flag("pretty") {
-                serde_json::to_string_pretty(&json!(card))?
+        if json_out {
+            let serialized = if pretty {
+                serde_json::to_string_pretty(&card_json)?
             } else {
-                serde_json::to_string(&json!(card))?
+                serde_json::to_string(&card_json)?
             };
             println!("{}", serialized);
         } else {
-            print_summary(&card);
+            print_summary(&card_json);
+            if let Some(url) = &share_url {
+                println!("  {}", bold(&format!("Report card: {url}")));
+                println!();
+            }
         }
 
-        if let Some(min) = matches.get_one::<u32>("min_score")
-            && card.overall < *min
-        {
-            anyhow::bail!(
-                "readiness score {} is below the required minimum of {}",
-                card.overall,
-                min
-            );
+        if let Some(min) = matches.get_one::<u32>("min_score") {
+            let overall = card_json
+                .get("overall")
+                .and_then(Value::as_u64)
+                .unwrap_or(0) as u32;
+            if overall < *min {
+                anyhow::bail!(
+                    "readiness score {} is below the required minimum of {}",
+                    overall,
+                    min
+                );
+            }
         }
 
         Ok(())
     }
 }
 
-/// Terminal rendering. Default output, because a wall of JSON is not an answer
-/// to "how ready is this" — the checklist and the unmet items are.
-fn print_summary(card: &ReportCard) {
-    println!();
-    println!("  {}  {}/100", bold("Enterprise Readiness"), card.overall);
-    println!("  {}", dim(&card.headline));
-    println!();
+/// Deterministic-only card, built locally. No network, no auth, no cost.
+fn offline_card(app_root: &Path, app_name: &str, modules_path: &str) -> Result<Value> {
+    let modules_root = app_root.join(modules_path);
+    let findings = run_local_checks(&modules_root)?;
+    let module_count = std::fs::read_dir(&modules_root)
+        .map(|entries| {
+            entries
+                .filter_map(|e| e.ok())
+                .filter(|e| e.path().is_dir())
+                .count()
+        })
+        .unwrap_or(0);
 
-    for (key, dim_) in &card.dimensions {
-        let label = {
-            let mut c = key.chars();
-            match c.next() {
-                Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
-                None => key.clone(),
-            }
-        };
+    let card: ReportCard =
+        build_local_report_card(app_name, module_count, &findings, iso8601_now());
+    Ok(json!(card))
+}
 
-        if dim_.pending.unwrap_or(false) {
-            println!("  {:<16} {}", label, dim("not assessed"));
-            continue;
-        }
+fn studio_url(path: &str) -> String {
+    format!(
+        "{}/studio-orchestrator/analysis{}",
+        get_studio_orchestrator_api_url(),
+        path
+    )
+}
 
-        println!("  {:<16} {}/100", label, dim_.score);
-        for item in &dim_.items {
-            let mark = if item.status == "met" { "+" } else { "-" };
-            println!("      {} {}", mark, item.label);
-        }
-        if !dim_.findings.is_empty() {
-            println!(
-                "      {}",
-                dim(&format!("{} finding(s)", dim_.findings.len()))
-            );
-        }
+/// Pack → upload → poll → (optionally) share.
+fn score_via_api(
+    app_root: &Path,
+    app_name: &str,
+    want_share: bool,
+    quiet: bool,
+) -> Result<(Value, Option<String>)> {
+    let auth = AuthMode::detect();
+
+    if !quiet {
         println!();
+        println!("  {} packing workspace…", dim("→"));
+    }
+    let (archive, summary) = pack_workspace(app_root)?;
+    if !quiet {
+        println!(
+            "  {} {} files, {:.1} MB{}",
+            dim("→"),
+            summary.files,
+            summary.bytes as f64 / (1024.0 * 1024.0),
+            if summary.skipped_large > 0 {
+                format!(" ({} large file(s) skipped)", summary.skipped_large)
+            } else {
+                String::new()
+            }
+        );
     }
 
-    println!("  {}", dim(&card.caveat));
+    let zip_base64 = base64::engine::general_purpose::STANDARD.encode(&archive);
+    let body = json!({ "appId": app_name, "zipBase64": zip_base64 });
+
+    if !quiet {
+        println!("  {} uploading for analysis…", dim("→"));
+    }
+    let response = post_with_auth(&auth, &studio_url("/zip"), body)
+        .context("could not reach the analysis API")?;
+    let status = response.status();
+    if !status.is_success() {
+        let text = response.text().unwrap_or_default();
+        return Err(api_error(status.as_u16(), &text));
+    }
+
+    let accepted: Value = response.json().context("analysis API returned no job id")?;
+    let job_id = accepted
+        .get("jobId")
+        .and_then(Value::as_str)
+        .context("analysis API returned no job id")?
+        .to_string();
+
+    let job = poll_job(&auth, &job_id, quiet)?;
+    let card = job
+        .get("reportCard")
+        .cloned()
+        .context("the analysis finished without producing a report card")?;
+
+    let share_url = if want_share {
+        mint_share(&auth, &job_id).unwrap_or(None)
+    } else {
+        None
+    };
+
+    Ok((card, share_url))
+}
+
+/// Poll until the job reaches a terminal state.
+fn poll_job(auth: &AuthMode, job_id: &str, quiet: bool) -> Result<Value> {
+    let started = Instant::now();
+    let mut last_status = String::new();
+
+    loop {
+        if started.elapsed() > POLL_TIMEOUT {
+            anyhow::bail!(
+                "analysis did not finish within {} minutes. It may still complete — check the \
+                 dashboard, or poll job {job_id} directly.",
+                POLL_TIMEOUT.as_secs() / 60
+            );
+        }
+
+        let response = get_with_auth(auth, &studio_url(&format!("/job/{job_id}")))
+            .context("lost contact with the analysis API")?;
+        let http_status = response.status();
+        if !http_status.is_success() {
+            let text = response.text().unwrap_or_default();
+            return Err(api_error(http_status.as_u16(), &text));
+        }
+
+        let job: Value = response.json().context("could not read the job status")?;
+        let status = job.get("status").and_then(Value::as_str).unwrap_or("");
+
+        match status {
+            "done" => return Ok(job),
+            "error" => {
+                let message = job
+                    .get("error")
+                    .and_then(Value::as_str)
+                    .unwrap_or("the analysis failed without a reason");
+                anyhow::bail!("analysis failed: {message}");
+            }
+            other => {
+                if !quiet && other != last_status {
+                    println!("  {} {other}…", dim("→"));
+                    last_status = other.to_string();
+                }
+            }
+        }
+
+        std::thread::sleep(POLL_INTERVAL);
+    }
+}
+
+/// Mint a revocable share link. Best-effort: a scored card the caller can see
+/// is worth more than an error because the link step failed.
+fn mint_share(auth: &AuthMode, job_id: &str) -> Result<Option<String>> {
+    let response = post_with_auth(auth, &studio_url("/share"), json!({ "jobId": job_id }))?;
+    if !response.status().is_success() {
+        return Ok(None);
+    }
+    let body: Value = response.json()?;
+    Ok(body
+        .get("sharePath")
+        .and_then(Value::as_str)
+        .map(|path| format!("{}{}", get_platform_ui_url(), path)))
+}
+
+/// Turn the API's status codes into something a person can act on. The tiering
+/// (anonymous → sign in → free tier → credits) is invisible from a raw 401/402.
+fn api_error(status: u16, body: &str) -> anyhow::Error {
+    match status {
+        401 => anyhow::anyhow!(
+            "not signed in. Run `forklaunch login`, or use `forklaunch score --offline` for the \
+             deterministic checks without an account."
+        ),
+        402 => anyhow::anyhow!(
+            "analysis credits exhausted for this account. Add credits, or use \
+             `forklaunch score --offline` for the deterministic checks."
+        ),
+        413 => anyhow::anyhow!(
+            "the workspace archive was rejected as too large. Exclude generated directories or \
+             score a narrower path with --path."
+        ),
+        _ => anyhow::anyhow!("analysis API returned {status} — {body}"),
+    }
+}
+
+/// Terminal rendering. Default output, because a wall of JSON is not an answer
+/// to "how ready is this" — the checklist and the unmet items are.
+fn print_summary(card: &Value) {
+    let overall = card.get("overall").and_then(Value::as_u64).unwrap_or(0);
     println!();
-    println!(
-        "  {}",
-        dim("Run with --json for the full card, including every finding and its fix.")
-    );
+    println!("  {}  {}/100", bold("Enterprise Readiness"), overall);
+    if let Some(headline) = card.get("headline").and_then(Value::as_str) {
+        println!("  {}", dim(headline));
+    }
     println!();
+
+    if let Some(dimensions) = card.get("dimensions").and_then(Value::as_object) {
+        let mut keys: Vec<&String> = dimensions.keys().collect();
+        keys.sort();
+        for key in keys {
+            let rail = &dimensions[key];
+            let label = {
+                let mut c = key.chars();
+                match c.next() {
+                    Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
+                    None => key.clone(),
+                }
+            };
+
+            if rail.get("pending").and_then(Value::as_bool).unwrap_or(false) {
+                println!("  {:<16} {}", label, dim("not assessed"));
+                continue;
+            }
+
+            let score = rail.get("score").and_then(Value::as_u64).unwrap_or(0);
+            println!("  {:<16} {}/100", label, score);
+
+            if let Some(items) = rail.get("items").and_then(Value::as_array) {
+                for item in items.iter().take(8) {
+                    let met = item.get("status").and_then(Value::as_str) == Some("met");
+                    let text = item.get("label").and_then(Value::as_str).unwrap_or("");
+                    println!("      {} {}", if met { "+" } else { "-" }, text);
+                }
+            }
+            if let Some(findings) = rail.get("findings").and_then(Value::as_array)
+                && !findings.is_empty()
+            {
+                println!("      {}", dim(&format!("{} finding(s)", findings.len())));
+            }
+            println!();
+        }
+    }
+
+    if let Some(caveat) = card.get("caveat").and_then(Value::as_str) {
+        println!("  {}", dim(caveat));
+        println!();
+    }
 }
 
 fn bold(s: &str) -> String {
@@ -160,4 +384,49 @@ fn bold(s: &str) -> String {
 
 fn dim(s: &str) -> String {
     format!("\x1b[2m{s}\x1b[0m")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auth_failures_explain_the_tier_rather_than_the_status_code() {
+        // A raw 401/402 tells the caller nothing about the anonymous → signed-in
+        // → free-tier → credits ladder, and both have an offline escape hatch
+        // worth naming at the point of failure.
+        let unauthorised = api_error(401, "{}").to_string();
+        assert!(unauthorised.contains("forklaunch login"), "{unauthorised}");
+        assert!(unauthorised.contains("--offline"), "{unauthorised}");
+
+        let payment = api_error(402, "{}").to_string();
+        assert!(payment.contains("credits"), "{payment}");
+        assert!(payment.contains("--offline"), "{payment}");
+    }
+
+    #[test]
+    fn an_unexpected_status_keeps_the_body_rather_than_swallowing_it() {
+        let err = api_error(500, "boom").to_string();
+        assert!(err.contains("500"), "{err}");
+        assert!(err.contains("boom"), "{err}");
+    }
+
+    #[test]
+    fn the_studio_path_matches_what_the_dashboard_calls() {
+        // The client hits `${STUDIO_API_URL}/studio-orchestrator/analysis/...`;
+        // a mismatch here 404s against a service that is up and healthy.
+        assert!(studio_url("/zip").ends_with("/studio-orchestrator/analysis/zip"));
+        assert!(studio_url("/share").ends_with("/studio-orchestrator/analysis/share"));
+    }
+
+    #[test]
+    fn summary_renders_a_card_without_panicking_on_missing_fields() {
+        // The API's response is untyped (`unknownSchema`), so the renderer has
+        // to tolerate a card that omits anything.
+        print_summary(&json!({}));
+        print_summary(&json!({
+            "overall": 72,
+            "dimensions": { "security": { "score": 80, "items": [], "findings": [] } }
+        }));
+    }
 }


### PR DESCRIPTION
`forklaunch score` now produces a real **five-rail agent-scored card and a link**, rather than a number that disappears with your scrollback.

```
Enterprise Readiness  72/100
…
Report card: https://forklaunch.com/report-card/<token>
```

It packs the workspace → `POST /analysis/zip` → polls the job → prints the card → mints a revocable share link.

## Why it uploads

Not a choice. `POST /analysis/repo` takes a `workspaceRoot` — a path on the **orchestrator's own disk** — so it cannot see a laptop. `POST /analysis/zip` is the only route from a local checkout. The orchestrator extracts by shelling out to `unzip`, which is why this adds the `zip` crate rather than reusing the `tar`/`flate2` already present.

## What goes in the archive

This sends someone's source to a remote service, so exclusion is layered rather than incidental:

1. **`.gitignore` is honoured** (via `ignore`, the walker ripgrep uses). A repo that declines to track `.env` has already said it shouldn't leave the machine.
2. **`.git`, `node_modules`, `target`, `dist` and friends are dropped regardless.** `.git` carries every secret ever committed *and later removed*; a repo that forgot to ignore something large shouldn't silently upload it.
3. **Files over 2 MB are skipped**, and the whole archive is capped.

Against this repo: **2865 files, 11.5 MB**, 5 large files skipped.

## The cost, and what it means for the loop

Analysis is metered — free tier, then credits — needs `forklaunch login`, and returns a job to poll. That's a milestone action, not a per-pass one.

`--offline` keeps the previous behaviour for the tight loop: deterministic checks only, no upload, no auth, no cost, ~1s — and honest that it can decide only **compliance and security**.

Both skills are rewritten to match. `/getting-started` now calls `score --offline` after every pass and the full `score` at milestones, **and says why** — otherwise an agent following it would bill per codegen pass.

| flag | |
|---|---|
| *(none)* | upload, score, print summary + share link |
| `--offline` | deterministic only — free, ~1s, two rails |
| `--no-share` | score without minting a link |
| `--json` / `--pretty` | raw card for tooling |
| `--min-score N` | CI gate |

## Errors that say what to do

401 and 402 are translated at the point of failure. The tiering (anonymous → sign in → free tier → credits) is invisible from a raw status code, and both cases have an offline escape hatch worth naming right there:

> `not signed in. Run forklaunch login, or use forklaunch score --offline for the deterministic checks without an account.`

## Tests

612 pass. The archive tests cover what actually matters rather than the happy path: a gitignored `.env` and `secrets/` stay local, `.git` and `node_modules` are excluded **even when not gitignored**, oversized files are skipped and counted, and an empty workspace is an error rather than a confident score over nothing.

## Follow-up

Run history — persisting the full card per run and loading a past run into the same `/analyze` view — is the companion PR on the platform side. Nothing persists a card today; only import jobs and share tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UDKRm9cMDurLvhvodioUnE

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forklaunch/codesmith/forklaunch/pr/315"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790881169&installation_model_id=434648&pr_number=315&repository=forklaunch%2Fforklaunch&return_to=https%3A%2F%2Fgithub.com%2Fforklaunch%2Fforklaunch%2Fpull%2F315&signature=6fe4af232851a860d93e3726be5501eba3d54a7cbaf853fcb3eac84d8f42c9ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added online workspace scoring with enterprise-readiness reports, progress updates, and optional shareable results.
  * Added an offline scoring mode for free, read-only compliance and security checks without uploads or network access.
  * Added workspace packaging that respects ignore rules, excludes sensitive files, and reports skipped or oversized content.
  * Added minimum-score enforcement and improved handling of incomplete scoring results.

* **Bug Fixes**
  * Improved error handling and resilient display of scoring results when data is unavailable or incomplete.

* **Documentation**
  * Clarified online, offline, CI, and compliance scoring workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->