### PR TITLE
feat(cli): add `release list` command

### DIFF
--- a/cli/src/release/info.rs
+++ b/cli/src/release/info.rs
@@ -1,46 +1,17 @@
 use std::io::Write;
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Result, bail};
 use clap::{Arg, ArgMatches, Command};
-use serde::Deserialize;
 use termcolor::{ColorChoice, ColorSpec, StandardStream, WriteColor};
 
+use super::shared::fetch_releases;
 use crate::{
     CliCommand,
-    constants::{ERROR_FAILED_TO_SEND_REQUEST, get_platform_management_api_url},
     core::{
         command::command,
-        http_client,
         validate::{require_auth, require_integration, require_manifest},
     },
 };
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct ReleaseSummary {
-    #[serde(default)]
-    id: Option<String>,
-    #[serde(default)]
-    version: Option<String>,
-    #[serde(default)]
-    status: Option<String>,
-    #[serde(default)]
-    created_at: Option<String>,
-    #[serde(default)]
-    git_commit: Option<String>,
-    #[serde(default)]
-    git_branch: Option<String>,
-    #[serde(default)]
-    released_by: Option<String>,
-    #[serde(default)]
-    notes: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct ReleaseListResponse {
-    #[serde(default)]
-    releases: Vec<ReleaseSummary>,
-}
 
 fn print_field(out: &mut StandardStream, label: &str, value: &Option<String>) -> Result<()> {
     if let Some(v) = value {
@@ -84,33 +55,18 @@ impl CliCommand for InfoCommand {
         let app = require_integration(&manifest)?;
         let mut stdout = StandardStream::stdout(ColorChoice::Always);
 
-        let url = format!(
-            "{}/releases/?applicationId={}&limit=50",
-            get_platform_management_api_url(),
-            app
-        );
-        let response = http_client::get(&url).with_context(|| ERROR_FAILED_TO_SEND_REQUEST)?;
-        if !response.status().is_success() {
-            bail!(
-                "Failed to list releases: {}",
-                response.text().unwrap_or_default()
-            );
-        }
-        let list: ReleaseListResponse = response
-            .json()
-            .with_context(|| "Failed to parse release list response")?;
+        let releases = fetch_releases(&app, 50)?;
 
         match matches.get_one::<String>("version") {
             Some(version) => {
-                let Some(release) = list
-                    .releases
+                let Some(release) = releases
                     .iter()
                     .find(|r| r.version.as_deref() == Some(version))
                 else {
                     bail!(
                         "Release '{}' not found. Known versions: {}",
                         version,
-                        list.releases
+                        releases
                             .iter()
                             .filter_map(|r| r.version.clone())
                             .take(10)
@@ -130,7 +86,7 @@ impl CliCommand for InfoCommand {
             }
             None => {
                 writeln!(stdout)?;
-                for release in list.releases.iter().take(5) {
+                for release in releases.iter().take(5) {
                     writeln!(
                         stdout,
                         "  {}  {}  {}",
@@ -139,7 +95,7 @@ impl CliCommand for InfoCommand {
                         release.created_at.clone().unwrap_or_default()
                     )?;
                 }
-                if list.releases.is_empty() {
+                if releases.is_empty() {
                     log_info!(stdout, "No releases yet. Create one with: forklaunch release create --version <version>");
                 }
             }

--- a/cli/src/release/list.rs
+++ b/cli/src/release/list.rs
@@ -1,0 +1,112 @@
+use std::io::Write;
+
+use anyhow::Result;
+use clap::{Arg, ArgMatches, Command};
+use termcolor::{ColorChoice, ColorSpec, StandardStream, WriteColor};
+
+use super::shared::fetch_releases;
+use crate::{
+    CliCommand,
+    core::{
+        command::command,
+        validate::{require_auth, require_integration, require_manifest},
+    },
+};
+
+#[derive(Debug)]
+pub(crate) struct ListCommand;
+
+impl ListCommand {
+    pub(crate) fn new() -> Self {
+        Self {}
+    }
+}
+
+impl CliCommand for ListCommand {
+    fn command(&self) -> Command {
+        command("list", "List all releases for the current application")
+            .arg(
+                Arg::new("limit")
+                    .long("limit")
+                    .default_value("50")
+                    .value_parser(clap::value_parser!(u32).range(1..))
+                    .help("Maximum number of releases to fetch"),
+            )
+            .arg(
+                Arg::new("json")
+                    .long("json")
+                    .help("Output raw JSON instead of a formatted table")
+                    .action(clap::ArgAction::SetTrue),
+            )
+            .arg(
+                Arg::new("base_path")
+                    .long("path")
+                    .short('p')
+                    .help("Path to application root (optional)"),
+            )
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        let _token = require_auth()?;
+        let (_app_root, manifest) = require_manifest(matches)?;
+        let app = require_integration(&manifest)?;
+
+        let limit = matches.get_one::<u32>("limit").copied().unwrap_or(50);
+        let json_output = matches.get_flag("json");
+
+        let releases = fetch_releases(&app, limit)?;
+
+        if json_output {
+            println!("{}", serde_json::to_string_pretty(&releases)?);
+            return Ok(());
+        }
+
+        let mut stdout = StandardStream::stdout(ColorChoice::Always);
+
+        if releases.is_empty() {
+            log_info!(
+                stdout,
+                "No releases yet. Create one with: forklaunch release create --version <version>"
+            );
+            return Ok(());
+        }
+
+        writeln!(stdout)?;
+        stdout.set_color(ColorSpec::new().set_bold(true))?;
+        writeln!(
+            stdout,
+            "  {:<16}  {:<12}  {:<20}  {:<12}  {:<16}  {}",
+            "VERSION", "STATUS", "CREATED", "COMMIT", "BRANCH", "RELEASED BY"
+        )?;
+        stdout.reset()?;
+
+        for release in &releases {
+            let created = release
+                .created_at
+                .as_deref()
+                .map(|c| c.get(..19).unwrap_or(c).to_string())
+                .unwrap_or_default();
+            let commit = release
+                .git_commit
+                .as_deref()
+                .map(|c| c.chars().take(10).collect::<String>())
+                .unwrap_or_default();
+            writeln!(
+                stdout,
+                "  {:<16}  {:<12}  {:<20}  {:<12}  {:<16}  {}",
+                release.version.as_deref().unwrap_or("?"),
+                release.status.as_deref().unwrap_or(""),
+                created,
+                commit,
+                release.git_branch.as_deref().unwrap_or(""),
+                release.released_by.as_deref().unwrap_or("")
+            )?;
+        }
+
+        writeln!(stdout)?;
+        writeln!(stdout, "  {} release(s).", releases.len())?;
+        writeln!(stdout)?;
+
+        Ok(())
+    }
+}

--- a/cli/src/release/mod.rs
+++ b/cli/src/release/mod.rs
@@ -3,20 +3,24 @@ use clap::{ArgMatches, Command};
 use create::CreateCommand;
 use eject::EjectCommand;
 use info::InfoCommand;
+use list::ListCommand;
 
 use crate::{CliCommand, core::command::command};
 
 mod create;
 mod eject;
 mod info;
+mod list;
 mod git;
 mod manifest_generator;
 pub(crate) mod s3_upload;
+mod shared;
 
 #[derive(Debug)]
 pub(crate) struct ReleaseCommand {
     create: CreateCommand,
     info: InfoCommand,
+    list: ListCommand,
     eject: EjectCommand,
 }
 
@@ -25,6 +29,7 @@ impl ReleaseCommand {
         Self {
             create: CreateCommand::new(),
             info: InfoCommand::new(),
+            list: ListCommand::new(),
             eject: EjectCommand::new(),
         }
     }
@@ -35,6 +40,7 @@ impl CliCommand for ReleaseCommand {
         command("release", "Release management")
             .subcommand(self.create.command())
             .subcommand(self.info.command())
+            .subcommand(self.list.command())
             .subcommand(self.eject.command())
     }
 
@@ -42,6 +48,7 @@ impl CliCommand for ReleaseCommand {
         match matches.subcommand() {
             Some(("create", sub_matches)) => self.create.handler(sub_matches),
             Some(("info", sub_matches)) => self.info.handler(sub_matches),
+            Some(("list", sub_matches)) => self.list.handler(sub_matches),
             Some(("eject", sub_matches)) => self.eject.handler(sub_matches),
             // Default to create for convenience
             None => self.create.handler(matches),

--- a/cli/src/release/shared.rs
+++ b/cli/src/release/shared.rs
@@ -1,0 +1,58 @@
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    constants::{ERROR_FAILED_TO_SEND_REQUEST, get_platform_management_api_url},
+    core::http_client,
+};
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ReleaseSummary {
+    #[serde(default)]
+    pub(crate) id: Option<String>,
+    #[serde(default)]
+    pub(crate) version: Option<String>,
+    #[serde(default)]
+    pub(crate) status: Option<String>,
+    #[serde(default)]
+    pub(crate) created_at: Option<String>,
+    #[serde(default)]
+    pub(crate) git_commit: Option<String>,
+    #[serde(default)]
+    pub(crate) git_branch: Option<String>,
+    #[serde(default)]
+    pub(crate) released_by: Option<String>,
+    #[serde(default)]
+    pub(crate) notes: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) struct ReleaseListResponse {
+    #[serde(default)]
+    pub(crate) releases: Vec<ReleaseSummary>,
+}
+
+/// Fetch the release list for an application via `GET /releases/`.
+///
+/// Shared by `release info` and `release list` so both hit the same
+/// platform endpoint with identical parsing.
+pub(crate) fn fetch_releases(app: &str, limit: u32) -> Result<Vec<ReleaseSummary>> {
+    let url = format!(
+        "{}/releases/?applicationId={}&limit={}",
+        get_platform_management_api_url(),
+        app,
+        limit
+    );
+    let response = http_client::get(&url).with_context(|| ERROR_FAILED_TO_SEND_REQUEST)?;
+    if !response.status().is_success() {
+        bail!(
+            "Failed to list releases: {}",
+            response.text().unwrap_or_default()
+        );
+    }
+    let list: ReleaseListResponse = response
+        .json()
+        .with_context(|| "Failed to parse release list response")?;
+    Ok(list.releases)
+}


### PR DESCRIPTION
## What

Adds a `forklaunch release list` subcommand to the Rust CLI that renders a full table of **all** releases for the current application — version, status, created, git commit, git branch, and released-by.

## How

- Reuses the existing `GET /releases/?applicationId=&limit=` platform endpoint — no new route. The application id is resolved from the manifest/integration exactly like `release info`.
- Extracts the fetch + `ReleaseSummary`/`ReleaseListResponse` types out of `release info` into a shared `release/shared.rs` (`fetch_releases`), so `info` and `list` hit the same endpoint with identical parsing. `release info` now calls the shared helper (behavior unchanged).

## Flags

- `--json` — raw JSON output instead of the formatted table.
- `--limit <n>` — max releases to fetch (default 50).

Unlike `release info` (which prints the 5 most recent), `list` renders every returned release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forklaunch/codesmith/forklaunch/pr/317"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790966499&installation_model_id=434648&pr_number=317&repository=forklaunch%2Fforklaunch&return_to=https%3A%2F%2Fgithub.com%2Fforklaunch%2Fforklaunch%2Fpull%2F317&signature=6e2a1c624a43f6ad700551a934b77c9e99b66303adbad3f040573adb5e89b0ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `release list` command for viewing application releases.
  - Supports table and pretty JSON output.
  - Displays release versions, statuses, timestamps, commit and branch details, authors, and notes.
  - Added configurable result limits with validation and clear handling when no releases are available.

- **Improvements**
  - Release information now uses consistent retrieval and display behavior across release commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->