### PR TITLE
fix(cli): record the origin remote as git_repository on git-mode releases

### DIFF
--- a/cli/src/release/create.rs
+++ b/cli/src/release/create.rs
@@ -128,7 +128,7 @@ use termcolor::{Color, ColorChoice, StandardStream, WriteColor};
 use toml::to_string_pretty;
 
 use super::{
-    git::{get_git_branch, get_git_commit, is_git_repo},
+    git::{get_git_branch, get_git_commit, get_git_remote_url, is_git_repo},
     manifest_generator::{
         EnvironmentVariableComponent, EnvironmentVariableComponentProperty,
         EnvironmentVariableComponentType, EnvironmentVariableRequirement, EnvironmentVariableScope,
@@ -174,10 +174,7 @@ struct CreateReleaseRequest {
     /// Pin the autodeploy fan-out to a specific environment. Honored by
     /// `FORKLAUNCH_TARGET_ENVIRONMENT` env var (set by the worker when the
     /// webhook already matched the push to an env via the branch matrix).
-    #[serde(
-        rename = "targetEnvironment",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(rename = "targetEnvironment", skip_serializing_if = "Option::is_none")]
     target_environment: Option<String>,
 }
 
@@ -541,6 +538,40 @@ impl CliCommand for CreateCommand {
             },
             git_branch.as_deref().unwrap_or("unknown")
         );
+
+        // A git-mode release from inside a checkout must also say WHICH repo the
+        // commit lives in, or the deploy has nothing to clone. Record the origin
+        // remote of the checkout in the manifest; a manifest that already names
+        // a different repository is kept but flagged.
+        if !local_mode && is_git_repo() {
+            match (get_git_remote_url(), manifest.git_repository.as_deref()) {
+                (Some(remote), Some(existing)) if existing.trim_end_matches('/') != remote => {
+                    log_warn!(
+                        stdout,
+                        "manifest.toml names git_repository {} but this checkout's origin is {}; the release will be built from {}",
+                        existing,
+                        remote,
+                        existing
+                    );
+                }
+                (Some(_), Some(_)) => {}
+                (Some(remote), None) => {
+                    manifest.git_repository = Some(remote.clone());
+                    let manifest_str = to_string_pretty(&manifest)
+                        .with_context(|| "Failed to serialize manifest")?;
+                    fs::write(&manifest_path, manifest_str)
+                        .with_context(|| "Failed to write manifest")?;
+                    log_ok!(stdout, "Git repository recorded from origin: {}", remote);
+                }
+                (None, Some(_)) => {}
+                (None, None) => {
+                    log_warn!(
+                        stdout,
+                        "No 'origin' remote found; the deploy will use the repository connected to this application on the platform"
+                    );
+                }
+            }
+        }
 
         // Step 2: Export OpenAPI specs
         let openapi_path = app_root.join(".forklaunch").join("openapi");
