### PR TITLE
feat(cli): managed instance --instance-size + strip .env from release tarball

### DIFF
--- a/cli/src/managed/instance/create.rs
+++ b/cli/src/managed/instance/create.rs
@@ -58,6 +58,16 @@ impl CliCommand for CreateCommand {
                 .help("Region to provision the instance in (for example: us-west-2)"),
         )
         .arg(
+            Arg::new("instance-size")
+                .long("instance-size")
+                .value_parser([
+                    "pico", "nano", "micro", "small", "medium", "large", "xlarge", "2xlarge",
+                ])
+                .help(
+                    "Compute tier for the instance's services. Omitted => the managed default (pico, ~0.1 vCPU / 256 MB). Use a larger tier to give the instance more compute.",
+                ),
+        )
+        .arg(
             Arg::new("no-wait")
                 .long("no-wait")
                 .help(
@@ -88,8 +98,12 @@ impl CliCommand for CreateCommand {
         let region = matches
             .get_one::<String>("region")
             .context("--region is required")?;
+        let instance_size = matches.get_one::<String>("instance-size");
 
-        let body = json!({ "templateSlug": template, "region": region });
+        let mut body = json!({ "templateSlug": template, "region": region });
+        if let Some(size) = instance_size {
+            body["instanceSize"] = json!(size);
+        }
 
         if matches.get_flag("dryrun") {
             return print_dryrun("POST", "/instances", Some(&body));

--- a/cli/src/release/s3_upload.rs
+++ b/cli/src/release/s3_upload.rs
@@ -58,6 +58,20 @@ pub(crate) fn create_app_tarball(
             continue;
         }
 
+        // Never ship any .env* file. Deployed containers must receive
+        // configuration ONLY from injected env vars; a stray .env in the
+        // release artifact (a tracked .env.template/.env.test, or a local
+        // .env.local) can shadow the real environment once baked into the
+        // image. .gitignore already drops .env.local, but this covers the
+        // tracked placeholders and anything .gitignore misses.
+        if path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map_or(false, |n| n.starts_with(".env"))
+        {
+            continue;
+        }
+
         if path == output_path {
             continue;
         }


### PR DESCRIPTION
## What
- **`forklaunch managed instance create --instance-size <tier>`** — optional compute-tier override (`pico|nano|micro|small|medium|large|xlarge|2xlarge`) sent as `instanceSize` on `POST /instances`. Omitted => the platform's managed default (`pico`, ~0.1 vCPU / 256 MB). Pairs with the platform PR that adds the `pico` tier and the per-instance override column.
- **`.env*` stripped from the release tarball** (`create_app_tarball`) — a release artifact never carries a `.env` into the built image, so deployed containers get configuration only from injected env vars. Complements the deployment worker's build-context sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forklaunch/codesmith/forklaunch/pr/328"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791071859&installation_model_id=434648&pr_number=328&repository=forklaunch%2Fforklaunch&return_to=https%3A%2F%2Fgithub.com%2Fforklaunch%2Fforklaunch%2Fpull%2F328&signature=fbd0956012423783a4799ab184a74970cdd684fd39c8ce021a9e6c09ef9a99a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional `--instance-size` option when creating managed instances, allowing users to select a compute tier.

- **Bug Fixes**
  - Release packages no longer include files beginning with `.env`, including templates and test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->