### PR TITLE
feat(cli): robustly wire the relay module into any conformant iam

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -75,7 +75,7 @@ jobs:
             scripts: "change_application.sh init_application_custom_path.sh init_module.sh init_service.sh init_worker_mappers.sh init_worker_workspace_and_typecheck.sh sync_application_add.sh"
           - group: 6
             name: "Other Tests"
-            scripts: "delete_router.sh environment_sync.sh init_billing_stripe.sh init_cac.sh init_iam_better_auth.sh init_library.sh init_relay.sh init_router.sh sync_library_subcommand.sh"
+            scripts: "delete_router.sh environment_sync.sh init_billing_stripe.sh init_cac.sh init_iam_better_auth.sh init_library.sh init_relay.sh init_relay_drift.sh init_router.sh sync_library_subcommand.sh"
 
     name: ${{ matrix.name }}
 

--- a/cli/src/core/ast/injections/inject_into_registrations_ts.rs
+++ b/cli/src/core/ast/injections/inject_into_registrations_ts.rs
@@ -4,6 +4,44 @@ use anyhow::Result;
 use oxc_allocator::{Allocator, CloneIn};
 use oxc_ast::ast::{Argument, Expression, ObjectPropertyKind, Program, PropertyKey, Statement};
 
+/// Returns, in source order, the names of every `const <name> = <expr>.chain({ … })`
+/// declaration in a registrations.ts program.
+///
+/// The config-injector pattern builds its dependency graph as a chain of
+/// `.chain({ … })` calls: `configInjector` -> `environmentConfig` ->
+/// `runtimeDependencies` -> `serviceDependencies` -> `expressApplicationOptions`.
+/// Locating the chains structurally (by the `.chain(...)` call shape) lets a
+/// caller target "the environment chain" or "the terminal chain" without
+/// hardcoding a specific sibling entry's text, so a customized iam whose entries
+/// have drifted is still wired correctly.
+pub(crate) fn find_config_injector_chain_names(program: &Program<'_>) -> Vec<String> {
+    let mut names = Vec::new();
+
+    for statement in &program.body {
+        let Statement::VariableDeclaration(decl) = statement else {
+            continue;
+        };
+
+        for declarator in &decl.declarations {
+            let Some(name) = declarator.id.get_identifier_name() else {
+                continue;
+            };
+
+            let Some(Expression::CallExpression(call)) = &declarator.init else {
+                continue;
+            };
+
+            if let Expression::StaticMemberExpression(member) = &call.callee
+                && member.property.name == "chain"
+            {
+                names.push(name.to_string());
+            }
+        }
+    }
+
+    names
+}
+
 pub(crate) fn inject_into_registrations_config_injector<'a>(
     allocator: &'a Allocator,
     registrations_program: &mut Program<'a>,
@@ -120,6 +158,71 @@ mod tests {
             .with_options(CodegenOptions::default())
             .build(program)
             .code
+    }
+
+    #[test]
+    fn test_find_config_injector_chain_names_orders_the_chain() {
+        let allocator = Allocator::default();
+
+        // Mirrors the real registrations.ts shape: createConfigInjector(...) is
+        // NOT a `.chain(...)` call, so only the four chained declarations count,
+        // in source order, with the terminal chain last.
+        let registrations = r#"
+const configInjector = createConfigInjector(schemaValidator, {});
+const environmentConfig = configInjector.chain({});
+const runtimeDependencies = environmentConfig.chain({});
+const serviceDependencies = runtimeDependencies.chain({});
+const expressApplicationOptions = serviceDependencies.chain({});
+export const createDependencyContainer = (envFilePath) => ({});
+"#;
+        let program = parse_ast_program(&allocator, registrations, SourceType::ts());
+
+        let names = super::find_config_injector_chain_names(&program);
+
+        assert_eq!(
+            names,
+            vec![
+                "environmentConfig".to_string(),
+                "runtimeDependencies".to_string(),
+                "serviceDependencies".to_string(),
+                "expressApplicationOptions".to_string(),
+            ]
+        );
+        // The terminal chain is the last entry regardless of its name, which is
+        // how the relay targets the chain where BetterAuth is in scope.
+        assert_eq!(names.last().unwrap(), "expressApplicationOptions");
+    }
+
+    #[test]
+    fn test_find_config_injector_chain_names_handles_a_renamed_terminal_chain() {
+        let allocator = Allocator::default();
+
+        // A drifted iam whose terminal chain is renamed: the finder still returns
+        // it as the last (terminal) chain, so no verbatim name is required.
+        let registrations = r#"
+const environmentConfig = configInjector.chain({});
+const runtimeDependencies = environmentConfig.chain({});
+const applicationOptions = runtimeDependencies.chain({});
+"#;
+        let program = parse_ast_program(&allocator, registrations, SourceType::ts());
+
+        let names = super::find_config_injector_chain_names(&program);
+
+        assert_eq!(names.last().unwrap(), "applicationOptions");
+        assert_eq!(names.len(), 3);
+    }
+
+    #[test]
+    fn test_find_config_injector_chain_names_empty_when_no_chains() {
+        let allocator = Allocator::default();
+
+        let registrations = r#"
+const foo = 'bar';
+const baz = someFn({});
+"#;
+        let program = parse_ast_program(&allocator, registrations, SourceType::ts());
+
+        assert!(super::find_config_injector_chain_names(&program).is_empty());
     }
 
     #[test]

