### PR TITLE
feat(cli): guard deploy create against managed templates

### DIFF
--- a/cli/src/deploy/create.rs
+++ b/cli/src/deploy/create.rs
@@ -16,10 +16,12 @@ use crate::{
         command::command,
         env::extract_env_value,
         env_scope::is_pulumi_injected,
+        hmac::AuthMode,
         http_client,
         validate::{require_active_account, require_integration, require_manifest, resolve_auth},
     },
     deploy::utils::stream_deployment_status,
+    managed::detect::{ManagedDetection, detect_managed_template},
 };
 
 #[derive(Debug, Serialize)]
@@ -485,6 +487,32 @@ fn collect_app_var_keys(blocked_error: &DeploymentBlockedError) -> HashSet<Strin
 }
 
 
+/// Best-effort check for whether this application has any prior deployment. Used only to
+/// decide whether to print the one-line managed-mode hint on a first deploy, so any
+/// uncertainty (request failure, unexpected shape) resolves to `false` and the hint is
+/// never shown spuriously.
+fn has_no_prior_deployments(auth_mode: &AuthMode, application_id: &str) -> bool {
+    let url = format!(
+        "{}/deployments/?applicationId={}&limit=1",
+        get_platform_management_api_url(),
+        application_id
+    );
+    let Ok(response) = http_client::get_with_auth(auth_mode, &url) else {
+        return false;
+    };
+    if !response.status().is_success() {
+        return false;
+    }
+    let Ok(value) = response.json::<serde_json::Value>() else {
+        return false;
+    };
+    value
+        .get("deployments")
+        .and_then(|deployments| deployments.as_array())
+        .map(|deployments| deployments.is_empty())
+        .unwrap_or(false)
+}
+
 #[derive(Debug)]
 pub(crate) struct CreateCommand;
 
@@ -561,6 +589,12 @@ impl CliCommand for CreateCommand {
                     .value_parser(["production", "development"])
                     .help("NODE_ENV for this deployment (production or development)"),
             )
