### PR TITLE
feat(cli): managed instance create waits and shows provisioning state

### DIFF
--- a/cli/src/managed/instance/create.rs
+++ b/cli/src/managed/instance/create.rs
@@ -1,18 +1,26 @@
-use std::io::Write;
+use std::{io::Write, thread::sleep, time::Duration};
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use clap::{Arg, ArgAction, ArgMatches, Command};
 use serde_json::json;
 use termcolor::{ColorChoice, StandardStream, WriteColor};
 
 use crate::{
     CliCommand,
-    core::command::command,
+    core::{command::command, hmac::AuthMode},
     managed::{
-        client::{Missing, post_json, print_dryrun, require_managed_mode, resolve_managed_auth},
+        client::{
+            Missing, extract_list, get_value_if_supported, post_json, print_dryrun,
+            require_managed_mode, resolve_managed_auth,
+        },
         types::ManagedInstance,
     },
 };
+
+/// How long to wait between instance-list polls while following a provision. Kept in
+/// the 3 to 5 second range the sibling `deploy create` status loop uses, so the two
+/// commands feel the same to an operator watching either one.
+const POLL_INTERVAL_SECS: u64 = 4;
 
 #[derive(Debug)]
 pub(super) struct CreateCommand;
@@ -48,6 +56,14 @@ impl CliCommand for CreateCommand {
                 .long("region")
                 .required(true)
                 .help("Region to provision the instance in (for example: us-west-2)"),
+        )
+        .arg(
+            Arg::new("no-wait")
+                .long("no-wait")
+                .help(
+                    "Return as soon as the instance is launched instead of waiting for provisioning to finish",
+                )
+                .action(ArgAction::SetTrue),
         )
         .arg(
             Arg::new("dryrun")
@@ -93,9 +109,13 @@ impl CliCommand for CreateCommand {
         )?;
 
         if matches.get_flag("json") {
+            // --json is a one-shot machine-readable dump of the launched instance, so it
+            // returns immediately rather than following provisioning.
             println!("{}", serde_json::to_string_pretty(&instance)?);
             return Ok(());
         }
+
+        let wait = !matches.get_flag("no-wait");
 
         log_ok!(
             stdout,
@@ -112,23 +132,155 @@ impl CliCommand for CreateCommand {
         if let Some(host) = instance.host.as_deref() {
             log_info!(stdout, "Host: {}", host);
         }
-        if let Some(state) = instance.state.as_deref() {
-            log_info!(stdout, "State: {}", state);
+
+        // Without an id there is nothing to poll for (the control plane returns it on
+        // create), so drop back to the background-provisioning guidance either way.
+        let id = instance.id.as_deref();
+        if !wait || id.is_none() {
+            if let Some(state) = instance.state.as_deref() {
+                log_info!(stdout, "State: {}", state);
+            }
+            writeln!(stdout)?;
+            log_info!(
+                stdout,
+                "Provisioning runs in the background. Watch it with `forklaunch managed instance list`."
+            );
+            if let Some(id) = id {
+                log_info!(
+                    stdout,
+                    "Once it reaches awaiting_claim, hand the customer their claim link: forklaunch managed instance claim-link --id {}",
+                    id
+                );
+            }
+            return Ok(());
         }
 
         writeln!(stdout)?;
-        log_info!(
-            stdout,
-            "Provisioning runs in the background. Watch it with `forklaunch managed instance list`."
-        );
-        if let Some(id) = instance.id.as_deref() {
-            log_info!(
-                stdout,
-                "Once it reaches awaiting_claim, hand the customer their claim link: forklaunch managed instance claim-link --id {}",
-                id
-            );
+        log_info!(stdout, "Waiting for provisioning to finish...");
+        wait_for_provisioning(
+            &auth_mode,
+            id.expect("id presence checked above"),
+            instance.state.as_deref(),
+            &mut stdout,
+        )
+    }
+}
+
+/// A terminal provisioning result.
+enum Outcome {
+    /// `awaiting_claim`: the instance is up and ready to hand to the customer.
+    AwaitingClaim,
+    /// `provisioning_failed`: provisioning gave up.
+    Failed,
+}
+
+/// Maps a state to its terminal outcome, or `None` while it is still in progress.
+///
+/// Only the two states the task defines as terminal end the wait; every other state
+/// (including `provisioning` itself) is treated as still in progress so a state the
+/// platform adds later does not end the wait prematurely.
+fn terminal_outcome(state: &str) -> Option<Outcome> {
+    match state {
+        "awaiting_claim" => Some(Outcome::AwaitingClaim),
+        "provisioning_failed" => Some(Outcome::Failed),
+        _ => None,
+    }
+}
+
+/// Fetches the current instance list, preferring the dedicated list endpoint and
+/// falling back to the managed-mode summary, exactly as `managed instance list` does.
+/// There is no single-instance GET endpoint on the control plane today, so following
+/// one instance means polling the list and filtering by id.
+fn fetch_instances(auth_mode: &AuthMode) -> Result<Vec<ManagedInstance>> {
+    match get_value_if_supported(auth_mode, "/instances")? {
+        Some(value) => extract_list::<ManagedInstance>(value, &["instances"]),
+        None => Ok(require_managed_mode(auth_mode)?.instances),
+    }
+}
+
+/// Polls the instance list until this instance reaches a terminal state, printing each
+/// CHANGED state as it goes. Reuses the shape of the sibling `deploy create` status
+/// loop (fixed poll interval, last-value dedupe, terminal detection).
+fn wait_for_provisioning(
+    auth_mode: &AuthMode,
+    id: &str,
+    initial_state: Option<&str>,
+    stdout: &mut StandardStream,
+) -> Result<()> {
+    let mut last_state: Option<String> = None;
+
+    // The create response already carries a state (typically `provisioning`); print it
+    // now so the operator sees progress before the first poll interval elapses, and in
+    // case the instance is already terminal.
+    if let Some(state) = initial_state {
+        log_info!(stdout, "State: {}", state);
+        last_state = Some(state.to_string());
+        if let Some(outcome) = terminal_outcome(state) {
+            return finish(outcome, id, None, stdout);
+        }
+    }
+
+    loop {
+        sleep(Duration::from_secs(POLL_INTERVAL_SECS));
+
+        let instances = fetch_instances(auth_mode)?;
+        let instance = instances
+            .into_iter()
+            .find(|instance| instance.id.as_deref() == Some(id));
+
+        // Right after create the instance can be briefly absent from the list, and a
+        // partial control plane may omit the state; in both cases keep polling rather
+        // than failing.
+        let Some(instance) = instance else {
+            continue;
+        };
+        let Some(state) = instance.state.clone() else {
+            continue;
+        };
+
+        if last_state.as_deref() != Some(state.as_str()) {
+            log_info!(stdout, "State: {}", state);
+            last_state = Some(state.clone());
         }
 
-        Ok(())
+        if let Some(outcome) = terminal_outcome(&state) {
+            return finish(outcome, id, instance.last_error.as_deref(), stdout);
+        }
+    }
+}
+
+/// Prints the closing message for a terminal outcome and, on failure, exits non-zero.
+fn finish(
+    outcome: Outcome,
+    id: &str,
+    last_error: Option<&str>,
+    stdout: &mut StandardStream,
+) -> Result<()> {
+    match outcome {
+        Outcome::AwaitingClaim => {
+            writeln!(stdout)?;
+            log_ok!(stdout, "Instance provisioned and awaiting claim.");
+            log_info!(
+                stdout,
+                "Hand the customer their one-time claim link: forklaunch managed instance claim-link --id {}",
+                id
+            );
+            Ok(())
+        }
+        Outcome::Failed => {
+            writeln!(stdout)?;
+            log_error!(stdout, "Provisioning failed.");
+            // `lastError` is a bonus field on the list projection; print it when the
+            // control plane includes it, otherwise point the operator at the list.
+            if let Some(error) = last_error {
+                log_error!(stdout, "Error: {}", error);
+            } else {
+                log_info!(
+                    stdout,
+                    "See `forklaunch managed instance list` for details."
+                );
+            }
+            bail!("instance provisioning failed");
+        }
     }
 }


### PR DESCRIPTION
## What it does

`forklaunch managed instance create` used to POST once, print the launched instance, and tell the operator to go run `managed instance list` themselves. It now follows provisioning to completion by default.

After the launch POST returns the instance id, the command polls the instance list on a 4 second interval, filters by that id, and prints each STATE change (typically `provisioning`, then the terminal state) with last-value dedupe so a long provision does not scroll the terminal. This copies the shape of the sibling `deploy create` status loop (`cli/src/deploy/utils.rs`).

Terminal states:
- `awaiting_claim` (success): prints the next step, revealing the claim link via `forklaunch managed instance claim-link --id <id>`.
- `provisioning_failed` (failure): prints the instance `lastError` when the list projection includes it (falls back to pointing at `managed instance list` when it does not), and exits non-zero.

## The `--no-wait` flag

`--no-wait` keeps the old fire-and-forget behavior (launch, print, return immediately). Waiting is the default. `--json` also returns immediately, since it is a one-shot machine-readable dump.

## Endpoint reuse

No new endpoints or response fields were invented. There is no single-instance GET endpoint on the control plane today, so polling the existing list endpoint (`GET /managed-mode/instances`, the same one `managed instance list` uses) filtered by id is the correct approach. It reuses the existing managed client (`get_value_if_supported` with a summary fallback, `extract_list`) and the existing `ManagedInstance` type (`state` and the bonus `lastError` field were already parsed).

## Verification

`cd cli && cargo build` is exit 0 with no errors and no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forklaunch/codesmith/forklaunch/pr/318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790967236&installation_model_id=434648&pr_number=318&repository=forklaunch%2Fforklaunch&return_to=https%3A%2F%2Fgithub.com%2Fforklaunch%2Fforklaunch%2Fpull%2F318&signature=cd05a166e8128db77cb6490edcb398ca869c06d6d984ee60cbbc017eaf65883a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->