--- a/cli/src/init/relay.rs
+++ b/cli/src/init/relay.rs
@@ -22,11 +22,24 @@ use std::{fs::read_to_string, io::Write, path::Path};
 
 use anyhow::{Result, bail};
 use convert_case::{Case, Casing};
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{Expression, SourceType, Statement};
+use oxc_codegen::{Codegen, CodegenOptions};
 use termcolor::{Color, StandardStream, WriteColor};
 
 use crate::{
     constants::{Database, Module, error_failed_to_read_file},
     core::{
+        ast::{
+            injections::{
+                inject_into_import_statement::inject_into_import_statement,
+                inject_into_registrations_ts::{
+                    find_config_injector_chain_names, inject_into_registrations_config_injector,
+                },
+                inject_into_server_ts::inject_into_server_ts,
+            },
+            parse_ast_program::parse_ast_program,
+        },
         database::{get_database_port, get_db_driver, is_in_memory_database},
         format::format_code,
         manifest::{
@@ -257,6 +270,13 @@ fn build_iam_service_manifest_data(
 /// to the iam `server.ts`. The handoff GET is a raw route (it must Set-Cookie +
 /// 302, which a typed handler cannot), mirroring the existing `/api/auth/*` raw
 /// routes.
+///
+/// Wiring is STRUCTURAL, not verbatim-string-matched. It reuses the same
+/// `inject_into_server_ts` / `inject_into_import_statement` AST machinery the
+/// normal `init module` router flow uses (`transform_server_ts`): the router is
+/// mounted after the run of `app.use(...)` calls and the handoff route is placed
+/// just before the first one, so any conformant iam wires - not only the pristine
+/// blueprint whose last mount happens to be `app.use(complianceRouter)`.
 fn inject_relay_into_server_ts(iam_dir: &Path) -> Result<Option<RenderedTemplate>> {
     let server_path = iam_dir.join("server.ts");
     let content = read_to_string(&server_path)
@@ -266,34 +286,14 @@ fn inject_relay_into_server_ts(iam_dir: &Path) -> Result<Option<RenderedTemplate
         return Ok(None);
     }
 
-    // 1. Imports, appended after the last local import so ordering is stable.
-    let import_anchor = "import { iamSdkClient } from './sdk';";
-    if !content.contains(import_anchor) {
-        bail!(
-            "Could not find the expected import anchor in {}; refusing to guess where to wire the \
-             relay in. Wire it by hand following the module docs.",
-            server_path.display()
-        );
-    }
-    let import_block = format!(
-        "{import_anchor}\nimport {{ relayRouter }} from './api/routes/relay.routes';\nimport {{ serializeSessionCookie }} from './domain/services/relaySession.service';"
-    );
-    let mut updated = content.replace(import_anchor, &import_block);
+    let allocator = Allocator::default();
+    let source_type = SourceType::from_path(&server_path)?;
+    let mut server_program = parse_ast_program(&allocator, &content, source_type);
 
-    // 2. The browser-facing handoff redirect, placed just before the routes are
-    // mounted so it wins over any catch-all.
-    let mount_anchor = "//! mounts the routes to the app";
-    if !updated.contains(mount_anchor) {
-        bail!(
-            "Could not find the route-mount anchor in {}; wire the relay by hand.",
-            server_path.display()
-        );
-    }
-    let handoff_route = r#"//! Managed-apps relay handoff: redeems a one-time ticket minted by
-//! /relay/session-ingest, sets the better-auth session cookie, and 302s the
-//! browser to a sanitized root-relative path. A raw route because it must
-//! Set-Cookie + redirect.
-app.internal.get('/relay/handoff', async (req, res) => {
+    // 1. The browser-facing handoff redirect, placed just before the routes are
+    // mounted so it wins over any catch-all. Inserted at the position of the
+    // first `app.use(...)` (i.e. immediately before the mount run).
+    let handoff_text = r#"app.internal.get('/relay/handoff', async (req, res) => {
   const ticket = String(req.query.ticket || '');
   if (!ticket) {
     res.redirect('/');
@@ -317,20 +317,59 @@ app.internal.get('/relay/handoff', async (req, res) => {
     );
     res.redirect('/');
   }
-});
-
-"#;
-    updated = updated.replace(mount_anchor, &format!("{handoff_route}{mount_anchor}"));
-
-    // 3. Mount the typed session-ingest router alongside the others.
-    let use_anchor = "app.use(complianceRouter);";
-    if !updated.contains(use_anchor) {
-        bail!(
-            "Could not find the router-mount anchor in {}; wire the relay by hand.",
+});"#;
+    let mut handoff_injection = parse_ast_program(&allocator, handoff_text, source_type);
+    inject_into_server_ts(&mut server_program, &mut handoff_injection, |statements| {
+        find_first_app_use_index(statements)
+    })
+    .map_err(|_| {
+        anyhow::anyhow!(
+            "Could not find any `app.use(...)` route mounts in {}; there is nothing to mount the \
+             relay alongside. Wire it by hand following the module docs.",
             server_path.display()
-        );
-    }
-    updated = updated.replace(use_anchor, &format!("{use_anchor}\napp.use(relayRouter);"));
+        )
+    })?;
+
+    // 2. Mount the typed session-ingest router after the run of `app.use(...)`
+    // calls, wherever that run is.
+    let use_text = "app.use(relayRouter);";
+    let mut use_injection = parse_ast_program(&allocator, use_text, source_type);
+    inject_into_server_ts(&mut server_program, &mut use_injection, |statements| {
+        find_after_last_app_use_index(statements)
+    })
+    .map_err(|_| {
+        anyhow::anyhow!(
+            "Could not find any `app.use(...)` route mounts in {}; there is nothing to mount the \
+             relay alongside. Wire it by hand following the module docs.",
+            server_path.display()
+        )
+    })?;
+
+    // 3. Imports for the router + the cookie serializer. `inject_into_import_statement`
+    // slots each new import in among the existing ones structurally.
+    let router_import_text = "import { relayRouter } from './api/routes/relay.routes';";
+    let mut router_import = parse_ast_program(&allocator, router_import_text, source_type);
+    inject_into_import_statement(
+        &mut server_program,
+        &mut router_import,
+        "./api/routes/relay.routes",
+        &content,
+    )?;
+
+    let serializer_import_text =
+        "import { serializeSessionCookie } from './domain/services/relaySession.service';";
+    let mut serializer_import = parse_ast_program(&allocator, serializer_import_text, source_type);
+    inject_into_import_statement(
+        &mut server_program,
+        &mut serializer_import,
+        "./domain/services/relaySession.service",
+        &content,
+    )?;
+
+    let updated = Codegen::new()
+        .with_options(CodegenOptions::default())
+        .build(&server_program)
+        .code;
 
     Ok(Some(RenderedTemplate {
         path: server_path,
@@ -339,8 +378,61 @@ app.internal.get('/relay/handoff', async (req, res) => {
     }))
 }
 
+/// Index of the first top-level `app.use(...)` call statement, for inserting the
+/// handoff route just ahead of the route-mount run.
+fn find_first_app_use_index(statements: &oxc_allocator::Vec<'_, Statement<'_>>) -> Option<usize> {
+    statements.iter().enumerate().find_map(|(index, stmt)| {
+        if is_app_use_statement(stmt) {
+            Some(index)
+        } else {
+            None
+        }
+    })
+}
+
+/// Index just after the last top-level `app.use(...)` call statement, mirroring
+/// the closure `transform_server_ts` uses to append a router mount.
+fn find_after_last_app_use_index(
+    statements: &oxc_allocator::Vec<'_, Statement<'_>>,
+) -> Option<usize> {
+    let mut splice_pos = None;
+    for (index, stmt) in statements.iter().enumerate() {
+        if is_app_use_statement(stmt) {
+            splice_pos = Some(index + 1);
+        }
+    }
+    splice_pos
+}
+
+/// Whether a statement is an `app.use(...)` call expression.
+fn is_app_use_statement(stmt: &Statement<'_>) -> bool {
+    let Statement::ExpressionStatement(expr) = stmt else {
+        return false;
+    };
+    let Expression::CallExpression(call) = &expr.expression else {
+        return false;
+    };
+    let Expression::StaticMemberExpression(member) = &call.callee else {
+        return false;
+    };
+    let Expression::Identifier(id) = &member.object else {
+        return false;
+    };
+    id.name == "app" && member.property.name == "use"
+}
+
 /// Adds the `INSTANCE_ID` / `INSTANCE_HMAC_KEY` environment config and the
 /// `RelaySessionService` DI registration to the iam `registrations.ts`.
+///
+/// Wiring is STRUCTURAL. It reuses the same `inject_into_registrations_config_injector`
+/// AST machinery `transform_registrations_ts` uses: it locates the config-injector
+/// `.chain({ … })` calls by shape (via `find_config_injector_chain_names`) and
+/// appends entries to them, instead of matching a specific sibling entry's
+/// verbatim text. The env vars land in the environment chain; `RelaySessionService`
+/// lands in the terminal chain (the last `.chain(...)`, where `BetterAuth` is
+/// registered and thus in scope for its factory) - exactly where the blueprint
+/// puts it. A customized iam whose entries have drifted (e.g. a last service that
+/// is not `RetentionService`) still wires.
 fn inject_relay_into_registrations_ts(iam_dir: &Path) -> Result<Option<RenderedTemplate>> {
     let registrations_path = iam_dir.join("registrations.ts");
     let content = read_to_string(&registrations_path)
@@ -350,44 +442,117 @@ fn inject_relay_into_registrations_ts(iam_dir: &Path) -> Result<Option<RenderedT
         return Ok(None);
     }
 
+    let allocator = Allocator::default();
+    let source_type = SourceType::from_path(&registrations_path)?;
+    let mut registrations_program = parse_ast_program(&allocator, &content, source_type);
+
+    // Locate the config-injector chains structurally. The environment vars land
+    // in the environment chain; the service lands in the terminal chain so the
+    // BetterAuth registered there is in scope for its factory.
+    let chain_names = find_config_injector_chain_names(&registrations_program);
+    let Some(service_chain) = chain_names.last().cloned() else {
+        bail!(
+            "Could not find any config-injector `.chain({{ … }})` in {}; this does not look like a \
+             ForkLaunch registrations file. Wire the relay by hand following the module docs.",
+            registrations_path.display()
+        );
+    };
+    // Prefer the conventional `environmentConfig` chain; fall back to the first
+    // chain when a customized iam has renamed it.
+    let env_chain = chain_names
+        .iter()
+        .find(|name| name.as_str() == "environmentConfig")
+        .cloned()
+        .or_else(|| chain_names.first().cloned())
+        .expect("chain_names is non-empty (service_chain was Some)");
+
     // 1. Imports for the service + its cookie-context type.
-    let import_anchor = "import mikroOrmOptionsConfig from './mikro-orm.config';";
-    if !content.contains(import_anchor) {
-        bail!(
-            "Could not find the import anchor in {}; wire the relay by hand.",
-            registrations_path.display()
-        );
-    }
-    let import_block = format!(
-        "{import_anchor}\nimport {{\n  BetterAuthCookieContext,\n  RelaySessionService\n}} from './domain/services/relaySession.service';"
+    let import_text = "import { BetterAuthCookieContext, RelaySessionService } from './domain/services/relaySession.service';";
+    let mut import_injection = parse_ast_program(&allocator, import_text, source_type);
+    inject_into_import_statement(
+        &mut registrations_program,
+        &mut import_injection,
+        "./domain/services/relaySession.service",
+        &content,
+    )?;
+
+    // 2. Environment config: INSTANCE_ID / INSTANCE_HMAC_KEY, appended to the
+    // environment chain.
+    let env_injection_text = format!(
+        "const {env_chain} = configInjector.chain({{
+  INSTANCE_ID: {{
+    lifetime: Lifetime.Singleton,
+    type: optional(string),
+    value: getEnvVar('INSTANCE_ID') ?? undefined
+  }},
+  INSTANCE_HMAC_KEY: {{
+    lifetime: Lifetime.Singleton,
+    type: optional(string),
+    value: getEnvVar('INSTANCE_HMAC_KEY') ?? undefined
+  }}
+}});"
     );
-    let mut updated = content.replace(import_anchor, &import_block);
+    let mut env_injection = parse_ast_program(&allocator, &env_injection_text, source_type);
+    inject_into_registrations_config_injector(
+        &allocator,
+        &mut registrations_program,
+        &mut env_injection,
+        &env_chain,
+    )?;
 
-    // 2. Environment config: INSTANCE_ID / INSTANCE_HMAC_KEY, inserted at the
-    // end of the environmentConfig block (after the last known entry).
-    if !updated.contains("INSTANCE_ID") {
-        let env_anchor = "  JWKS_PUBLIC_KEY_URL: {\n    lifetime: Lifetime.Singleton,\n    type: string,\n    value: getEnvVar('JWKS_PUBLIC_KEY_URL')\n  }\n});";
-        if !updated.contains(env_anchor) {
-            bail!(
-                "Could not find the environmentConfig anchor in {}; wire the relay by hand.",
-                registrations_path.display()
-            );
-        }
-        let env_block = "  JWKS_PUBLIC_KEY_URL: {\n    lifetime: Lifetime.Singleton,\n    type: string,\n    value: getEnvVar('JWKS_PUBLIC_KEY_URL')\n  },\n  INSTANCE_ID: {\n    lifetime: Lifetime.Singleton,\n    type: optional(string),\n    value: getEnvVar('INSTANCE_ID') ?? undefined\n  },\n  INSTANCE_HMAC_KEY: {\n    lifetime: Lifetime.Singleton,\n    type: optional(string),\n    value: getEnvVar('INSTANCE_HMAC_KEY') ?? undefined\n  }\n});";
-        updated = updated.replace(env_anchor, env_block);
-    }
+    // 3. The RelaySessionService itself, appended to the terminal chain so
+    // BetterAuth is available to its factory.
+    let service_injection_text = format!(
+        "const {service_chain} = serviceDependencies.chain({{
+  RelaySessionService: {{
+    lifetime: Lifetime.Scoped,
+    type: RelaySessionService,
+    factory: ({{ EntityManager, BetterAuth, OtelCollector }}) =>
+      new RelaySessionService(
+        EntityManager,
+        async (): Promise<BetterAuthCookieContext> => {{
+          const ctx = (await (BetterAuth as BetterAuth).$context) as unknown as {{
+            secret: string;
+            authCookies: {{
+              sessionToken: {{
+                name: string;
+                attributes: BetterAuthCookieContext['sessionTokenAttributes'];
+              }};
+            }};
+          }};
+          return {{
+            secret: ctx.secret,
+            sessionTokenName: ctx.authCookies.sessionToken.name,
+            sessionTokenAttributes: ctx.authCookies.sessionToken.attributes
+          }};
+        }},
+        OtelCollector
+      )
+  }}
+}});"
+    );
+    let mut service_injection = parse_ast_program(&allocator, &service_injection_text, source_type);
+    inject_into_registrations_config_injector(
+        &allocator,
+        &mut registrations_program,
+        &mut service_injection,
+        &service_chain,
+    )?;
 