+            .arg(
+                Arg::new("force")
+                    .long("force")
+                    .action(clap::ArgAction::SetTrue)
+                    .help("Deploy even if this app is a managed template (bypasses the managed-template guard)"),
+            )
     }
 
     fn handler(&self, matches: &ArgMatches) -> Result<()> {
@@ -586,6 +620,48 @@ impl CliCommand for CreateCommand {
 
         let wait = !matches.get_flag("no-wait");
         let dry_run = matches.get_flag("dry-run");
+        let force = matches.get_flag("force");
+
+        // Managed-template guard. Whether an app is "managed" is a control-plane fact
+        // (a template keyed by its source repository), not a manifest flag, so ask the
+        // control plane. A managed template must be instantiated per customer via
+        // `managed instance create`, never sent down the single-app deploy pipeline.
+        // Detection is best-effort: it never fails the deploy on its own account.
+        match detect_managed_template(&auth_mode, manifest.git_repository.as_deref()) {
+            ManagedDetection::MatchedTemplate(slug) if !force => {
+                bail!(
+                    "This app is a managed template ({slug}). Launch customer instances with \
+                     `forklaunch managed instance create --template {slug} --region {region}`, \
+                     not `deploy create`. Pass --force to deploy it down the single-app pipeline anyway."
+                );
+            }
+            ManagedDetection::MatchedTemplate(slug) => {
+                log_warn!(
+                    stdout,
+                    "This app matches managed template ({}); deploying it as a single app because --force was given.",
+                    slug
+                );
+                writeln!(stdout)?;
+            }
+            ManagedDetection::ManagedModeAvailableNoMatch => {
+                // First deploy only: a one-line, non-blocking nudge that managed mode
+                // exists, for the case where the user meant to publish a template.
+                if has_no_prior_deployments(&auth_mode, &application_id) {
+                    log_info!(
+                        stdout,
+                        "Managed mode is available here. If this app is meant to be launched per customer, see `forklaunch managed template --help`. Continuing with a single-app deploy."
+                    );
+                    writeln!(stdout)?;
+                }
+            }
+            ManagedDetection::Inconclusive => {
+                if std::env::var("FORKLAUNCH_DEBUG").is_ok() {
+                    eprintln!(
+                        "debug: managed-template detection was inconclusive (no /managed-mode route, non-session auth, or request failed); proceeding as a single-app deploy"
+                    );
+                }
+            }
+        }
 
         let config_pull_url = format!(
             "{}/config/pull?applicationId={}&region={}&environment={}",

--- a/cli/src/managed/detect.rs
+++ b/cli/src/managed/detect.rs
@@ -1,0 +1,129 @@
+//! Deploy-time detection of whether the app being deployed is really a managed
+//! template rather than a single-app project.
+//!
+//! Whether an app is "managed" is a control-plane fact, not something the manifest
+//! records: a managed template is keyed by its source repository. So this asks the
+//! control plane, listing the organization's templates and matching each template's
+//! `sourceRepo` against the manifest's `git_repository`. It never fails the deploy on
+//! its own account. A control plane without the `/managed-mode` routes, or credentials
+//! that cannot be scoped to an organization, both resolve to `Inconclusive` so the
+//! caller proceeds as a single-app deploy.
+
+use super::client::{extract_list, managed_url};
+use super::types::AppTemplate;
+use crate::core::{hmac::AuthMode, http_client::get_with_auth};
+
+/// Outcome of asking the control plane whether the app being deployed is a managed
+/// template.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ManagedDetection {
+    /// The app's git repository matches a template the organization has registered.
+    /// Carries the template slug so the caller can redirect the user to
+    /// `managed instance create`.
+    MatchedTemplate(String),
+    /// The control plane exposes managed mode and answered, but no template matched.
+    /// A first deploy can use this to hint that managed mode exists.
+    ManagedModeAvailableNoMatch,
+    /// Detection could not run: this control plane has no `/managed-mode` routes (an
+    /// older or self-hosted platform answers 404), the credentials carry no organization
+    /// identity (HMAC/CI answers 401/403), or the request itself failed. The caller must
+    /// treat the app as NOT managed and proceed.
+    Inconclusive,
+}
+
+/// Normalizes a git repository URL for tolerant comparison: trims surrounding
+/// whitespace, drops a trailing `.git` and any trailing slash, and lowercases (host case
+/// is not significant, and the repositories these compare are not case-sensitive in
+/// practice). It deliberately does not try to reconcile ssh and https forms, because the
+/// only differences in scope are the trivial ones, and over-normalizing risks a false
+/// match that would wrongly block a deploy.
+fn normalize_repo(repo: &str) -> String {
+    let trimmed = repo.trim().trim_end_matches('/');
+    let without_git = trimmed.strip_suffix(".git").unwrap_or(trimmed);
+    without_git.trim_end_matches('/').to_lowercase()
+}
+
+/// Given the resolved manifest's `git_repository`, returns the matching template slug (as
+/// `MatchedTemplate`) if any published or unpublished template's `sourceRepo` matches.
+///
+/// Reuses the same 404 tolerance the rest of the managed client relies on: any
+/// non-success status (404 for an unmounted router, 401/403 for HMAC/CI credentials that
+/// carry no organization) resolves to `Inconclusive`, as does a network error or a
+/// response this CLI cannot parse. The deploy is never failed just because detection
+/// could not run.
+pub(crate) fn detect_managed_template(
+    auth_mode: &AuthMode,
+    git_repository: Option<&str>,
+) -> ManagedDetection {
+    // With no repository recorded in the manifest there is nothing to match on.
+    let Some(git_repository) = git_repository else {
+        return ManagedDetection::Inconclusive;
+    };
+    let target = normalize_repo(git_repository);
+    if target.is_empty() {
+        return ManagedDetection::Inconclusive;
+    }
+
+    // Include unpublished templates on purpose: deploying a DRAFT managed template down
+    // the single-app pipeline is exactly as wrong as deploying a published one.
+    let url = managed_url("/templates?includeUnpublished=true");
+    let response = match get_with_auth(auth_mode, &url) {
+        Ok(response) => response,
+        Err(_) => return ManagedDetection::Inconclusive,
+    };
+
+    if !response.status().is_success() {
+        return ManagedDetection::Inconclusive;
+    }
+
+    let value = match response.json::<serde_json::Value>() {
+        Ok(value) => value,
+        Err(_) => return ManagedDetection::Inconclusive,
+    };
+    let templates: Vec<AppTemplate> = match extract_list(value, &["templates"]) {
+        Ok(templates) => templates,
+        Err(_) => return ManagedDetection::Inconclusive,
+    };
+
+    for template in &templates {
+        let (Some(source_repo), Some(slug)) =
+            (template.source_repo.as_deref(), template.slug.as_deref())
+        else {
+            continue;
+        };
+        if normalize_repo(source_repo) == target {
+            return ManagedDetection::MatchedTemplate(slug.to_string());
+        }
+    }
+
+    ManagedDetection::ManagedModeAvailableNoMatch
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_repo_ignores_trailing_git_slash_and_case() {
+        assert_eq!(
+            normalize_repo("https://GitHub.com/Acme/clinic.git"),
+            normalize_repo("https://github.com/acme/clinic")
+        );
+        assert_eq!(
+            normalize_repo("https://github.com/acme/clinic/"),
+            "https://github.com/acme/clinic"
+        );
+        assert_eq!(
+            normalize_repo("https://github.com/acme/clinic.git/"),
+            "https://github.com/acme/clinic"
+        );
+    }
+
+    #[test]
+    fn normalize_repo_does_not_conflate_different_repositories() {
+        assert_ne!(
+            normalize_repo("https://github.com/acme/clinic"),
+            normalize_repo("https://github.com/acme/clinic-staging")
+        );
+    }
+}

--- a/cli/src/managed/mod.rs
+++ b/cli/src/managed/mod.rs
@@ -4,6 +4,7 @@ use clap::{ArgMatches, Command};
 use crate::{CliCommand, core::command::command};
 
 mod client;
+pub(crate) mod detect;
 mod instance;
 mod summary;
 mod template;


### PR DESCRIPTION
## Problem

`forklaunch deploy create` resolves its target from the manifest and POSTs `/deployments` with no check for whether the app is a managed template. A managed template is meant to be instantiated once per customer via `managed instance create`; if you point `deploy create` at one, it silently deploys the template itself down the single-app pipeline, which is the wrong path entirely and produces a deployment nobody wants.

## Detection is control-plane-authoritative

Whether an app is "managed" is a control-plane fact, not a manifest flag: a managed template is keyed by its `sourceRepo`. So detection asks the control plane rather than adding a manifest field. The new `managed::detect` helper calls `GET /managed-mode/templates?includeUnpublished=true` and compares each template's `sourceRepo` against the manifest's `git_repository`, normalizing the trivial differences (trailing `.git`, trailing slash, host/casing). Unpublished templates are included on purpose, because deploying a draft template down the single-app pipeline is just as wrong as deploying a published one.

Detection is best-effort and never fails the deploy on its own account. It reuses the existing 404 tolerance in the managed client: a control plane with no `/managed-mode` routes (older or self-hosted) answers 404, HMAC/CI credentials that carry no organization answer 401/403, and a network error is a network error. All of these resolve to `Inconclusive`, and the deploy proceeds as a single app (with a debug note under `FORKLAUNCH_DEBUG`).

## The guard, the override, and the first-deploy hint

Right after resolving the integration and before the deploy POST:

- **Match found:** error out with a redirect. "This app is a managed template (`<slug>`). Launch customer instances with `forklaunch managed instance create --template <slug> --region <region>`, not `deploy create`."
- **`--force`:** a new flag that bypasses the guard for the rare intentional case (deploys with a warning instead of blocking).
- **First-deploy hint:** when this is a first deploy (no prior deployment for the app) and managed mode is exposed but nothing matched, print a one-line non-blocking hint that managed mode exists and where to look. It is a printed hint, not an interactive prompt, so it is safe with no TTY.

## Verification

- `cd cli && cargo build` exits 0.
- `cargo test detect` passes (repo-normalization unit tests, including that different repositories are not conflated).
- Only the three intended files are touched: `cli/src/managed/detect.rs` (new), `cli/src/managed/mod.rs`, `cli/src/deploy/create.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forklaunch/codesmith/forklaunch/pr/319"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790967334&installation_model_id=434648&pr_number=319&repository=forklaunch%2Fforklaunch&return_to=https%3A%2F%2Fgithub.com%2Fforklaunch%2Fforklaunch%2Fpull%2F319&signature=61bc703e0d127ffa0264199f4b1906272c05ffaf04cef98a4a8424eb2d51483a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->