### PR TITLE
fix(cli): config prune resolves <project>-service/-worker scopes

### DIFF
--- a/cli/src/config/prune.rs
+++ b/cli/src/config/prune.rs
@@ -41,10 +41,7 @@ use clap::{Arg, ArgAction, ArgMatches, Command};
 use serde_json::{Value, json};
 use termcolor::{ColorChoice, StandardStream, WriteColor};
 
-use super::{
-    CliCommand,
-    unset::{ScopeTarget, classify_scope},
-};
+use super::{CliCommand, unset::ScopeTarget};
 use crate::{
     constants::{ERROR_FAILED_TO_SEND_REQUEST, get_platform_management_api_url},
     core::{
@@ -105,6 +102,36 @@ pub(crate) fn project_of_scope(scope: &str) -> String {
         .or_else(|| scope.strip_suffix("-worker"))
         .unwrap_or(scope)
         .to_string()
+}
+
+/// Which endpoint owns a pulled scope. The manifest names a project once
+/// (`payments`), while the pulled config names its deployed components
+/// (`payments-service`, `payments-worker`), so both suffixes must resolve —
+/// the `unset` resolver only knew the bare name and `-worker`.
+pub(crate) fn scope_target_from<'a>(
+    projects: impl IntoIterator<Item = (&'a str, &'a ProjectType)>,
+    scope: &str,
+    id: String,
+) -> Option<ScopeTarget> {
+    let base = project_of_scope(scope);
+    let (_, kind) = projects.into_iter().find(|(name, _)| *name == base)?;
+    match kind {
+        ProjectType::Library => None,
+        _ if scope.ends_with("-worker") => Some(ScopeTarget::Worker(id)),
+        _ => Some(ScopeTarget::Service(id)),
+    }
+}
+
+pub(crate) fn scope_target(
+    projects: &[ProjectEntry],
+    scope: &str,
+    id: String,
+) -> Option<ScopeTarget> {
+    scope_target_from(
+        projects.iter().map(|p| (p.name.as_str(), &p.r#type)),
+        scope,
+        id,
+    )
 }
 
 /// Keys the platform generates on every deploy. Deleting a stored copy is
@@ -560,7 +587,7 @@ impl CliCommand for PruneCommand {
                 let id = id.clone().ok_or_else(|| {
                     anyhow::anyhow!("scope '{}' has no platform id in the pulled config", scope)
                 })?;
-                classify_scope(&manifest.projects, scope, id).ok_or_else(|| {
+                scope_target(&manifest.projects, scope, id).ok_or_else(|| {
                     anyhow::anyhow!(
                         "scope '{}' is not a service or worker in this application's manifest",
                         scope
@@ -720,6 +747,30 @@ mod tests {
             ),
             Verdict::Orphan
         );
+    }
+
+    #[test]
+    fn scope_target_resolves_service_and_worker_suffixes() {
+        let projects = [
+            ("managed-apps", ProjectType::Worker),
+            ("iam", ProjectType::Service),
+            ("core", ProjectType::Library),
+        ];
+        let it = || projects.iter().map(|(n, t)| (*n, t));
+        assert!(matches!(
+            scope_target_from(it(), "managed-apps-service", "s".into()),
+            Some(ScopeTarget::Service(_))
+        ));
+        assert!(matches!(
+            scope_target_from(it(), "managed-apps-worker", "w".into()),
+            Some(ScopeTarget::Worker(_))
+        ));
+        assert!(matches!(
+            scope_target_from(it(), "iam", "i".into()),
+            Some(ScopeTarget::Service(_))
+        ));
+        assert!(scope_target_from(it(), "core", "c".into()).is_none());
+        assert!(scope_target_from(it(), "nope-service", "n".into()).is_none());
     }
 
     #[test]


### PR DESCRIPTION
Prune listed the right keys but refused to delete in a `<project>-service` scope (the resolver reused from `unset` only knew bare names and `-worker`). Resolves both suffixes against the manifest project. Verified live: staging pruned 5, prod 7, each confirmed by the post-delete re-pull. Supersedes cli-v1.11.3 → cli-v1.11.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWR4xL34BHMe2gjvsdLbRk

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forklaunch/codesmith/forklaunch/pr/332"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791130204&installation_model_id=434648&pr_number=332&repository=forklaunch%2Fforklaunch&return_to=https%3A%2F%2Fgithub.com%2Fforklaunch%2Fforklaunch%2Fpull%2F332&signature=b7f1f059821d4a6701aee573d80e493ec20aec4ed0ced4b13b4fb658b594ffdc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pruning to correctly identify service and worker scopes from suffixes and bare names.
  * Prevented library scopes from being treated as deployable targets.
  * Added safer handling for unknown or unmatched scopes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->