### PR TITLE
fix(cli): teach which directory each command runs in

### DIFF
--- a/cli/src/init/application.rs
+++ b/cli/src/init/application.rs
@@ -3,7 +3,7 @@ use std::{
     env,
     fs::read_to_string,
     io::{IsTerminal, Write},
-    path::Path,
+    path::{Path, PathBuf},
 };
 
 use anyhow::{Context, Result, bail};
@@ -281,6 +281,59 @@ impl ApplicationCommand {
     pub(super) fn new() -> Self {
         Self {}
     }
+}
+
+/// Render a path relative to the current directory when it is underneath it,
+/// so the hint reads `./my-app` rather than a wall of absolute path.
+fn display_path(path: &Path) -> String {
+    let rendered = std::env::current_dir()
+        .ok()
+        .and_then(|cwd| path.strip_prefix(&cwd).ok().map(|p| p.to_path_buf()))
+        .map(|relative| {
+            if relative.as_os_str().is_empty() {
+                PathBuf::from(".")
+            } else {
+                PathBuf::from(".").join(relative)
+            }
+        })
+        .unwrap_or_else(|| path.to_path_buf());
+    rendered.to_string_lossy().to_string()
+}
+
+/// A scaffolded application has TWO roots, and they are not the same directory.
+///
+/// The manifest lives at the application root; the pnpm/bun workspace lives
+/// inside `--modules-path`. So `forklaunch` commands run in one place and
+/// package-manager commands run in another, and running `pnpm install` at the
+/// application root fails with `ERR_PNPM_NO_PKG_MANIFEST` — which reads as a
+/// broken scaffold rather than as the wrong directory.
+///
+/// Nothing said so at the one moment the user is guaranteed to be looking: the
+/// end of `init`. Saying it once here is cheaper than every user rediscovering
+/// it, and cheaper than the support answer.
+fn next_steps(app_root: &Path, workspace_root: &Path, runtime: &str) -> String {
+    let package_manager = if runtime == "bun" { "bun" } else { "pnpm" };
+    let app = display_path(app_root);
+    let workspace = display_path(workspace_root);
+
+    // When modules-path is empty the two roots coincide and there is no trap to
+    // warn about — do not invent a distinction the user does not have.
+    if app == workspace {
+        return format!(
+            "\nNext steps\n  cd {app}\n  {package_manager} install\n  forklaunch score --offline\n"
+        );
+    }
+
+    format!(
+        "\nTwo directories, and they are not the same one:\n\
+         \n  {app:<width$}  forklaunch commands run here (.forklaunch/manifest.toml)\
+         \n  {workspace:<width$}  {package_manager} commands run here (package.json, workspace root)\
+         \n\
+         \nNext steps\n  cd {workspace} && {package_manager} install\n  cd {app} && forklaunch score --offline\n\
+         \n`{package_manager} install` at {app} fails with a \"no package.json\" error.\n\
+         That is the wrong directory, not a broken scaffold.\n",
+        width = app.len().max(workspace.len())
+    )
 }
 
 impl CliCommand for ApplicationCommand {
@@ -1320,6 +1373,11 @@ impl CliCommand for ApplicationCommand {
 
         if !dryrun {
             log_ok!(stdout, "{} initialized successfully!", name);
+            write!(
+                stdout,
+                "{}",
+                next_steps(&origin_path, &generation_path, &data.runtime)
+            )?;
             format_code(&Path::new(&application_path), &data.runtime.parse()?);
         }
 
@@ -1388,5 +1446,47 @@ mod tests {
         let new_condition = matches.get_many::<String>("modules").is_none();
         assert!(!old_condition, "old condition incorrectly returns false with name arg");
         assert!(new_condition, "new condition correctly identifies modules prompt is needed");
+    }
+}
+
+#[cfg(test)]
+mod next_steps_tests {
+    use super::*;
+
+    /// The trap this exists to prevent: `pnpm install` at the application root,
+    /// which fails in a way that reads as a broken scaffold.
+    #[test]
+    fn names_both_roots_and_the_failure_they_cause() {
+        let out = next_steps(
+            Path::new("/tmp/my-app"),
+            Path::new("/tmp/my-app/src/modules"),
+            "node",
+        );
+        assert!(out.contains("/tmp/my-app"), "{out}");
+        assert!(out.contains("/tmp/my-app/src/modules"), "{out}");
+        assert!(out.contains("forklaunch commands run here"), "{out}");
+        assert!(out.contains("pnpm commands run here"), "{out}");
+        assert!(out.contains("wrong directory"), "{out}");
+    }
+
+    #[test]
+    fn names_the_runtimes_own_package_manager() {
+        let bun = next_steps(
+            Path::new("/tmp/a"),
+            Path::new("/tmp/a/modules"),
+            "bun",
+        );
+        assert!(bun.contains("bun install"), "{bun}");
+        assert!(!bun.contains("pnpm"), "{bun}");
+    }
+
+    /// With no modules path the two roots coincide. Warning about a distinction
+    /// the user does not have would be noise, and worse, confusing.
+    #[test]
+    fn says_nothing_about_two_roots_when_there_is_only_one() {
+        let out = next_steps(Path::new("/tmp/a"), Path::new("/tmp/a"), "node");
+        assert!(!out.contains("Two directories"), "{out}");
+        assert!(!out.contains("wrong directory"), "{out}");
+        assert!(out.contains("pnpm install"), "{out}");
     }
 }

--- a/cli/src/templates/basic/README.md
+++ b/cli/src/templates/basic/README.md
@@ -20,7 +20,18 @@ This creates a new project with the basic structure including:
 - Development environment setup
 - Pre-configured linter, formatter, and Husky
 
-On first run, you'll need to run the following commands:
+### Two directories, and they are not the same one
+
+This file sits in the **workspace root** — the directory holding `package.json`,
+where every `{{#is_node}}pnpm{{/is_node}}{{#is_bun}}bun{{/is_bun}}` command below runs.
+
+The **application root** is above it: the directory holding
+`.forklaunch/manifest.toml`, where every `forklaunch` command runs.
+
+Running `{{#is_node}}pnpm{{/is_node}}{{#is_bun}}bun{{/is_bun}} install` from the application root fails with a
+"no package.json" error. That is the wrong directory, not a broken project.
+
+On first run, from **this** directory:
 
 ```bash
 {{#is_node}}pnpm{{/is_node}}{{#is_bun}}bun{{/is_bun}} install
@@ -37,6 +48,9 @@ Now, you can run the project with:
 ## Core Commands
 
 ### Adding Components
+
+> Every `forklaunch` command in this section runs from the **application root**
+> (the directory holding `.forklaunch/manifest.toml`), not from here.
 
 #### Add a Service
 


### PR DESCRIPTION
Closes the last open finding from the skills audit (F05).

## The problem

A scaffolded application has **two roots**, and nothing ever said so:

```
my-app/.forklaunch/manifest.toml   <- application root: forklaunch commands
my-app/src/modules/package.json    <- workspace root:   pnpm/bun commands
```

So the obvious first move fails:

```
$ cd my-app && pnpm install
ERR_PNPM_NO_PKG_MANIFEST  No package.json found in .../my-app
```

That error reads as a broken scaffold rather than as the wrong directory — the worst failure mode for someone on their first app, because it is not recoverable by reasoning, only by knowing.

## The fix — teach the path, don't move the workspace

Two places now say it, both places a user is actually looking.

**1. The end of `init application`** — the one moment attention is guaranteed:

```
[OK] ledgerbox initialized successfully!

Two directories, and they are not the same one:

  ./ledgerbox              forklaunch commands run here (.forklaunch/manifest.toml)
  ./ledgerbox/src/modules  pnpm commands run here (package.json, workspace root)

Next steps
  cd ./ledgerbox/src/modules && pnpm install
  cd ./ledgerbox && forklaunch score --offline

`pnpm install` at ./ledgerbox fails with a "no package.json" error.
That is the wrong directory, not a broken scaffold.
```

Paths render relative to the current directory when possible, and the package manager follows the chosen runtime (`bun` for bun projects).

**2. The generated README**, which sits *in* the workspace root — so its `pnpm` commands were always correct and its `forklaunch add` commands never were, with nothing marking the difference. Both are now labelled.

## Why not just move `package.json` to the application root

That was the other option, and it was rejected: it changes the shape of every application already generated, to fix something a sentence fixes.

## Detail worth noting

The hint **stays quiet** when `--modules-path` leaves the two roots identical. Warning about a distinction the user does not have is worse than saying nothing — there is a test for it.

## Testing

`cargo test`: **644 passed, 0 failed** (641 + 3 new). Verified by scaffolding real applications with both `src/modules` and `modules` as the modules path, and reading the rendered output and README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019on1U8FvxLWCELRKuz6n56

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forklaunch/codesmith/forklaunch/pr/326"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791047018&installation_model_id=434648&pr_number=326&repository=forklaunch%2Fforklaunch&return_to=https%3A%2F%2Fgithub.com%2Fforklaunch%2Fforklaunch%2Fpull%2F326&signature=804a53f86e7cbe3b7fed15509f3ed76818a986cfea4c900631cd32f98da7940e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Initialization now displays clearer next steps, including the application root, workspace root, and runtime-specific package manager commands.
  * Output handles applications whose workspace and application roots are the same without unnecessary warnings.

* **Documentation**
  * Updated project guidance to clarify where key configuration files are located and which directory to use for package setup and CLI commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->