### PR TITLE
fix(skills): make --check compare content, not the source repo's HEAD

### DIFF
--- a/scripts/sync-skills.bash
+++ b/scripts/sync-skills.bash
@@ -57,7 +57,14 @@ fi
 
 # Resolve the source commit before copying, and require a clean tree, so the
 # vendored content and the recorded source_commit can never disagree.
-SOURCE_SHA=$(git -C "$SOURCE_DIR" rev-parse HEAD 2>/dev/null || echo "unknown")
+#
+# Deliberately the last commit that TOUCHED the skills, not the source repo's
+# HEAD. HEAD moves on every commit to forklaunch-platform -- a billing fix, a
+# bot rebuilding .ai-packs -- none of which change a single vendored byte. Using
+# it made `--check` cry drift constantly, and a check that is usually wrong is
+# one nobody reads.
+SOURCE_SHA=$(git -C "$SOURCE_DIR" log -1 --format=%H -- . 2>/dev/null || echo "unknown")
+[[ -n "$SOURCE_SHA" ]] || SOURCE_SHA="unknown"
 if [[ "$SOURCE_SHA" != "unknown" ]] && [[ -n "$(git -C "$SOURCE_DIR" status --porcelain -- . 2>/dev/null)" ]]; then
   echo "error: $SOURCE_DIR has uncommitted changes — commit or stash before syncing" >&2
   exit 1
@@ -77,21 +84,41 @@ done
 
 if $CHECK; then
   RECORDED_SHA=$(grep -E '^source_commit = "' "$MANIFEST" | sed -E 's/^source_commit = "(.*)"/\1/')
-  if [[ "$SOURCE_SHA" != "unknown" ]] && [[ "$RECORDED_SHA" != "$SOURCE_SHA" ]]; then
-    echo "skill pack is out of sync with $SOURCE_DIR:" >&2
-    echo "  manifest records source_commit=$RECORDED_SHA, but $SOURCE_DIR is at $SOURCE_SHA" >&2
-    exit 1
-  fi
+
+  # CONTENT is the check that matters, so it runs first and always runs.
+  #
+  # It used to run second, behind a source_commit comparison that exited 1 on a
+  # mismatch -- so the moment the source repo moved ahead for any reason, the
+  # comparison the pack actually depends on was never reached. A real content
+  # difference hid behind that noise: `deploy logs` documentation lived only in
+  # the vendored copy for days, one routine `rm -rf` away from deletion, while
+  # --check reported "out of sync" for an unrelated reason the whole time.
   DIFF_OUT=$(mktemp)
   trap 'rm -f "$DIFF_OUT"; rm -rf "$WORKDIR"' EXIT
-  if diff -rq "$WORKDIR" "$DEST" > "$DIFF_OUT" 2>&1; then
-    echo "skill pack is in sync with $SOURCE_DIR"
-    exit 0
-  else
-    echo "skill pack is out of sync with $SOURCE_DIR:" >&2
+
+  if ! diff -rq "$WORKDIR" "$DEST" > "$DIFF_OUT" 2>&1; then
+    echo "skill pack CONTENT differs from $SOURCE_DIR:" >&2
     cat "$DIFF_OUT" >&2
+    echo >&2
+    echo "  Run scripts/sync-skills.bash to re-vendor from the source." >&2
+    echo "  If the vendored copy is the one with the newer text, move that text" >&2
+    echo "  into $SOURCE_DIR first -- the sync overwrites the pack from there." >&2
     exit 1
   fi
+
+  # Content matches. A differing source_commit now means only that the skills
+  # were touched in a commit that left the allowlisted files byte-identical
+  # (editing a skill the pack does not ship, say). Worth reporting, not worth
+  # failing a build over.
+  if [[ "$SOURCE_SHA" != "unknown" ]] && [[ "$RECORDED_SHA" != "$SOURCE_SHA" ]]; then
+    echo "skill pack content is in sync with $SOURCE_DIR"
+    echo "note: recorded source_commit=$RECORDED_SHA, latest skills commit is $SOURCE_SHA"
+    echo "      content is identical; run scripts/sync-skills.bash to refresh the record."
+    exit 0
+  fi
+
+  echo "skill pack is in sync with $SOURCE_DIR"
+  exit 0
 else
   rm -rf "$DEST"
   mkdir -p "$DEST"


### PR DESCRIPTION
`sync-skills.bash --check` is the guard against the vendored skill pack drifting from its source in forklaunch-platform. It had a content diff already — it just never reached it.

## The bug

```bash
SOURCE_SHA=$(git -C "$SOURCE_DIR" rev-parse HEAD ...)   # ← the source repo's HEAD
...
if [[ "$RECORDED_SHA" != "$SOURCE_SHA" ]]; then
  echo "skill pack is out of sync..." >&2
  exit 1                                                 # ← returns before the content diff
fi
DIFF_OUT=$(mktemp)                                       # ← never reached
```

`HEAD` moves on **every** commit to forklaunch-platform. A billing fix, a bot rebuilding `.ai-packs` — HEAD moves, `--check` says "out of sync", and not one vendored byte has changed. Today, concretely:

```
platform repo HEAD:                  09d93a97   ← bot commit, touched only .ai-packs/dist
last commit touching .claude/skills:  685c0756
```

The old check called that drift. It isn't.

A check that is usually wrong is one nobody reads — and the comparison that actually matters sat behind it, unreachable.

## What it hid

forklaunch#310 documented `deploy logs` in the **vendored** copy and never in the source. Real content drift, one routine `sync-skills.bash` (`rm -rf` + re-copy) away from silent deletion, invisible for days behind an unrelated "out of sync" message.

## Changes

- **`SOURCE_SHA` is now the last commit that *touched* the skills directory** (`git log -1 -- .`), so the recorded provenance moves when the skills move and not otherwise.
- **The content diff runs first and always runs.** It is the gate. A differing `source_commit` with byte-identical content is a stale bookkeeping record — reported, not fatal.
- A content failure now names the differing files and says what to do, **including the case that caused this**: when the vendored copy holds the newer text, it must be moved into the source first, because the sync overwrites the pack from there.

## Verification

Against a real platform checkout at `origin/main`:

| scenario | before | after |
|---|---|---|
| content matches, `source_commit` stale | `exit 1` — the everyday false alarm | `exit 0` + note |
| text edited only in the vendored copy | never reached | `exit 1`, names the file, gives the fix |

```
$ sync-skills.bash --check
skill pack content is in sync with .../.claude/skills
note: recorded source_commit=09d93a97..., latest skills commit is 685c0756...
      content is identical; run scripts/sync-skills.bash to refresh the record.
```

No CI job invokes this script — it needs a forklaunch-platform checkout, so it runs locally and from the sync workflow. Nothing in this PR changes what CI does.

Note that running `--check` against `main` today legitimately reports content drift: several skills are vendored but missing from main's allowlist. That is the bug #329 fixes, and this check now surfaces it instead of masking it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019on1U8FvxLWCELRKuz6n56

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forklaunch/codesmith/forklaunch/pr/335"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791148489&installation_model_id=434648&pr_number=335&repository=forklaunch%2Fforklaunch&return_to=https%3A%2F%2Fgithub.com%2Fforklaunch%2Fforklaunch%2Fpull%2F335&signature=5c1280701e55610711689f643102527187bcac0d96f7f7575e23bd0bbaa8fbbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->