@@ -1214,7 +1245,10 @@ fn upload_release(
             "/internal",
         )
     } else {
-        (format!("{}/releases", get_platform_management_api_url()), "/")
+        (
+            format!("{}/releases", get_platform_management_api_url()),
+            "/",
+        )
     };
 
     let response = http_client::post_with_auth_and_sign_path(

--- a/cli/src/release/git.rs
+++ b/cli/src/release/git.rs
@@ -95,3 +95,85 @@ pub(crate) fn is_git_repo() -> bool {
         .map(|output| output.status.success())
         .unwrap_or(false)
 }
+
+/// The `origin` remote of the current checkout as an `https://` URL, or None
+/// when there is no remote. Normalises the SSH and `.git` spellings so the
+/// value matches what the platform stores for a connected repository:
+///   git@github.com:acme/app.git      -> https://github.com/acme/app
+///   ssh://git@github.com/acme/app.git -> https://github.com/acme/app
+///   https://github.com/acme/app.git  -> https://github.com/acme/app
+pub(crate) fn get_git_remote_url() -> Option<String> {
+    let output = Command::new("git")
+        .args(&["remote", "get-url", "origin"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let raw = String::from_utf8(output.stdout).ok()?;
+    normalize_git_remote_url(raw.trim())
+}
+
+pub(crate) fn normalize_git_remote_url(raw: &str) -> Option<String> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    let without_scheme = if let Some(rest) = raw.strip_prefix("ssh://") {
+        // ssh://git@host/owner/repo(.git)
+        let rest = rest.split_once('@').map(|(_, r)| r).unwrap_or(rest);
+        rest.to_string()
+    } else if let Some(rest) = raw.strip_prefix("git@") {
+        // git@host:owner/repo(.git)
+        rest.replacen(':', "/", 1)
+    } else if let Some(rest) = raw
+        .strip_prefix("https://")
+        .or_else(|| raw.strip_prefix("http://"))
+    {
+        // https://[user[:token]@]host/owner/repo(.git)
+        rest.rsplit_once('@')
+            .map(|(_, r)| r)
+            .unwrap_or(rest)
+            .to_string()
+    } else {
+        return None;
+    };
+    let trimmed = without_scheme
+        .trim_end_matches('/')
+        .trim_end_matches(".git")
+        .trim_end_matches('/');
+    if trimmed.split('/').count() < 3 {
+        return None;
+    }
+    Some(format!("https://{}", trimmed))
+}
+
+#[cfg(test)]
+mod remote_url_tests {
+    use super::normalize_git_remote_url;
+
+    #[test]
+    fn normalizes_ssh_https_and_git_suffix() {
+        for raw in [
+            "git@github.com:acme/app.git",
+            "ssh://git@github.com/acme/app.git",
+            "https://github.com/acme/app.git",
+            "https://github.com/acme/app",
+            "https://x-access-token:tok@github.com/acme/app.git",
+            "https://github.com/acme/app/",
+        ] {
+            assert_eq!(
+                normalize_git_remote_url(raw).as_deref(),
+                Some("https://github.com/acme/app"),
+                "{raw}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_empty_and_local_paths() {
+        assert_eq!(normalize_git_remote_url(""), None);
+        assert_eq!(normalize_git_remote_url("/srv/git/app.git"), None);
+        assert_eq!(normalize_git_remote_url("https://github.com/acme"), None);
+    }
+}


### PR DESCRIPTION
## Why

A git-mode `release create` run from inside a git checkout records the commit but not the repository: `manifest.git_repository` was only ever written on the path where the CLI had to ask the platform for one (outside a checkout). The deploy worker then fails before provisioning:

```
Release <id> is missing git metadata (gitCommit=<sha>, gitRepository=undefined) and has no codeSourceUrl
```

Hit today by a customer (forklaunch-platform deployment `df6165f1`).

## What

- `get_git_remote_url()` reads `git remote get-url origin` and `normalize_git_remote_url` maps the SSH / `ssh://` / `.git` / credential-embedded spellings to the canonical `https://host/owner/repo` the platform stores for a connected repository.
- In `release create`, after git metadata detection: git mode + inside a checkout + no `git_repository` in the manifest → record the origin remote and save manifest.toml (same as the platform-provided path). No remote → warning; the deploy worker falls back to the application's connected repository (forklaunch-platform #597).

## Tests

- `remote_url_tests`: six remote spellings normalise to the same URL; empty, local path, and owner-only URLs are rejected.
- `cargo build` clean, 2/2 new tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWR4xL34BHMe2gjvsdLbRk

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forklaunch/codesmith/forklaunch/pr/334"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791145084&installation_model_id=434648&pr_number=334&repository=forklaunch%2Fforklaunch&return_to=https%3A%2F%2Fgithub.com%2Fforklaunch%2Fforklaunch%2Fpull%2F334&signature=12792638acf225601b076afe89f8f03db857b3d184490d2da44d7f6a129b34a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->