### PR TITLE
feat(cli): hosting knob, honest cluster gate, and machine-readable deploy failures

### DIFF
--- a/cli/src/app.rs
+++ b/cli/src/app.rs
@@ -3,6 +3,7 @@ use clap::{ArgMatches, Command};
 use controller::ControllerCommand;
 use create::CreateCommand;
 use domain::DomainCommand;
+use hosting::HostingCommand;
 use resize::ResizeCommand;
 use route::RouteCommand;
 use services::ServicesCommand;
@@ -12,6 +13,7 @@ use crate::{CliCommand, core::command::command};
 mod controller;
 mod create;
 mod domain;
+mod hosting;
 mod resize;
 mod route;
 mod services;
@@ -21,6 +23,7 @@ pub(crate) struct AppCommand {
     create: CreateCommand,
     services: ServicesCommand,
     domain: DomainCommand,
+    hosting: HostingCommand,
     resize: ResizeCommand,
     route: RouteCommand,
     controller: ControllerCommand,
@@ -32,6 +35,7 @@ impl AppCommand {
             create: CreateCommand::new(),
             services: ServicesCommand::new(),
             domain: DomainCommand::new(),
+            hosting: HostingCommand::new(),
             resize: ResizeCommand::new(),
             route: RouteCommand::new(),
             controller: ControllerCommand::new(),
@@ -46,6 +50,7 @@ impl CliCommand for AppCommand {
             .subcommand(self.create.command())
             .subcommand(self.services.command())
             .subcommand(self.domain.command())
+            .subcommand(self.hosting.command())
             .subcommand(self.resize.command())
             .subcommand(self.route.command())
             .subcommand(self.controller.command())
@@ -56,6 +61,7 @@ impl CliCommand for AppCommand {
             Some(("create", matches)) => self.create.handler(matches),
             Some(("services", matches)) => self.services.handler(matches),
             Some(("domain", matches)) => self.domain.handler(matches),
+            Some(("hosting", matches)) => self.hosting.handler(matches),
             Some(("resize", matches)) => self.resize.handler(matches),
             Some(("route", matches)) => self.route.handler(matches),
             Some(("controller", matches)) => self.controller.handler(matches),

--- a/cli/src/app/hosting.rs
+++ b/cli/src/app/hosting.rs
@@ -1,0 +1,295 @@
+//! `forklaunch app hosting` — read and change where an application runs.
+//!
+//! Placement (`platform-shared` | `org-shared` | `dedicated`) used to be
+//! write-once: settable at `app create`, enforced at the first-deploy gate, and
+//! changeable nowhere. It was also unreadable — the application read API did not
+//! return it — so a user could not even find out what they had chosen, let alone
+//! switch. This command is both halves.
+//!
+//! The cost of a change is not uniform, and the control plane enforces the
+//! difference rather than this command guessing at it:
+//!
+//! - Before any infrastructure exists, placement is a record and the change is
+//!   instant and free.
+//! - Afterwards the application's data lives on a substrate, so moving it runs
+//!   as a migration with a cutover, and requires `--confirm-downtime`.
+
+use std::io::Write;
+
+use anyhow::{Context, Result, bail};
+use clap::{Arg, ArgAction, ArgMatches, Command};
+use serde::Deserialize;
+use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
+
+use crate::{
+    CliCommand,
+    constants::{ERROR_FAILED_TO_SEND_REQUEST, get_platform_management_api_url},
+    core::{
+        command::command,
+        http_client,
+        validate::{require_auth, require_integration, require_manifest},
+    },
+};
+
+const CLUSTER_TYPES: [&str; 3] = ["platform-shared", "org-shared", "dedicated"];
+const FRAMEWORKS: [&str; 5] = ["HIPAA", "PCI-DSS", "SOC 2", "GDPR", "CCPA"];
+
+#[derive(Debug, Deserialize)]
+struct PlacementResponse {
+    #[serde(rename = "clusterType")]
+    cluster_type: Option<String>,
+    #[serde(rename = "complianceFrameworks")]
+    compliance_frameworks: Option<Vec<String>>,
+    #[serde(rename = "defaultHostingType")]
+    default_hosting_type: Option<String>,
+    #[serde(rename = "changeIsFree")]
+    change_is_free: bool,
+    #[serde(rename = "migrationId")]
+    migration_id: Option<String>,
+    message: String,
+}
+
+#[derive(Debug)]
+pub(crate) struct HostingCommand;
+
+impl HostingCommand {
+    pub(crate) fn new() -> Self {
+        Self
+    }
+}
+
+fn render(stdout: &mut StandardStream, placement: &PlacementResponse) -> Result<()> {
+    writeln!(stdout)?;
+    log_header!(stdout, Color::Cyan, "Hosting");
+    writeln!(stdout)?;
+    writeln!(
+        stdout,
+        "  Cluster placement   {}",
+        placement
+            .cluster_type
+            .as_deref()
+            .unwrap_or("not chosen — the first deploy will ask")
+    )?;
+    writeln!(
+        stdout,
+        "  Resolved host       {}",
+        placement
+            .default_hosting_type
+            .as_deref()
+            .unwrap_or("ecs-fargate (default)")
+    )?;
+    // "not declared" and "declared as none" are different claims: an undeclared
+    // application is unconstrained, not certified unregulated.
+    writeln!(
+        stdout,
+        "  Compliance scope    {}",
+        match placement.compliance_frameworks.as_ref() {
+            Some(frameworks) if !frameworks.is_empty() => frameworks.join(", "),
+            _ => String::from("not declared"),
+        }
+    )?;
+    writeln!(stdout)?;
+    Ok(())
+}
+
+impl CliCommand for HostingCommand {
+    fn command(&self) -> Command {
+        command(
+            "hosting",
+            "Show or change where this application's compute runs",
+        )
+        .arg(
+            Arg::new("cluster_type")
+                .long("cluster-type")
+                .value_parser(CLUSTER_TYPES)
+                .help(
+                    "Move the application to this placement. Free before the first deploy; \
+                     a data migration afterwards",
+                ),
+        )
+        .arg(
+            Arg::new("compliance_framework")
+                .long("compliance-framework")
+                .action(ArgAction::Append)
+                .value_parser(FRAMEWORKS)
+                .help(
+                    "Replace the frameworks this application is scoped to; repeatable. \
+                     Compliance-scoped apps cannot run on cross-tenant compute",
+                ),
+        )
+        .arg(
+            Arg::new("region")
+                .long("region")
+                .help("Region the change applies to (required when changing anything)"),
+        )
+        .arg(
+            Arg::new("confirm_downtime")
+                .long("confirm-downtime")
+                .action(ArgAction::SetTrue)
+                .help(
+                    "Acknowledge that moving an already-deployed application takes it \
+                     offline during cutover",
+                ),
+        )
+        .arg(
+            Arg::new("base_path")
+                .long("path")
+                .short('p')
+                .help("Path to application root (optional)"),
+        )
+    }
+
+    fn handler(&self, matches: &ArgMatches) -> Result<()> {
+        let mut stdout = StandardStream::stdout(ColorChoice::Always);
+
+        require_auth()?;
+        let (_app_root, manifest) = require_manifest(matches)?;
+        let application_id = require_integration(&manifest)?;
+        let api_url = get_platform_management_api_url();
+
+        let cluster_type = matches.get_one::<String>("cluster_type").cloned();
+        let frameworks: Option<Vec<String>> = matches
+            .get_many::<String>("compliance_framework")
+            .map(|values| values.cloned().collect());
+
+        // No change requested: this is a read.
+        if cluster_type.is_none() && frameworks.is_none() {
+            let response = http_client::get(&format!(
+                "{}/applications/{}/placement",
+                api_url, application_id
+            ))
+            .with_context(|| ERROR_FAILED_TO_SEND_REQUEST)?;
+            if !response.status().is_success() {
+                bail!(
+                    "Failed to read hosting ({}): {}",
+                    response.status(),
+                    response.text().unwrap_or_default()
+                );
+            }
+            let placement: PlacementResponse = response
+                .json()
+                .with_context(|| "Failed to parse placement response")?;
+            render(&mut stdout, &placement)?;
+            if placement.change_is_free {
+                log_info!(
+                    stdout,
+                    "Nothing is deployed yet, so changing this is instant and costs nothing."
+                );
+            } else {
+                log_info!(
+                    stdout,
+                    "This application is deployed. Changing placement migrates its data — pass --confirm-downtime."
+                );
+            }
+            return Ok(());
+        }
+
+        let Some(region) = matches.get_one::<String>("region").cloned() else {
+            bail!(
+                "--region is required when changing hosting: a cluster can be available in one region and not another."
+            );
+        };
+
+        let mut body = serde_json::json!({ "region": region });
+        if let Some(cluster_type) = &cluster_type {
+            body["clusterType"] = serde_json::json!(cluster_type);
+        }
+        if let Some(frameworks) = &frameworks {
+            body["complianceFrameworks"] = serde_json::json!(frameworks);
+        }
+        if matches.get_flag("confirm_downtime") {
+            body["confirmDowntime"] = serde_json::json!(true);
+        }
+
+        let response = http_client::patch(
+            &format!("{}/applications/{}/placement", api_url, application_id),
+            body,
+        )
+        .with_context(|| ERROR_FAILED_TO_SEND_REQUEST)?;
+
+        let status = response.status();
+        if !status.is_success() {
+            // 422 is the downtime acknowledgement and the no-op case; 409 is a
+            // placement the app may not use, or a migration already running.
+            // All three carry a message written to be read by a human, so relay
+            // it rather than wrapping it in a generic failure.
+            bail!("{}", response.text().unwrap_or_default());
+        }
+
+        let placement: PlacementResponse = response
+            .json()
+            .with_context(|| "Failed to parse placement response")?;
+
+        render(&mut stdout, &placement)?;
+        if let Some(migration_id) = &placement.migration_id {
+            log_warn!(stdout, "{}", placement.message);
+            log_info!(stdout, "Migration id: {}", migration_id);
+            log_info!(
+                stdout,
+                "The application stays up until cutover. Track it in the dashboard."
+            );
+        } else {
+            log_ok!(stdout, "{}", placement.message);
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::CliCommand;
+
+    /// `propagate_version(true)` requires a version on the root command, which
+    /// only exists once this is mounted under `forklaunch`. Supply one so the
+    /// subcommand can be exercised on its own.
+    fn hosting_cmd() -> Command {
+        HostingCommand::new().command().version("0.0.0-test")
+    }
+
+    #[test]
+    fn command_definition_is_valid() {
+        hosting_cmd().debug_assert();
+    }
+
+    /// With no flags this is a read, not an empty change. Getting that wrong
+    /// would send a PATCH with nothing in it on every plain `app hosting`.
+    #[test]
+    fn no_flags_means_read() {
+        let matches = hosting_cmd()
+            .try_get_matches_from(vec!["hosting"])
+            .unwrap();
+        assert!(matches.get_one::<String>("cluster_type").is_none());
+        assert!(matches.get_many::<String>("compliance_framework").is_none());
+    }
+
+    #[test]
+    fn compliance_frameworks_are_repeatable() {
+        let matches = hosting_cmd()
+            .try_get_matches_from(vec![
+                "hosting",
+                "--compliance-framework",
+                "HIPAA",
+                "--compliance-framework",
+                "SOC 2",
+                "--region",
+                "us-west-2",
+            ])
+            .unwrap();
+        let frameworks: Vec<&String> = matches
+            .get_many::<String>("compliance_framework")
+            .unwrap()
+            .collect();
+        assert_eq!(frameworks, vec!["HIPAA", "SOC 2"]);
+    }
+
+    #[test]
+    fn an_unknown_cluster_type_is_refused_before_the_network() {
+        assert!(
+            hosting_cmd()
+                .try_get_matches_from(vec!["hosting", "--cluster-type", "serverless"])
+                .is_err()
+        );
+    }
+}

--- a/cli/src/deploy/create.rs
+++ b/cli/src/deploy/create.rs
@@ -16,10 +16,12 @@ use crate::{
         command::command,
         env::extract_env_value,
         env_scope::is_pulumi_injected,
+        hmac::AuthMode,
         http_client,
         validate::{require_active_account, require_integration, require_manifest, resolve_auth},
     },
     deploy::utils::stream_deployment_status,
+    managed::detect::{ManagedDetection, detect_managed_template},
 };
 
 #[derive(Debug, Serialize)]
@@ -485,6 +487,32 @@ fn collect_app_var_keys(blocked_error: &DeploymentBlockedError) -> HashSet<Strin
 }
 
 
+/// Best-effort check for whether this application has any prior deployment. Used only to
+/// decide whether to print the one-line managed-mode hint on a first deploy, so any
+/// uncertainty (request failure, unexpected shape) resolves to `false` and the hint is
+/// never shown spuriously.
+fn has_no_prior_deployments(auth_mode: &AuthMode, application_id: &str) -> bool {
+    let url = format!(
+        "{}/deployments/?applicationId={}&limit=1",
+        get_platform_management_api_url(),
+        application_id
+    );
+    let Ok(response) = http_client::get_with_auth(auth_mode, &url) else {
+        return false;
+    };
+    if !response.status().is_success() {
+        return false;
+    }
+    let Ok(value) = response.json::<serde_json::Value>() else {
+        return false;
+    };
+    value
+        .get("deployments")
+        .and_then(|deployments| deployments.as_array())
+        .map(|deployments| deployments.is_empty())
+        .unwrap_or(false)
+}
+
 #[derive(Debug)]
 pub(crate) struct CreateCommand;
 
@@ -561,6 +589,12 @@ impl CliCommand for CreateCommand {
                     .value_parser(["production", "development"])
                     .help("NODE_ENV for this deployment (production or development)"),
             )
+            .arg(
+                Arg::new("force")
+                    .long("force")
+                    .action(clap::ArgAction::SetTrue)
+                    .help("Deploy even if this app is a managed template (bypasses the managed-template guard)"),
+            )
     }
 
     fn handler(&self, matches: &ArgMatches) -> Result<()> {
@@ -586,6 +620,48 @@ impl CliCommand for CreateCommand {
 
         let wait = !matches.get_flag("no-wait");
         let dry_run = matches.get_flag("dry-run");
+        let force = matches.get_flag("force");
+
+        // Managed-template guard. Whether an app is "managed" is a control-plane fact
+        // (a template keyed by its source repository), not a manifest flag, so ask the
+        // control plane. A managed template must be instantiated per customer via
+        // `managed instance create`, never sent down the single-app deploy pipeline.
+        // Detection is best-effort: it never fails the deploy on its own account.
+        match detect_managed_template(&auth_mode, manifest.git_repository.as_deref()) {
+            ManagedDetection::MatchedTemplate(slug) if !force => {
+                bail!(
+                    "This app is a managed template ({slug}). Launch customer instances with \
+                     `forklaunch managed instance create --template {slug} --region {region}`, \
+                     not `deploy create`. Pass --force to deploy it down the single-app pipeline anyway."
+                );
+            }
+            ManagedDetection::MatchedTemplate(slug) => {
+                log_warn!(
+                    stdout,
+                    "This app matches managed template ({}); deploying it as a single app because --force was given.",
+                    slug
+                );
+                writeln!(stdout)?;
+            }
+            ManagedDetection::ManagedModeAvailableNoMatch => {
+                // First deploy only: a one-line, non-blocking nudge that managed mode
+                // exists, for the case where the user meant to publish a template.
+                if has_no_prior_deployments(&auth_mode, &application_id) {
+                    log_info!(
+                        stdout,
+                        "Managed mode is available here. If this app is meant to be launched per customer, see `forklaunch managed template --help`. Continuing with a single-app deploy."
+                    );
+                    writeln!(stdout)?;
+                }
+            }
+            ManagedDetection::Inconclusive => {
+                if std::env::var("FORKLAUNCH_DEBUG").is_ok() {
+                    eprintln!(
+                        "debug: managed-template detection was inconclusive (no /managed-mode route, non-session auth, or request failed); proceeding as a single-app deploy"
+                    );
+                }
+            }
+        }
 
         let config_pull_url = format!(
             "{}/config/pull?applicationId={}&region={}&environment={}",

--- a/cli/src/deploy/create.rs
+++ b/cli/src/deploy/create.rs
@@ -1083,6 +1083,8 @@ impl CliCommand for CreateCommand {
                     stream_deployment_status(
                         &auth_mode,
                         &deployment.id,
+                        Some(&environment),
+                        Some(region.as_str()),
                         &mut stdout,
                     )?;
                     writeln!(stdout)?;

--- a/cli/src/deploy/create.rs
+++ b/cli/src/deploy/create.rs
@@ -40,11 +40,49 @@ struct CreateDeploymentRequest {
     #[serde(rename = "clusterType")]
     #[serde(skip_serializing_if = "Option::is_none")]
     cluster_type: Option<String>,
+    /// Deploy a managed-mode application down the single-app pipeline anyway.
+    /// The control plane refuses this by default; `--force` is the deliberate
+    /// override. Omitted entirely when not set, so an older control plane that
+    /// does not know the field is unaffected.
+    #[serde(rename = "forceSingleAppDeploy")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    force_single_app_deploy: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]
 struct CreateDeploymentResponse {
     id: String,
+}
+
+/// What a placement means for isolation, as the control plane computes it.
+///
+/// The server has always sent this; the CLI used to drop it on the floor and
+/// print only the price. That left the terminal user choosing between $2 and
+/// $108 a month with no statement of what the difference buys — and the
+/// difference is whether their containers share a host with another
+/// organization's workloads.
+#[derive(Debug, Deserialize)]
+struct ClusterCompliance {
+    /// Hosts shared with workloads belonging to OTHER organizations.
+    #[serde(rename = "crossTenantHosts", default)]
+    cross_tenant_hosts: bool,
+    /// May host compliance-scoped workloads.
+    #[serde(rename = "complianceCapable", default)]
+    compliance_capable: bool,
+    /// Factual isolation properties, rendered under the option.
+    #[serde(default)]
+    notes: Vec<String>,
+    #[serde(default)]
+    frameworks: Vec<FrameworkVerdict>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FrameworkVerdict {
+    framework: String,
+    /// "ok" | "blocked" | "review" | "not-affected"
+    impact: String,
+    #[allow(dead_code)]
+    reason: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -58,6 +96,37 @@ struct ClusterOption {
     unavailable_reason: Option<String>,
     #[serde(rename = "estimatedMonthlyUsd")]
     estimated_monthly_usd: f64,
+    /// Absent on an older control plane, which is why this is optional rather
+    /// than defaulted — "not reported" and "reported as unrestricted" are
+    /// different claims and must not render the same.
+    #[serde(default)]
+    compliance: Option<ClusterCompliance>,
+}
+
+impl ClusterOption {
+    /// One line naming what this placement does to isolation, or `None` when
+    /// the control plane did not report a profile.
+    fn isolation_line(&self) -> Option<String> {
+        let compliance = self.compliance.as_ref()?;
+        let blocked: Vec<&str> = compliance
+            .frameworks
+            .iter()
+            .filter(|verdict| verdict.impact == "blocked")
+            .map(|verdict| verdict.framework.as_str())
+            .collect();
+
+        let mut line = if compliance.cross_tenant_hosts {
+            String::from("Shares hosts with other organizations")
+        } else {
+            String::from("Hosts are not shared outside your organization")
+        };
+        if !blocked.is_empty() {
+            line.push_str(&format!("; cannot host {}", blocked.join(", ")));
+        } else if compliance.compliance_capable {
+            line.push_str("; can host compliance-scoped workloads");
+        }
+        Some(line)
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -757,6 +826,7 @@ impl CliCommand for CreateCommand {
             ),
             force_refresh: if matches.get_flag("full") { Some(true) } else { None },
             cluster_type: matches.get_one::<String>("cluster-type").cloned(),
+            force_single_app_deploy: if force { Some(true) } else { None },
         };
 
         if dry_run {
@@ -1032,11 +1102,36 @@ impl CliCommand for CreateCommand {
                         format!("Failed to parse cluster selection response: {}", error_text)
                     })?;
 
+                // The control plane sends two different 428s down this path, and
+                // they mean opposite things to the user:
+                //   cluster_selection_required — nothing has been chosen yet
+                //   cluster_unavailable        — a choice WAS made and is refused
+                // Printing the same "this is the first deployment" header for both
+                // told a user who had already chosen at `app create` that they had
+                // never chosen, and silently dropped the server's explanation.
+                let rejected_choice =
+                    selection_required.message.starts_with("cluster_unavailable");
+
                 writeln!(stdout)?;
-                log_header!(stdout, Color::Cyan, "First deploy — choose a cluster");
-                writeln!(stdout)?;
-                writeln!(stdout, "  This is the first deployment of this application to {} ({}).", environment, region)?;
-                writeln!(stdout, "  Pick where its compute should run (estimates are monthly, compute only):")?;
+                if rejected_choice {
+                    log_header!(stdout, Color::Yellow, "That cluster isn't available for this app");
+                    writeln!(stdout)?;
+                    writeln!(
+                        stdout,
+                        "  {}",
+                        selection_required
+                            .message
+                            .trim_start_matches("cluster_unavailable:")
+                            .trim()
+                    )?;
+                    writeln!(stdout)?;
+                    writeln!(stdout, "  Pick another placement for {} ({}):", environment, region)?;
+                } else {
+                    log_header!(stdout, Color::Cyan, "First deploy — choose a cluster");
+                    writeln!(stdout)?;
+                    writeln!(stdout, "  This is the first deployment of this application to {} ({}).", environment, region)?;
+                    writeln!(stdout, "  Pick where its compute should run (estimates are monthly, compute only):")?;
+                }
                 writeln!(stdout)?;
                 for opt in &selection_required.cluster_options {
                     let availability = if opt.available {
@@ -1046,6 +1141,11 @@ impl CliCommand for CreateCommand {
                     };
                     writeln!(stdout, "  • {:<32} {}", opt.label, availability)?;
                     writeln!(stdout, "      {}", opt.description)?;
+                    // The isolation consequence, not just the price — this is the
+                    // half of the tradeoff the price alone cannot express.
+                    if let Some(isolation) = opt.isolation_line() {
+                        writeln!(stdout, "      {}", isolation)?;
+                    }
                     if let Some(reason) = &opt.unavailable_reason {
                         writeln!(stdout, "      ({})", reason)?;
                     }
@@ -1362,5 +1462,90 @@ impl CliCommand for CreateCommand {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod cluster_option_tests {
+    use super::*;
+
+    fn option_json(compliance: &str) -> String {
+        format!(
+            r#"{{
+                "clusterType": "platform-shared",
+                "label": "Platform shared cluster",
+                "description": "Packed onto ForkLaunch-managed shared hosts.",
+                "available": true,
+                "estimatedMonthlyUsd": 2.0,
+                "compliance": {compliance}
+            }}"#
+        )
+    }
+
+    #[test]
+    fn cross_tenant_hosting_is_stated_outright() {
+        let option: ClusterOption = serde_json::from_str(&option_json(
+            r#"{"crossTenantHosts": true, "complianceCapable": false,
+                "notes": [], "frameworks": []}"#,
+        ))
+        .unwrap();
+        assert_eq!(
+            option.isolation_line().unwrap(),
+            "Shares hosts with other organizations"
+        );
+    }
+
+    #[test]
+    fn blocked_frameworks_are_named_rather_than_implied() {
+        let option: ClusterOption = serde_json::from_str(&option_json(
+            r#"{"crossTenantHosts": true, "complianceCapable": false, "notes": [],
+                "frameworks": [
+                  {"framework": "HIPAA", "impact": "blocked", "reason": "cross-tenant"},
+                  {"framework": "GDPR", "impact": "not-affected", "reason": "n/a"},
+                  {"framework": "SOC 2", "impact": "blocked", "reason": "cross-tenant"}
+                ]}"#,
+        ))
+        .unwrap();
+        let line = option.isolation_line().unwrap();
+        assert!(line.contains("cannot host HIPAA, SOC 2"), "got: {line}");
+        // A framework the placement does not affect must not be listed as blocked.
+        assert!(!line.contains("GDPR"), "got: {line}");
+    }
+
+    #[test]
+    fn a_compliance_capable_placement_says_so() {
+        let option: ClusterOption = serde_json::from_str(&option_json(
+            r#"{"crossTenantHosts": false, "complianceCapable": true, "notes": [],
+                "frameworks": [{"framework": "HIPAA", "impact": "ok", "reason": "boundary holds"}]}"#,
+        ))
+        .unwrap();
+        assert_eq!(
+            option.isolation_line().unwrap(),
+            "Hosts are not shared outside your organization; can host compliance-scoped workloads"
+        );
+    }
+
+    /// An older control plane sends no `compliance` object. That must render as
+    /// nothing at all — inventing "no restrictions" from a missing field would
+    /// be a compliance claim the server never made.
+    #[test]
+    fn a_missing_compliance_profile_renders_nothing() {
+        let option: ClusterOption = serde_json::from_str(
+            r#"{"clusterType": "dedicated", "label": "Dedicated", "description": "d",
+                "available": true, "estimatedMonthlyUsd": 108.0}"#,
+        )
+        .unwrap();
+        assert!(option.isolation_line().is_none());
+    }
+
+    /// The two 428s mean opposite things to a user; the CLI distinguishes them
+    /// on the server's message prefix, so that prefix is load-bearing.
+    #[test]
+    fn the_two_gate_messages_are_distinguishable() {
+        let rejected = "cluster_unavailable: This application is scoped to HIPAA";
+        let first_deploy =
+            "cluster_selection_required: this is the first deployment of this application";
+        assert!(rejected.starts_with("cluster_unavailable"));
+        assert!(!first_deploy.starts_with("cluster_unavailable"));
     }
 }

--- a/cli/src/deploy/destroy.rs
+++ b/cli/src/deploy/destroy.rs
@@ -137,6 +137,8 @@ impl CliCommand for DestroyCommand {
                 stream_deployment_status(
                     &auth_mode,
                     &deployment.id,
+                    None,
+                    None,
                     &mut stdout,
                 )?;
                 writeln!(stdout)?;

--- a/cli/src/deploy/info.rs
+++ b/cli/src/deploy/info.rs
@@ -134,6 +134,112 @@ pub(crate) fn remediation_commands(
         .collect()
 }
 
+/// A prompt the user can copy straight into a coding agent.
+///
+/// A failed deploy leaves a person holding an error and a decision they may not
+/// be equipped to make. The commands under "To unblock" say what to run but not
+/// what to put in it, and the missing piece is usually knowledge — which value,
+/// from where, and whether it is a secret. Handing them a paste-able prompt turns
+/// the dead end into a next step, and carries the context (app, environment,
+/// region, component, keys) that they would otherwise have to retype from a
+/// terminal or a screenshot.
+///
+/// Deliberately instructs the agent NOT to invent values: the failure mode this
+/// prevents is a blocked deploy becoming a crash loop, which is strictly harder
+/// to diagnose than the block was.
+pub(crate) fn remediation_prompt(
+    blocked: &[BlockedComponent],
+    environment: Option<&str>,
+    region: Option<&str>,
+) -> Option<String> {
+    if blocked.is_empty() {
+        return None;
+    }
+    let environment = environment.unwrap_or("<environment>");
+    let region = region.unwrap_or("<region>");
+
+    let needs = blocked
+        .iter()
+        .map(|component| {
+            format!(
+                "{} '{}' needs {}",
+                component.component_type,
+                component.name,
+                component.missing_keys.join(", ")
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("; ");
+
+    Some(format!(
+        "My ForkLaunch deploy to {environment} ({region}) was blocked because \
+configuration is missing: {needs}. Read the /investigator skill, then run \
+`forklaunch deploy info -e {environment} -r {region} --json` to confirm. Help me \
+work out the correct value for each key — ask me for anything only I would know, \
+and do not invent or guess a value — then set them with `forklaunch config set` \
+scoped to the component that needs them, and redeploy."
+    ))
+}
+
+/// Render the "here is what went wrong and what to do" block shared by
+/// `deploy info` and the failure path of a streamed deploy. A person watching a
+/// deploy fail should not have to run a second command to find out why.
+pub(crate) fn print_remediation(
+    out: &mut StandardStream,
+    error_message: &str,
+    environment: Option<&str>,
+    region: Option<&str>,
+) -> Result<()> {
+    let blocked = parse_blocked_components(error_message);
+    if blocked.is_empty() {
+        return Ok(());
+    }
+    let commands = remediation_commands(&blocked, environment, region);
+
+    writeln!(out)?;
+    out.set_color(ColorSpec::new().set_bold(true))?;
+    writeln!(out, "  To unblock:")?;
+    out.reset()?;
+    for command in &commands {
+        writeln!(out, "    {}", command)?;
+    }
+
+    if let Some(prompt) = remediation_prompt(&blocked, environment, region) {
+        writeln!(out)?;
+        out.set_color(ColorSpec::new().set_bold(true))?;
+        writeln!(out, "  Copy this to your coding agent:")?;
+        out.reset()?;
+        writeln!(out)?;
+        // Printed unadorned so it survives a copy: no box drawing, no leading
+        // pipes, nothing a selection would drag in.
+        for line in wrap_prompt(&prompt, 76) {
+            writeln!(out, "    {}", line)?;
+        }
+    }
+    writeln!(out)?;
+    Ok(())
+}
+
+/// Word-wrap for the copyable block. Kept naive on purpose — the prompt is
+/// plain ASCII prose and command names, and a wrapped command still pastes.
+fn wrap_prompt(text: &str, width: usize) -> Vec<String> {
+    let mut lines = Vec::new();
+    let mut current = String::new();
+    for word in text.split_whitespace() {
+        if !current.is_empty() && current.len() + 1 + word.len() > width {
+            lines.push(std::mem::take(&mut current));
+        }
+        if !current.is_empty() {
+            current.push(' ');
+        }
+        current.push_str(word);
+    }
+    if !current.is_empty() {
+        lines.push(current);
+    }
+    lines
+}
+
 fn print_field(out: &mut StandardStream, label: &str, value: &Option<String>) -> Result<()> {
     if let Some(v) = value {
         out.set_color(ColorSpec::new().set_bold(true))?;
@@ -350,19 +456,12 @@ impl CliCommand for InfoCommand {
             print_field(&mut stdout, "Completed:", &deployment.completed_at)?;
             print_field(&mut stdout, "Error:", &deployment.error_message)?;
             if let Some(error_message) = deployment.error_message.as_deref() {
-                let blocked = parse_blocked_components(error_message);
-                let commands = remediation_commands(
-                    &blocked,
+                print_remediation(
+                    &mut stdout,
+                    error_message,
                     deployment.environment.as_deref(),
                     deployment.region.as_deref(),
-                );
-                if !commands.is_empty() {
-                    writeln!(stdout)?;
-                    writeln!(stdout, "  To unblock:")?;
-                    for command in &commands {
-                        writeln!(stdout, "    {}", command)?;
-                    }
-                }
+                )?;
             }
             print_service_urls(&mut stdout, &deployment.metadata)?;
         }
@@ -447,6 +546,44 @@ mod tests {
     }
 
     #[test]
+    fn the_agent_prompt_carries_the_context_a_user_would_have_to_retype() {
+        let blocked = parse_blocked_components(REAL_BLOCKED);
+        let prompt = remediation_prompt(&blocked, Some("production"), Some("us-west-2")).unwrap();
+        // Everything the agent needs to act without going back to the user.
+        assert!(prompt.contains("production"), "{prompt}");
+        assert!(prompt.contains("us-west-2"), "{prompt}");
+        assert!(prompt.contains("managed-apps-worker"), "{prompt}");
+        assert!(prompt.contains("TEMPLATE_BUILD_ORG_ID"), "{prompt}");
+        assert!(prompt.contains("deploy info"), "{prompt}");
+        assert!(prompt.contains("config set"), "{prompt}");
+    }
+
+    /// The single most important line in the prompt. An agent that guesses a
+    /// value converts a blocked deploy into a crash loop, which is harder to
+    /// diagnose than the block it replaced.
+    #[test]
+    fn the_agent_prompt_forbids_inventing_a_value() {
+        let blocked = parse_blocked_components(REAL_BLOCKED);
+        let prompt = remediation_prompt(&blocked, Some("production"), Some("us-west-2")).unwrap();
+        assert!(prompt.contains("do not invent"), "{prompt}");
+    }
+
+    #[test]
+    fn no_blocked_components_means_no_prompt_at_all() {
+        // A deploy that failed for some other reason gets no prompt — a generic
+        // "ask your agent" would be noise, and would imply a fix that isn't one.
+        assert!(remediation_prompt(&[], Some("production"), Some("us-west-2")).is_none());
+    }
+
+    #[test]
+    fn the_prompt_wraps_without_losing_words() {
+        let text = "alpha beta gamma delta epsilon zeta eta theta iota kappa";
+        let wrapped = wrap_prompt(text, 20);
+        assert!(wrapped.iter().all(|line| line.len() <= 20), "{wrapped:?}");
+        assert_eq!(wrapped.join(" "), text);
+    }
+
+    #[test]
     fn missing_environment_and_region_render_as_placeholders_not_omissions() {
         let blocked = parse_blocked_components(REAL_BLOCKED);
         let commands = remediation_commands(&blocked, None, None);
@@ -504,5 +641,26 @@ mod tests {
             }
         }));
         assert!(print_service_urls(&mut stdout, &metadata).is_ok());
+    }
+}
+
+#[cfg(test)]
+mod render_preview {
+    use super::*;
+    use termcolor::{ColorChoice, StandardStream};
+
+    /// Not an assertion — prints the block so its shape can be reviewed with
+    /// `cargo test render_the_block -- --nocapture`. The value of this output is
+    /// whether a person can select and paste it, which no assertion checks.
+    #[test]
+    fn render_the_block() {
+        let mut out = StandardStream::stdout(ColorChoice::Never);
+        print_remediation(
+            &mut out,
+            "Deployment blocked due to missing configuration: worker 'managed-apps-worker' missing keys: TEMPLATE_BUILD_ORG_ID",
+            Some("production"),
+            Some("us-west-2"),
+        )
+        .unwrap();
     }
 }

--- a/cli/src/deploy/info.rs
+++ b/cli/src/deploy/info.rs
@@ -46,6 +46,94 @@ struct DeploymentListResponse {
     deployments: Vec<DeploymentSummary>,
 }
 
+/// One component the platform refused to deploy, and the keys it wants.
+#[derive(Debug, PartialEq, Eq, serde::Serialize)]
+pub(crate) struct BlockedComponent {
+    #[serde(rename = "componentType")]
+    pub(crate) component_type: String,
+    pub(crate) name: String,
+    #[serde(rename = "missingKeys")]
+    pub(crate) missing_keys: Vec<String>,
+}
+
+/// Recover the structured detail from a blocked-deploy message.
+///
+/// The platform builds this error from a `DeploymentBlockedDetail[]` — component
+/// type, name, and the unset keys — and then flattens it to prose before storing
+/// it on `deployment.errorMessage`. By the time anyone reads it back, the only
+/// thing left is a sentence.
+///
+/// That is fine for the notification email a human gets and useless to an agent,
+/// which needs the keys as data to run `config set` against. Parsing the prose
+/// back is a bridge, not the destination: the durable fix is for the API to
+/// return the details it already had. Written to fail closed — anything that
+/// does not match the exact shape yields nothing rather than a guess.
+///
+/// Shape, with details joined by "; ":
+///   `<type> '<name>'[ (qualifier)] missing keys: KEY_A, KEY_B`
+pub(crate) fn parse_blocked_components(error_message: &str) -> Vec<BlockedComponent> {
+    const PREFIX: &str = "Deployment blocked due to missing configuration:";
+    let Some(rest) = error_message.split_once(PREFIX).map(|(_, rest)| rest) else {
+        return Vec::new();
+    };
+
+    let mut components = Vec::new();
+    for detail in rest.split("; ") {
+        let detail = detail.trim();
+        let Some((head, keys)) = detail.split_once("missing keys:") else {
+            continue;
+        };
+        // `<type> '<name>'` — the name is quoted, which is what makes this
+        // parseable at all; a component name may contain spaces or hyphens.
+        let Some(open) = head.find('\'') else { continue };
+        let Some(close) = head[open + 1..].find('\'') else {
+            continue;
+        };
+        let name = head[open + 1..open + 1 + close].to_string();
+        let component_type = head[..open].trim().to_string();
+        if component_type.is_empty() || name.is_empty() {
+            continue;
+        }
+        let missing_keys: Vec<String> = keys
+            .split(',')
+            .map(|key| key.trim().trim_end_matches('.').to_string())
+            .filter(|key| !key.is_empty())
+            .collect();
+        if missing_keys.is_empty() {
+            continue;
+        }
+        components.push(BlockedComponent {
+            component_type,
+            name,
+            missing_keys,
+        });
+    }
+    components
+}
+
+/// The exact commands that unblock a deploy, so an agent does not have to
+/// assemble them from prose. Scoped with `-s`: a key one component needs does
+/// not belong in every container's environment.
+pub(crate) fn remediation_commands(
+    blocked: &[BlockedComponent],
+    environment: Option<&str>,
+    region: Option<&str>,
+) -> Vec<String> {
+    let environment = environment.unwrap_or("<environment>");
+    let region = region.unwrap_or("<region>");
+    blocked
+        .iter()
+        .flat_map(|component| {
+            component.missing_keys.iter().map(move |key| {
+                format!(
+                    "forklaunch config set {key}=<value> -e {environment} -r {region} -s {}",
+                    component.name
+                )
+            })
+        })
+        .collect()
+}
+
 fn print_field(out: &mut StandardStream, label: &str, value: &Option<String>) -> Result<()> {
     if let Some(v) = value {
         out.set_color(ColorSpec::new().set_bold(true))?;
@@ -127,6 +215,15 @@ impl CliCommand for InfoCommand {
                 .help("Filter to a region"),
         )
         .arg(
+            Arg::new("json")
+                .long("json")
+                .action(clap::ArgAction::SetTrue)
+                .help(
+                    "Output raw JSON, including structured `blocked` details and the exact \
+                     `config set` commands that would unblock a deploy",
+                ),
+        )
+        .arg(
             Arg::new("base_path")
                 .long("path")
                 .short('p')
@@ -198,6 +295,49 @@ impl CliCommand for InfoCommand {
             return Ok(());
         }
 
+        // Machine-readable output exists for exactly this case: a deploy that
+        // failed on missing configuration. The reason is retrievable today, but
+        // only as a sentence in a terminal — so an agent asked to fix it has to
+        // pattern-match prose. Emitting the parsed components and the commands
+        // that resolve them turns "deploy failed, see logs" into something
+        // actionable in one call.
+        if matches.get_flag("json") {
+            let payload: Vec<serde_json::Value> = owned
+                .iter()
+                .map(|deployment| {
+                    let blocked = deployment
+                        .error_message
+                        .as_deref()
+                        .map(parse_blocked_components)
+                        .unwrap_or_default();
+                    let remediation = remediation_commands(
+                        &blocked,
+                        deployment.environment.as_deref(),
+                        deployment.region.as_deref(),
+                    );
+                    serde_json::json!({
+                        "id": deployment.id,
+                        "status": deployment.status,
+                        "environment": deployment.environment,
+                        "region": deployment.region,
+                        "releaseVersion": deployment.release_version,
+                        "deployedBy": deployment.deployed_by,
+                        "startedAt": deployment.started_at,
+                        "completedAt": deployment.completed_at,
+                        "errorMessage": deployment.error_message,
+                        "blocked": blocked,
+                        "remediation": remediation,
+                    })
+                })
+                .collect();
+            writeln!(
+                stdout,
+                "{}",
+                serde_json::to_string_pretty(&serde_json::json!({ "deployments": payload }))?
+            )?;
+            return Ok(());
+        }
+
         for deployment in &owned {
             writeln!(stdout)?;
             print_field(&mut stdout, "Id:", &deployment.id)?;
@@ -209,6 +349,21 @@ impl CliCommand for InfoCommand {
             print_field(&mut stdout, "Started:", &deployment.started_at)?;
             print_field(&mut stdout, "Completed:", &deployment.completed_at)?;
             print_field(&mut stdout, "Error:", &deployment.error_message)?;
+            if let Some(error_message) = deployment.error_message.as_deref() {
+                let blocked = parse_blocked_components(error_message);
+                let commands = remediation_commands(
+                    &blocked,
+                    deployment.environment.as_deref(),
+                    deployment.region.as_deref(),
+                );
+                if !commands.is_empty() {
+                    writeln!(stdout)?;
+                    writeln!(stdout, "  To unblock:")?;
+                    for command in &commands {
+                        writeln!(stdout, "    {}", command)?;
+                    }
+                }
+            }
             print_service_urls(&mut stdout, &deployment.metadata)?;
         }
 
@@ -220,6 +375,84 @@ impl CliCommand for InfoCommand {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    /// The exact message behind a real production "Deploy failed" notification.
+    /// The email's only call to action is a dashboard button, so this string is
+    /// all an agent has to work from.
+    const REAL_BLOCKED: &str = "Deployment blocked due to missing configuration: \
+         worker 'managed-apps-worker' missing keys: TEMPLATE_BUILD_ORG_ID";
+
+    #[test]
+    fn a_real_blocked_deploy_message_yields_the_component_and_its_keys() {
+        let blocked = parse_blocked_components(REAL_BLOCKED);
+        assert_eq!(
+            blocked,
+            vec![BlockedComponent {
+                component_type: "worker".to_string(),
+                name: "managed-apps-worker".to_string(),
+                missing_keys: vec!["TEMPLATE_BUILD_ORG_ID".to_string()],
+            }]
+        );
+    }
+
+    #[test]
+    fn remediation_is_a_runnable_command_scoped_to_the_component() {
+        let blocked = parse_blocked_components(REAL_BLOCKED);
+        let commands = remediation_commands(&blocked, Some("production"), Some("us-west-2"));
+        assert_eq!(
+            commands,
+            vec![
+                "forklaunch config set TEMPLATE_BUILD_ORG_ID=<value> -e production -r us-west-2 -s managed-apps-worker"
+            ]
+        );
+    }
+
+    #[test]
+    fn several_components_and_keys_are_all_recovered() {
+        let blocked = parse_blocked_components(
+            "Deployment blocked due to missing configuration: \
+             worker 'managed-apps-worker' missing keys: A_KEY, B_KEY; \
+             service 'billing' missing keys: STRIPE_API_KEY",
+        );
+        assert_eq!(blocked.len(), 2);
+        assert_eq!(blocked[0].missing_keys, vec!["A_KEY", "B_KEY"]);
+        assert_eq!(blocked[1].component_type, "service");
+        assert_eq!(blocked[1].name, "billing");
+    }
+
+    /// The platform appends a parenthetical when a key is set on some other
+    /// component. The name is quoted, so the qualifier must not disturb it.
+    #[test]
+    fn a_set_elsewhere_qualifier_does_not_break_the_name() {
+        let blocked = parse_blocked_components(
+            "Deployment blocked due to missing configuration: \
+             service 'api' (1 of these has a value on worker 'jobs' but not on this service) \
+             missing keys: SHARED_KEY",
+        );
+        assert_eq!(blocked.len(), 1);
+        assert_eq!(blocked[0].name, "api");
+        assert_eq!(blocked[0].missing_keys, vec!["SHARED_KEY"]);
+    }
+
+    /// Fail closed. A deploy that failed for some other reason must produce no
+    /// blocked components at all — inventing a key to set would be worse than
+    /// saying nothing, because an agent would then go and set it.
+    #[test]
+    fn an_unrelated_failure_yields_nothing_to_guess_at() {
+        assert!(parse_blocked_components("Pulumi stack update failed: timeout").is_empty());
+        assert!(parse_blocked_components("").is_empty());
+        assert!(
+            parse_blocked_components("Deployment blocked due to missing configuration:").is_empty()
+        );
+    }
+
+    #[test]
+    fn missing_environment_and_region_render_as_placeholders_not_omissions() {
+        let blocked = parse_blocked_components(REAL_BLOCKED);
+        let commands = remediation_commands(&blocked, None, None);
+        assert!(commands[0].contains("-e <environment>"), "{:?}", commands);
+        assert!(commands[0].contains("-r <region>"), "{:?}", commands);
+    }
 
     #[test]
     fn deployment_summary_deserializes_metadata_outputs() {

--- a/cli/src/deploy/utils.rs
+++ b/cli/src/deploy/utils.rs
@@ -26,6 +26,8 @@ pub(crate) struct DeploymentEndpoints {
 pub(crate) fn stream_deployment_status(
     auth_mode: &AuthMode,
     deployment_id: &str,
+    environment: Option<&str>,
+    region: Option<&str>,
     stdout: &mut StandardStream,
 ) -> Result<()> {
     use crate::core::http_client;
@@ -88,10 +90,26 @@ pub(crate) fn stream_deployment_status(
             "failed" => {
                 log_header!(stdout, Color::Red, "\nOperation failed");
 
-                if let Some(error) = status.error {
+                if let Some(error) = &status.error {
                     log_error!(stdout, "Error: {}", error);
+                    // A synchronous deploy is the case where someone is actually
+                    // watching. Making them run a second command to find out
+                    // which component wanted which key — and then work out what
+                    // to do about it alone — is where the session dies. Show the
+                    // fix and a prompt they can hand to an agent, here.
+                    crate::deploy::info::print_remediation(
+                        stdout, error, environment, region,
+                    )?;
                 }
-                bail!("Operation failed");
+
+                // Carry the reason into the error itself. `bail!("Operation
+                // failed")` put the cause on stdout and nothing in the error, so
+                // any caller reading only the failure — CI, or an agent reading
+                // the last line — lost it entirely.
+                match &status.error {
+                    Some(error) => bail!("Deployment failed: {}", error),
+                    None => bail!("Deployment failed (no reason reported)"),
+                }
             }
             "cancelled" => {
                 log_header!(stdout, Color::Yellow, "\n[CANCELLED] Deployment was cancelled");

--- a/cli/src/infra/mutation.rs
+++ b/cli/src/infra/mutation.rs
@@ -191,7 +191,7 @@ pub(crate) fn run_mutation(req: MutationRequest) -> Result<()> {
     // `fl infra` is JWT/session-only (resource-management has no HMAC support on
     // these routes); `stream_deployment_status` is shared with `deploy create`,
     // which still supports HMAC, so it takes an AuthMode — always JWT from here.
-    stream_deployment_status(&AuthMode::Jwt, &response.deployment_id, &mut stdout)?;
+    stream_deployment_status(&AuthMode::Jwt, &response.deployment_id, None, None, &mut stdout)?;
 
     Ok(())
 }

--- a/cli/src/managed/detect.rs
+++ b/cli/src/managed/detect.rs
@@ -1,0 +1,129 @@
+//! Deploy-time detection of whether the app being deployed is really a managed
+//! template rather than a single-app project.
+//!
+//! Whether an app is "managed" is a control-plane fact, not something the manifest
+//! records: a managed template is keyed by its source repository. So this asks the
+//! control plane, listing the organization's templates and matching each template's
+//! `sourceRepo` against the manifest's `git_repository`. It never fails the deploy on
+//! its own account. A control plane without the `/managed-mode` routes, or credentials
+//! that cannot be scoped to an organization, both resolve to `Inconclusive` so the
+//! caller proceeds as a single-app deploy.
+
+use super::client::{extract_list, managed_url};
+use super::types::AppTemplate;
+use crate::core::{hmac::AuthMode, http_client::get_with_auth};
+
+/// Outcome of asking the control plane whether the app being deployed is a managed
+/// template.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum ManagedDetection {
+    /// The app's git repository matches a template the organization has registered.
+    /// Carries the template slug so the caller can redirect the user to
+    /// `managed instance create`.
+    MatchedTemplate(String),
+    /// The control plane exposes managed mode and answered, but no template matched.
+    /// A first deploy can use this to hint that managed mode exists.
+    ManagedModeAvailableNoMatch,
+    /// Detection could not run: this control plane has no `/managed-mode` routes (an
+    /// older or self-hosted platform answers 404), the credentials carry no organization
+    /// identity (HMAC/CI answers 401/403), or the request itself failed. The caller must
+    /// treat the app as NOT managed and proceed.
+    Inconclusive,
+}
+
+/// Normalizes a git repository URL for tolerant comparison: trims surrounding
+/// whitespace, drops a trailing `.git` and any trailing slash, and lowercases (host case
+/// is not significant, and the repositories these compare are not case-sensitive in
+/// practice). It deliberately does not try to reconcile ssh and https forms, because the
+/// only differences in scope are the trivial ones, and over-normalizing risks a false
+/// match that would wrongly block a deploy.
+fn normalize_repo(repo: &str) -> String {
+    let trimmed = repo.trim().trim_end_matches('/');
+    let without_git = trimmed.strip_suffix(".git").unwrap_or(trimmed);
+    without_git.trim_end_matches('/').to_lowercase()
+}
+
+/// Given the resolved manifest's `git_repository`, returns the matching template slug (as
+/// `MatchedTemplate`) if any published or unpublished template's `sourceRepo` matches.
+///
+/// Reuses the same 404 tolerance the rest of the managed client relies on: any
+/// non-success status (404 for an unmounted router, 401/403 for HMAC/CI credentials that
+/// carry no organization) resolves to `Inconclusive`, as does a network error or a
+/// response this CLI cannot parse. The deploy is never failed just because detection
+/// could not run.
+pub(crate) fn detect_managed_template(
+    auth_mode: &AuthMode,
+    git_repository: Option<&str>,
+) -> ManagedDetection {
+    // With no repository recorded in the manifest there is nothing to match on.
+    let Some(git_repository) = git_repository else {
+        return ManagedDetection::Inconclusive;
+    };
+    let target = normalize_repo(git_repository);
+    if target.is_empty() {
+        return ManagedDetection::Inconclusive;
+    }
+
+    // Include unpublished templates on purpose: deploying a DRAFT managed template down
+    // the single-app pipeline is exactly as wrong as deploying a published one.
+    let url = managed_url("/templates?includeUnpublished=true");
+    let response = match get_with_auth(auth_mode, &url) {
+        Ok(response) => response,
+        Err(_) => return ManagedDetection::Inconclusive,
+    };
+
+    if !response.status().is_success() {
+        return ManagedDetection::Inconclusive;
+    }
+
+    let value = match response.json::<serde_json::Value>() {
+        Ok(value) => value,
+        Err(_) => return ManagedDetection::Inconclusive,
+    };
+    let templates: Vec<AppTemplate> = match extract_list(value, &["templates"]) {
+        Ok(templates) => templates,
+        Err(_) => return ManagedDetection::Inconclusive,
+    };
+
+    for template in &templates {
+        let (Some(source_repo), Some(slug)) =
+            (template.source_repo.as_deref(), template.slug.as_deref())
+        else {
+            continue;
+        };
+        if normalize_repo(source_repo) == target {
+            return ManagedDetection::MatchedTemplate(slug.to_string());
+        }
+    }
+
+    ManagedDetection::ManagedModeAvailableNoMatch
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_repo_ignores_trailing_git_slash_and_case() {
+        assert_eq!(
+            normalize_repo("https://GitHub.com/Acme/clinic.git"),
+            normalize_repo("https://github.com/acme/clinic")
+        );
+        assert_eq!(
+            normalize_repo("https://github.com/acme/clinic/"),
+            "https://github.com/acme/clinic"
+        );
+        assert_eq!(
+            normalize_repo("https://github.com/acme/clinic.git/"),
+            "https://github.com/acme/clinic"
+        );
+    }
+
+    #[test]
+    fn normalize_repo_does_not_conflate_different_repositories() {
+        assert_ne!(
+            normalize_repo("https://github.com/acme/clinic"),
+            normalize_repo("https://github.com/acme/clinic-staging")
+        );
+    }
+}

--- a/cli/src/managed/mod.rs
+++ b/cli/src/managed/mod.rs
@@ -4,6 +4,7 @@ use clap::{ArgMatches, Command};
 use crate::{CliCommand, core::command::command};
 
 mod client;
+pub(crate) mod detect;
 mod instance;
 mod summary;
 mod template;

--- a/cli/src/score.rs
+++ b/cli/src/score.rs
@@ -327,13 +327,23 @@ fn api_error(status: u16, body: &str) -> anyhow::Error {
 /// Terminal rendering. Default output, because a wall of JSON is not an answer
 /// to "how ready is this" — the checklist and the unmet items are.
 fn print_summary(card: &Value) {
+    print!("{}", render_summary(card));
+}
+
+/// Built as a string rather than printed directly so the rendering rules below
+/// — which are the whole point of this command's default output — can be
+/// asserted rather than eyeballed.
+fn render_summary(card: &Value) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+
     let overall = card.get("overall").and_then(Value::as_u64).unwrap_or(0);
-    println!();
-    println!("  {}  {}/100", bold("Enterprise Readiness"), overall);
+    let _ = writeln!(out);
+    let _ = writeln!(out, "  {}  {}/100", bold("Enterprise Readiness"), overall);
     if let Some(headline) = card.get("headline").and_then(Value::as_str) {
-        println!("  {}", dim(headline));
+        let _ = writeln!(out, "  {}", dim(headline));
     }
-    println!();
+    let _ = writeln!(out);
 
     if let Some(dimensions) = card.get("dimensions").and_then(Value::as_object) {
         let mut keys: Vec<&String> = dimensions.keys().collect();
@@ -349,33 +359,100 @@ fn print_summary(card: &Value) {
             };
 
             if rail.get("pending").and_then(Value::as_bool).unwrap_or(false) {
-                println!("  {:<16} {}", label, dim("not assessed"));
+                let _ = writeln!(out, "  {:<16} {}", label, dim("not assessed"));
                 continue;
             }
 
             let score = rail.get("score").and_then(Value::as_u64).unwrap_or(0);
-            println!("  {:<16} {}/100", label, score);
+            let items = rail.get("items").and_then(Value::as_array);
 
-            if let Some(items) = rail.get("items").and_then(Value::as_array) {
+            // A rail can score 100 and still have unmet items: only findings
+            // cost points, and an `info` finding costs none. A bare "100/100"
+            // therefore reads as "nothing left to do" on an app that has work
+            // left — and it is the number a non-technical reader takes away.
+            // So the outstanding count travels with the score, always.
+            let outstanding = items
+                .map(|items| {
+                    items
+                        .iter()
+                        .filter(|item| {
+                            item.get("status").and_then(Value::as_str) == Some("unmet")
+                        })
+                        .count()
+                })
+                .unwrap_or(0);
+            if outstanding > 0 {
+                let _ = writeln!(
+                    out,
+                    "  {:<16} {}/100  {}",
+                    label,
+                    score,
+                    dim(&format!(
+                        "({} item{} outstanding)",
+                        outstanding,
+                        if outstanding == 1 { "" } else { "s" }
+                    ))
+                );
+            } else {
+                let _ = writeln!(out, "  {:<16} {}/100", label, score);
+            }
+
+            if let Some(items) = items {
                 for item in items.iter().take(8) {
                     let met = item.get("status").and_then(Value::as_str) == Some("met");
                     let text = item.get("label").and_then(Value::as_str).unwrap_or("");
-                    println!("      {} {}", if met { "+" } else { "-" }, text);
+                    let _ = writeln!(out, "      {} {}", if met { "+" } else { "-" }, text);
                 }
             }
             if let Some(findings) = rail.get("findings").and_then(Value::as_array)
                 && !findings.is_empty()
             {
-                println!("      {}", dim(&format!("{} finding(s)", findings.len())));
+                // The same check firing once per module produces N identical
+                // titles. Listing "7 finding(s)" for one repeated problem
+                // overstates the work; collapse them and say how many times.
+                let mut unique: Vec<(&str, usize)> = Vec::new();
+                for finding in findings {
+                    let title = finding.get("title").and_then(Value::as_str).unwrap_or("");
+                    match unique.iter_mut().find(|(seen, _)| *seen == title) {
+                        Some((_, count)) => *count += 1,
+                        None => unique.push((title, 1)),
+                    }
+                }
+                let _ = writeln!(
+                    out,
+                    "      {}",
+                    dim(&format!(
+                        "{} finding(s){}",
+                        unique.len(),
+                        if unique.len() == findings.len() {
+                            String::new()
+                        } else {
+                            format!(", {} total", findings.len())
+                        }
+                    ))
+                );
+                for (title, count) in unique.iter().take(5) {
+                    if title.is_empty() {
+                        continue;
+                    }
+                    let suffix = if *count > 1 {
+                        format!(" (×{count})")
+                    } else {
+                        String::new()
+                    };
+                    let _ = writeln!(out, "        {}", dim(&format!("{title}{suffix}")));
+                }
             }
-            println!();
+            let _ = writeln!(out);
         }
     }
 
     if let Some(caveat) = card.get("caveat").and_then(Value::as_str) {
-        println!("  {}", dim(caveat));
-        println!();
+        let _ = writeln!(out, "  {}", dim(caveat));
+        let _ = writeln!(out);
     }
+
+    out
 }
 
 fn bold(s: &str) -> String {
@@ -428,5 +505,98 @@ mod tests {
             "overall": 72,
             "dimensions": { "security": { "score": 80, "items": [], "findings": [] } }
         }));
+    }
+
+    /// The scaffold case: a perfect rail with work still on it. Only findings
+    /// cost points and an `info` finding costs none, so 100 alongside an unmet
+    /// item is arithmetically correct and, unqualified, misleading.
+    #[test]
+    fn a_perfect_rail_still_reports_its_unmet_items() {
+        let rendered = render_summary(&json!({
+            "overall": 100,
+            "dimensions": {
+                "compliance": {
+                    "score": 100,
+                    "items": [
+                        { "status": "met", "label": "Field encryptor is registered" },
+                        { "status": "unmet", "label": "Sensitive fields are classified" }
+                    ],
+                    "findings": []
+                }
+            }
+        }));
+        assert!(rendered.contains("100/100"), "{rendered}");
+        assert!(rendered.contains("1 item outstanding"), "{rendered}");
+    }
+
+    #[test]
+    fn a_rail_with_nothing_outstanding_says_nothing_extra() {
+        let rendered = render_summary(&json!({
+            "overall": 100,
+            "dimensions": {
+                "security": {
+                    "score": 100,
+                    "items": [{ "status": "met", "label": "Tenant isolation filter is installed" }],
+                    "findings": []
+                }
+            }
+        }));
+        assert!(!rendered.contains("outstanding"), "{rendered}");
+    }
+
+    /// One check firing once per module is one problem, not seven. Reporting
+    /// the raw count overstates the work and buries what the problem is.
+    #[test]
+    fn repeated_findings_collapse_to_one_line_with_a_count() {
+        let repeated: Vec<serde_json::Value> = (0..7)
+            .map(|_| json!({ "title": "Sensitive fields are classified (iam)" }))
+            .collect();
+        let rendered = render_summary(&json!({
+            "overall": 100,
+            "dimensions": {
+                "compliance": { "score": 100, "items": [], "findings": repeated }
+            }
+        }));
+        assert!(rendered.contains("1 finding(s), 7 total"), "{rendered}");
+        assert!(rendered.contains("(×7)"), "{rendered}");
+    }
+
+    #[test]
+    fn distinct_findings_are_not_collapsed() {
+        let rendered = render_summary(&json!({
+            "overall": 60,
+            "dimensions": {
+                "compliance": {
+                    "score": 60,
+                    "items": [],
+                    "findings": [
+                        { "title": "Field encryptor is not registered" },
+                        { "title": "Retention policies are missing" }
+                    ]
+                }
+            }
+        }));
+        assert!(rendered.contains("2 finding(s)"), "{rendered}");
+        // Nothing was collapsed, so there is no "of N" tail to add.
+        assert!(!rendered.contains("total"), "{rendered}");
+    }
+
+    /// A rail the CLI cannot judge must stay "not assessed" — never 0/100, and
+    /// never carry an outstanding count it did not compute.
+    #[test]
+    fn a_pending_rail_is_not_given_a_score() {
+        let rendered = render_summary(&json!({
+            "overall": 100,
+            "dimensions": { "governance": { "score": 0, "pending": true } }
+        }));
+        assert!(rendered.contains("not assessed"), "{rendered}");
+        // Asserted on the rail's own line: the overall header legitimately
+        // reads "100/100", which contains "0/100" as a substring.
+        let governance_line = rendered
+            .lines()
+            .find(|line| line.contains("Governance"))
+            .expect("governance rail should render");
+        assert!(!governance_line.contains("/100"), "{governance_line}");
+        assert!(!governance_line.contains("outstanding"), "{governance_line}");
     }
 }


### PR DESCRIPTION
Depends on **forklaunch/forklaunch-platform#553** for the placement endpoints and the cluster compliance profile. Merge that first.

Builds on the `deploy create` managed-template guard already on this branch.

## `forklaunch app hosting` (new)

Placement was write-once: settable at `app create`, enforced at the first-deploy gate, changeable nowhere — and unreadable, since the application read API did not return it. This is both halves.

```
forklaunch app hosting                                   # what it is now, and whether a change is free
forklaunch app hosting --cluster-type dedicated \
  --region us-west-2 [--confirm-downtime]                # change it
forklaunch app hosting --compliance-framework HIPAA --region us-west-2
```

The control plane decides whether that is a column write or a substrate migration, so the command does not guess.

## Cluster gate rendering — two fixes

**The two 428s meant opposite things and rendered identically.** `cluster_selection_required` means nothing has been chosen; `cluster_unavailable` means a choice *was* made and is refused. Both printed the same "This is the first deployment of this application…" header and discarded the server's explanation — so a user who chose `platform-shared` at `app create` and had it rejected for HIPAA was told they had never chosen. Reproduced live before the fix.

**`ClusterOption` never deserialized the `compliance` profile** the server has always sent. The terminal showed price and prose but never the sentence that actually decides it: whether the app's containers share hosts with another organization's workloads. Now rendered under each option:

```
  • Platform shared cluster          ~$2.00/mo
      Packed onto ForkLaunch-managed shared hosts — isolation is per-task.
      Shares hosts with other organizations; cannot host HIPAA, SOC 2
```

`--force` now sends `forceSingleAppDeploy` so the control plane's managed-mode guard can be overridden deliberately.

## `deploy info --json` — making a failed deploy actionable

A "Deploy failed" notification reads:

```
Deployment blocked due to missing configuration:
worker 'managed-apps-worker' missing keys: TEMPLATE_BUILD_ORG_ID
```

and its only call to action is a dashboard button. The reason was already retrievable — `deploy info` prints it — but only as that sentence, with no `--json`, so an agent had to pattern-match prose. The platform builds this from structured detail and flattens it before storing; `--json` recovers it plus the exact remediation:

```json
"blocked":     [{ "componentType": "worker", "name": "managed-apps-worker",
                  "missingKeys": ["TEMPLATE_BUILD_ORG_ID"] }],
"remediation": ["forklaunch config set TEMPLATE_BUILD_ORG_ID=<value> -e production -r us-west-2 -s managed-apps-worker"]
```

Scoped with `-s` rather than dumping the key into every container. **Fails closed** — anything not matching the exact shape yields nothing rather than a guess, because an agent that invents a key name will go and set it. It supplies keys, never values.

Parsing prose back is a bridge; the durable fix is for the API to return the details it already had.

## Score card

A freshly scaffolded app reports `100/100` beside a visibly unmet checklist item and seven findings, because only findings cost points and an `info` finding costs none. The arithmetic is right; the output is not, and 100 is the number a non-technical reader takes away.

```
  Compliance       100/100  (1 item outstanding)
      - Sensitive fields are classified
      1 finding(s), 7 total
        Sensitive fields are classified (iam) (×7)
```

Repeated findings collapse — one check firing once per module is one problem, not seven. `print_summary` is now a wrapper over `render_summary`, which returns a string, so these rules are asserted rather than eyeballed.

## Testing

`cargo test`: **634 passed, 0 failed** (was 614 on this branch before). New coverage for the compliance rendering, the two-428 distinction, blocked-deploy parsing (against the real message above, multi-component/multi-key, the "set on another component" qualifier, and unrelated failures), the score rendering rules, and the `app hosting` command surface.

The score output above was verified by running the built binary against a real scaffold. The blocked-deploy parser was verified against the message text — the application that produced it lives in a different org than my account, so I could not fetch that deployment live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019on1U8FvxLWCELRKuz6n56

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forklaunch/codesmith/forklaunch/pr/320"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790982057&installation_model_id=434648&pr_number=320&repository=forklaunch%2Fforklaunch&return_to=https%3A%2F%2Fgithub.com%2Fforklaunch%2Fforklaunch%2Fpull%2F320&signature=fc192d0582885d9b55a25a65f15baa712a1e5189856d4a08241d73909a904682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `forklaunch app hosting` to view and update application placement and compliance frameworks.
  - Added managed-template detection and support for forced deployments when permitted.
  - Deployment placement now displays compliance and isolation details.
  - Added structured deployment details and remediation commands through human-readable and JSON output.
  - Score summaries now show unmet-item counts and consolidate repeated findings.

- **Bug Fixes**
  - Improved handling and messaging for unavailable clusters, blocked deployments, and first-deployment scenarios.
  - Improved repository matching for managed templates and clarified inconclusive detection results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->