-    // 3. The RelaySessionService itself, appended to the last dependency chain
-    // (expressApplicationOptions) so BetterAuth is available to its factory.
-    let service_anchor = "  RetentionService: {\n    lifetime: Lifetime.Singleton,\n    type: RetentionService,\n    factory: ({ Orm, OtelCollector }) =>\n      new RetentionService(Orm, OtelCollector)\n  }\n});";
-    if !updated.contains(service_anchor) {
+    let updated = Codegen::new()
+        .with_options(CodegenOptions::default())
+        .build(&registrations_program)
+        .code;
+
+    // The chains were located structurally, so injection should always land;
+    // guard against a silently-unwired file rather than emitting a broken app.
+    if !updated.contains("RelaySessionService") || !updated.contains("INSTANCE_ID") {
         bail!(
-            "Could not find the serviceDependencies anchor in {}; wire the relay by hand.",
+            "Failed to wire the relay into {} (the config-injector chains were found but the \
+             entries did not inject). Wire the relay by hand following the module docs.",
             registrations_path.display()
         );
     }
-    let service_block = "  RetentionService: {\n    lifetime: Lifetime.Singleton,\n    type: RetentionService,\n    factory: ({ Orm, OtelCollector }) =>\n      new RetentionService(Orm, OtelCollector)\n  },\n  RelaySessionService: {\n    lifetime: Lifetime.Scoped,\n    type: RelaySessionService,\n    factory: ({ EntityManager, BetterAuth, OtelCollector }) =>\n      new RelaySessionService(\n        EntityManager,\n        async (): Promise<BetterAuthCookieContext> => {\n          const ctx = (await (BetterAuth as BetterAuth).$context) as unknown as {\n            secret: string;\n            authCookies: {\n              sessionToken: {\n                name: string;\n                attributes: BetterAuthCookieContext['sessionTokenAttributes'];\n              };\n            };\n          };\n          return {\n            secret: ctx.secret,\n            sessionTokenName: ctx.authCookies.sessionToken.name,\n            sessionTokenAttributes: ctx.authCookies.sessionToken.attributes\n          };\n        },\n        OtelCollector\n      )\n  }\n});";
-    updated = updated.replace(service_anchor, service_block);
 
     Ok(Some(RenderedTemplate {
         path: registrations_path,
@@ -512,7 +677,14 @@ mod tests {
             .expect("server.ts must be wired");
         assert!(server.content.contains("import { relayRouter }"));
         assert!(server.content.contains("app.use(relayRouter);"));
-        assert!(server.content.contains("app.internal.get('/relay/handoff'"));
+        // Codegen normalizes quotes, so match the path without asserting a quote style.
+        assert!(
+            server
+                .content
+                .contains("app.internal.get(\"/relay/handoff\"")
+        );
+        // The router mount joins the existing run of `app.use(...)` calls.
+        assert!(server.content.contains("app.use(complianceRouter);"));
 
         let registrations = inject_relay_into_registrations_ts(&iam)
             .unwrap()
@@ -520,6 +692,8 @@ mod tests {
         assert!(registrations.content.contains("RelaySessionService"));
         assert!(registrations.content.contains("INSTANCE_ID"));
         assert!(registrations.content.contains("INSTANCE_HMAC_KEY"));
+        // The service lands in the terminal chain, as a sibling of BetterAuth.
+        assert!(registrations.content.contains("BetterAuthCookieContext"));
 
         let entities = inject_relay_into_entities_index(&iam)
             .unwrap()
@@ -537,6 +711,83 @@ mod tests {
         assert!(inject_relay_into_server_ts(&iam).unwrap().is_none());
         assert!(inject_relay_into_registrations_ts(&iam).unwrap().is_none());
         assert!(inject_relay_into_entities_index(&iam).unwrap().is_none());
+
+        remove_dir_all(&tmp).ok();
+    }
+
+    /// The Health-Vault-shaped case: a customized iam whose wiring has DRIFTED
+    /// from the pristine blueprint. Here the terminal chain's last service is
+    /// renamed away from `RetentionService`, an EXTRA service is added, the last
+    /// mounted router is not `complianceRouter`, and the env chain's last entry
+    /// is not `JWKS_PUBLIC_KEY_URL`. The old verbatim-string anchors would bail
+    /// on every one of these; the structural wiring must still land.
+    #[test]
+    fn relay_wires_into_a_drifted_iam() {
+        let mut server = embedded("project/iam-better-auth/server.ts");
+        // Drift the mount run: rename complianceRouter -> auditRouter and drop the
+        // verbatim `app.use(complianceRouter);` anchor entirely, appending an
+        // extra mount so the last `app.use` is a fresh name.
+        server = server.replace("complianceRouter", "auditRouter").replace(
+            "app.use(auditRouter);",
+            "app.use(auditRouter);\napp.use(webhookRouter);",
+        );
+        assert!(!server.contains("app.use(complianceRouter);"));
+
+        let mut registrations = embedded("project/iam-better-auth/registrations.ts");
+        // Drift the terminal chain: rename RetentionService (the old service
+        // anchor) and add an extra service after it.
+        registrations = registrations.replace(
+            "RetentionService: {\n    lifetime: Lifetime.Singleton,\n    type: RetentionService,\n    factory: ({ Orm, OtelCollector }) =>\n      new RetentionService(Orm, OtelCollector)\n  }",
+            "DataRetentionService: {\n    lifetime: Lifetime.Singleton,\n    type: RetentionService,\n    factory: ({ Orm, OtelCollector }) =>\n      new RetentionService(Orm, OtelCollector)\n  },\n  AnalyticsService: {\n    lifetime: Lifetime.Scoped,\n    type: SurfacingService,\n    factory: ({ EntityManager }) => new SurfacingService(EntityManager)\n  }",
+        );
+        // Drift the env chain: append a custom env var after JWKS_PUBLIC_KEY_URL so
+        // the old env anchor (which required JWKS to be the LAST entry) is gone.
+        registrations = registrations.replace(
+            "  JWKS_PUBLIC_KEY_URL: {\n    lifetime: Lifetime.Singleton,\n    type: string,\n    value: getEnvVar('JWKS_PUBLIC_KEY_URL')\n  }\n});",
+            "  JWKS_PUBLIC_KEY_URL: {\n    lifetime: Lifetime.Singleton,\n    type: string,\n    value: getEnvVar('JWKS_PUBLIC_KEY_URL')\n  },\n  TENANT_HEADER: {\n    lifetime: Lifetime.Singleton,\n    type: optional(string),\n    value: getEnvVar('TENANT_HEADER') ?? undefined\n  }\n});",
+        );
+        // The exact block the old verbatim wiring anchored on is now gone.
+        assert!(!registrations.contains(
+            "  RetentionService: {\n    lifetime: Lifetime.Singleton,\n    type: RetentionService,\n    factory: ({ Orm, OtelCollector }) =>\n      new RetentionService(Orm, OtelCollector)\n  }\n});"
+        ));
+
+        let tmp = std::env::temp_dir().join(format!("fl-relay-drift-{}", std::process::id()));
+        let iam = tmp.join("iam");
+        create_dir_all(iam.join("api").join("controllers")).unwrap();
+        create_dir_all(iam.join("persistence").join("entities")).unwrap();
+        write(iam.join("server.ts"), &server).unwrap();
+        write(iam.join("registrations.ts"), &registrations).unwrap();
+        write(
+            iam.join("persistence").join("entities").join("index.ts"),
+            embedded("project/iam-better-auth/persistence/entities/index.ts"),
+        )
+        .unwrap();
+
+        // Despite none of the old verbatim anchors being present, the relay wires.
+        let server_out = inject_relay_into_server_ts(&iam)
+            .unwrap()
+            .expect("drifted server.ts must still be wired");
+        assert!(server_out.content.contains("app.use(relayRouter);"));
+        assert!(server_out.content.contains("import { relayRouter }"));
+        assert!(
+            server_out
+                .content
+                .contains("app.internal.get(\"/relay/handoff\"")
+        );
+        // The pre-existing (drifted) mounts survive.
+        assert!(server_out.content.contains("app.use(auditRouter);"));
+        assert!(server_out.content.contains("app.use(webhookRouter);"));
+
+        let registrations_out = inject_relay_into_registrations_ts(&iam)
+            .unwrap()
+            .expect("drifted registrations.ts must still be wired");
+        assert!(registrations_out.content.contains("RelaySessionService"));
+        assert!(registrations_out.content.contains("INSTANCE_ID"));
+        assert!(registrations_out.content.contains("INSTANCE_HMAC_KEY"));
+        // The drifted siblings survive alongside the injected entry.
+        assert!(registrations_out.content.contains("DataRetentionService"));
+        assert!(registrations_out.content.contains("AnalyticsService"));
+        assert!(registrations_out.content.contains("TENANT_HEADER"));
 
         remove_dir_all(&tmp).ok();
     }

--- a/cli/tests/init_relay_drift.sh
+++ b/cli/tests/init_relay_drift.sh
@@ -1,0 +1,145 @@
+# Proves the relay module wires into a CUSTOMIZED / DRIFTED iam service, not only
+# the pristine iam-better-auth blueprint. This is the Health-Vault-shaped case
+# that the old verbatim-string anchors could not handle: the terminal dependency
+# chain's last entry is no longer `RetentionService`, the environment chain's last
+# entry is no longer `JWKS_PUBLIC_KEY_URL`, and the last mounted router is no
+# longer `complianceRouter`.
+#
+# The drift below is deliberately typecheck-VALID (it reuses in-scope types and
+# imports), so `pnpm build` proves the structurally-injected relay wiring compiles
+# on a drifted iam.
+#
+# The CLI binary. CI builds it once and exports FORKLAUNCH_CLI so the scripts
+# share one compile instead of each re-checking a release build.
+FL="${FORKLAUNCH_CLI:-cargo run --release}"
+set -e
+
+if [ -d "output/init-relay-drift" ]; then
+    rm -rf output/init-relay-drift
+fi
+
+mkdir -p output/init-relay-drift
+cd output/init-relay-drift
+
+# 1. Scaffold a pristine better-auth iam.
+RUST_BACKTRACE=1 $FL init application relay-drift -p relay-drift -o src/modules -d postgresql -f prettier -l eslint -v zod -F express -r node -t vitest -m iam-better-auth -D "Test library" -A "Rohin Bhargava" -L 'AGPL-3.0'
+
+IAM_DIR="relay-drift/src/modules/iam"
+
+# 2. Drift the iam so NONE of the old verbatim anchors are present, while keeping
+# the TypeScript valid. Done in Node so the multi-line edits are exact.
+cat > _drift.cjs <<'DRIFT'
+const fs = require('fs');
+const path = require('path');
+
+const iamDir = process.argv[2];
+
+// --- registrations.ts ---
+const regPath = path.join(iamDir, 'registrations.ts');
+let reg = fs.readFileSync(regPath, 'utf8');
+
+// Terminal chain: append an EXTRA service after RetentionService so the last
+// entry is no longer RetentionService (defeats the old service anchor). Reuses
+// the already-imported RetentionService type + in-scope Orm/OtelCollector.
+const retentionBlock = `  RetentionService: {
+    lifetime: Lifetime.Singleton,
+    type: RetentionService,
+    factory: ({ Orm, OtelCollector }) =>
+      new RetentionService(Orm, OtelCollector)
+  }
+});`;
+const retentionReplacement = `  RetentionService: {
+    lifetime: Lifetime.Singleton,
+    type: RetentionService,
+    factory: ({ Orm, OtelCollector }) =>
+      new RetentionService(Orm, OtelCollector)
+  },
+  ManagedInstanceService: {
+    lifetime: Lifetime.Singleton,
+    type: RetentionService,
+    factory: ({ Orm, OtelCollector }) =>
+      new RetentionService(Orm, OtelCollector)
+  }
+});`;
+if (!reg.includes(retentionBlock)) {
+  throw new Error('drift: RetentionService terminal block not found in registrations.ts');
+}
+reg = reg.replace(retentionBlock, retentionReplacement);
+
+// Environment chain: append an EXTRA env var after JWKS_PUBLIC_KEY_URL so the
+// last entry is no longer JWKS (defeats the old env anchor).
+const jwksBlock = `  JWKS_PUBLIC_KEY_URL: {
+    lifetime: Lifetime.Singleton,
+    type: string,
+    value: getEnvVar('JWKS_PUBLIC_KEY_URL')
+  }
+});`;
+const jwksReplacement = `  JWKS_PUBLIC_KEY_URL: {
+    lifetime: Lifetime.Singleton,
+    type: string,
+    value: getEnvVar('JWKS_PUBLIC_KEY_URL')
+  },
+  MANAGED_MODE: {
+    lifetime: Lifetime.Singleton,
+    type: optional(string),
+    value: getEnvVar('MANAGED_MODE') ?? undefined
+  }
+});`;
+if (!reg.includes(jwksBlock)) {
+  throw new Error('drift: JWKS_PUBLIC_KEY_URL env block not found in registrations.ts');
+}
+reg = reg.replace(jwksBlock, jwksReplacement);
+
+fs.writeFileSync(regPath, reg);
+
+// --- server.ts ---
+const serverPath = path.join(iamDir, 'server.ts');
+let server = fs.readFileSync(serverPath, 'utf8');
+
+// Rename the compliance router binding + its mount so the verbatim
+// `app.use(complianceRouter);` anchor is gone, while staying valid via `as`.
+if (!server.includes("import { complianceRouter } from './api/routes/compliance.routes';")) {
+  throw new Error('drift: compliance router import not found in server.ts');
+}
+server = server.replace(
+  "import { complianceRouter } from './api/routes/compliance.routes';",
+  "import { complianceRouter as auditRouter } from './api/routes/compliance.routes';"
+);
+server = server.replace('app.use(complianceRouter);', 'app.use(auditRouter);');
+
+// Remove the mount marker comment the old wiring anchored the handoff route on.
+server = server.replace('//! mounts the routes to the app\n', '');
+
+fs.writeFileSync(serverPath, server);
+
+console.log('drift applied');
+DRIFT
+
+node _drift.cjs "$IAM_DIR"
+
+# Sanity: confirm the old anchors are really gone before wiring.
+if grep -q 'app.use(complianceRouter);' "$IAM_DIR/server.ts"; then
+    echo "drift precondition failed: complianceRouter mount still present" >&2
+    exit 1
+fi
+
+# 3. Wire the relay into the drifted iam.
+RUST_BACKTRACE=1 $FL init module -m relay -p relay-drift
+
+# 4. Assert the relay is wired despite the drift.
+grep -q 'RelaySessionService' "$IAM_DIR/registrations.ts" || { echo "FAIL: RelaySessionService not injected" >&2; exit 1; }
+grep -q 'INSTANCE_ID' "$IAM_DIR/registrations.ts" || { echo "FAIL: INSTANCE_ID not injected" >&2; exit 1; }
+grep -q 'INSTANCE_HMAC_KEY' "$IAM_DIR/registrations.ts" || { echo "FAIL: INSTANCE_HMAC_KEY not injected" >&2; exit 1; }
+grep -q 'ManagedInstanceService' "$IAM_DIR/registrations.ts" || { echo "FAIL: drifted service was clobbered" >&2; exit 1; }
+grep -q 'MANAGED_MODE' "$IAM_DIR/registrations.ts" || { echo "FAIL: drifted env var was clobbered" >&2; exit 1; }
+grep -q 'app.use(relayRouter);' "$IAM_DIR/server.ts" || { echo "FAIL: relayRouter not mounted" >&2; exit 1; }
+grep -q 'auditRouter' "$IAM_DIR/server.ts" || { echo "FAIL: drifted router mount was clobbered" >&2; exit 1; }
+grep -q '/relay/handoff' "$IAM_DIR/server.ts" || { echo "FAIL: handoff route not injected" >&2; exit 1; }
+
+echo "relay wired into drifted iam; typechecking..."
+
+# 5. Prove the injected TypeScript typechecks on the drifted iam.
+cd relay-drift/src/modules
+
+pnpm install
+pnpm build


### PR DESCRIPTION
## What was brittle

`forklaunch init module -m relay -p <app>` injects the managed-apps OAuth session-ingest endpoint into the app's EXISTING iam service, then wires it into `registrations.ts` and `server.ts`. The wiring used HARDCODED VERBATIM STRING ANCHORS copied from the canonical better-auth iam blueprint:

- `registrations.ts` import anchor `import mikroOrmOptionsConfig from './mikro-orm.config';`
- `registrations.ts` env anchor: a literal multi-line `JWKS_PUBLIC_KEY_URL: { ... }` block (required to be the LAST env entry)
- `registrations.ts` service anchor: a literal `RetentionService: { ... }` block (required to be the LAST terminal-chain entry)
- `server.ts` anchors: `import { iamSdkClient } from './sdk';`, `//! mounts the routes to the app`, `app.use(complianceRouter);`

On any customized/ported iam (e.g. Health Vault, whose terminal chain does not end in `RetentionService`), it bailed with "Could not find the serviceDependencies anchor; wire the relay by hand." It found `serviceDependencies` fine, it just could not find that one hardcoded block.

## How the injection is now structural

Reuses the same AST machinery the normal `init module` router flow already uses (`transform_server_ts` / `transform_registrations_ts`):

**registrations.ts** — a new `find_config_injector_chain_names` helper locates the config-injector `.chain({ ... })` calls by SHAPE (a `const X = <expr>.chain({...})` whose callee is a `.chain` member), in source order. The `INSTANCE_ID` / `INSTANCE_HMAC_KEY` env entries are appended to the environment chain and the `RelaySessionService` DI entry to the TERMINAL chain (the last `.chain(...)`, where `BetterAuth` is registered and thus in scope for its factory, exactly where the blueprint puts it), via the existing `inject_into_registrations_config_injector`. No sibling entry's text is matched. Imports go through `inject_into_import_statement`.

**server.ts** — `relayRouter` is mounted after the run of `app.use(...)` calls, and the raw `/relay/handoff` route is placed just ahead of them, via `inject_into_server_ts` with the same closure `transform_server_ts` uses. No `app.use(complianceRouter);` or mount-marker comment is required.

Genuine safe-bails remain for a registrations file with no config-injector chain at all, and a server with no `app.use(...)` mounts at all. Idempotency (`RelaySessionService` / `relayRouter` already present) is unchanged.

## Proof

- **Rust unit tests**: `find_config_injector_chain_names` ordering + terminal-chain selection (incl. a renamed terminal chain); `relay_wires_into_a_drifted_iam` drifts the embedded blueprint (renamed/extended terminal service so the last entry is not `RetentionService`, a non-compliance last router, an extra env var after JWKS) and asserts the relay still wires and the drifted siblings survive. The existing `relay_wires_into_the_better_auth_iam_blueprint` test still passes against the AST output. `cargo test`: 650 passed.
- **New e2e `init_relay_drift.sh`** (executable bit set, registered in the e2e matrix group 6): scaffolds a better-auth iam, drifts it in a typecheck-VALID way so none of the old anchors remain, runs `init module -m relay`, asserts the wiring landed (`RelaySessionService`, `INSTANCE_ID`, `INSTANCE_HMAC_KEY`, `app.use(relayRouter);`, handoff route, and the drifted siblings), then `pnpm build` typechecks. Ran locally to green (iam build: Done).
- **Existing `init_relay.sh`** ran locally through scaffold -> `init module -m relay` -> `pnpm install` -> `pnpm build` (iam build: Done). It stops only at `docker compose up postgresql` because port 5432 is held by an unrelated running dev stack on this machine; CI has no such collision.
- Spot-checked the real generated node app: `app.use(relayRouter);` joins the `app.use` run, `RelaySessionService` lands in the terminal `expressApplicationOptions` chain, and `format_code` (prettier) normalizes the codegen output back to project style with `//!` markers preserved.

`cargo build` + `cargo test` + `cargo clippy` clean (no new warnings; the one remaining clippy note is pre-existing on `main`). `cargo fmt` applied to changed files only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWR4xL34BHMe2gjvsdLbRk

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forklaunch/codesmith/forklaunch/pr/327"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791057831&installation_model_id=434648&pr_number=327&repository=forklaunch%2Fforklaunch&return_to=https%3A%2F%2Fgithub.com%2Fforklaunch%2Fforklaunch%2Fpull%2F327&signature=594d4271b5a3af38d158d465c3a330bcfb0a04220be77e8c7cc518e11995cfd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Relay initialization now adapts to customized IAM applications, including renamed routers, routes, service registrations, and environment bindings.
  * Added validation to identify missing integration points and report unsuccessful wiring clearly.

* **Bug Fixes**
  * Improved relay setup reliability when existing application structure differs from the expected defaults.

* **Tests**
  * Added end-to-end coverage that verifies relay wiring remains intact and generated applications build successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->