### PR TITLE
feat(cli): app resize saves by default; --apply <save|release|deploy>; validate sizes

### DIFF
--- a/cli/src/app/resize.rs
+++ b/cli/src/app/resize.rs
@@ -15,6 +15,11 @@ use crate::{
     },
 };
 
+pub(crate) const INSTANCE_SIZES: &[&str] = &[
+    "nano", "micro", "small", "medium", "large", "xlarge", "2xlarge",
+];
+pub(crate) const APPLY_MODES: &[&str] = &["save", "release", "deploy"];
+
 fn parse_instance_sizes(sizes: &[&String]) -> Result<serde_json::Map<String, serde_json::Value>> {
     let mut instance_sizes = serde_json::Map::new();
     for entry in sizes {
@@ -26,6 +31,14 @@ fn parse_instance_sizes(sizes: &[&String]) -> Result<serde_json::Map<String, ser
         }
         if instance_sizes.contains_key(id) {
             bail!("--size specified more than once for id '{}'", id);
+        }
+        if !INSTANCE_SIZES.contains(&size) {
+            bail!(
+                "--size '{}': '{}' is not an instance size (one of {})",
+                entry,
+                size,
+                INSTANCE_SIZES.join(", ")
+            );
         }
         instance_sizes.insert(id.to_string(), serde_json::Value::String(size.to_string()));
     }
@@ -45,28 +58,42 @@ impl CliCommand for ResizeCommand {
     fn command(&self) -> Command {
         command(
             "resize",
-            "Resize one or more services/workers — creates a new release and triggers a deployment",
+            "Set the instance size of one or more services/workers (saved for the next deploy unless --apply says otherwise)",
         )
         .arg(
             Arg::new("environment")
                 .short('e')
                 .long("environment")
                 .required(true)
-                .help("Environment to deploy the resize into"),
+                .help("Environment the size applies to"),
         )
         .arg(
             Arg::new("region")
                 .short('r')
                 .long("region")
                 .required(true)
-                .help("Region to deploy the resize into"),
+                .help("Region the size applies to"),
         )
         .arg(
             Arg::new("size")
                 .long("size")
                 .required(true)
                 .action(ArgAction::Append)
-                .help("<service-or-worker-id>=<instance-size>, repeatable (e.g. --size svc-1=t3.medium)"),
+                .help(
+                    "<service-or-worker>=<size>, repeatable. The component is its manifest name \
+                     (e.g. billing-service, billing-worker); sizes: nano, micro, small, medium, \
+                     large, xlarge, 2xlarge (e.g. --size billing-worker=large)",
+                ),
+        )
+        .arg(
+            Arg::new("apply")
+                .long("apply")
+                .value_parser(APPLY_MODES.to_vec())
+                .default_value("save")
+                .help(
+                    "How far to take the change: save = record the size for the next deploy \
+                     (default); release = also create a release; deploy = release and deploy now",
+                ),
         )
         .arg(
             Arg::new("base_path")
@@ -93,11 +120,17 @@ impl CliCommand for ResizeCommand {
 
         let instance_sizes = parse_instance_sizes(&sizes)?;
 
+        let apply = matches
+            .get_one::<String>("apply")
+            .map(String::as_str)
+            .unwrap_or("save");
+
         let body = serde_json::json!({
             "applicationId": application_id,
             "environment": environment,
             "region": region,
             "instanceSizes": instance_sizes,
+            "apply": apply,
         });
 
         let url = format!("{}/instance-sizes", get_platform_management_api_url());
@@ -105,10 +138,7 @@ impl CliCommand for ResizeCommand {
             http_client::post(&url, body).with_context(|| ERROR_FAILED_TO_SEND_REQUEST)?;
 
         if !response.status().is_success() {
-            bail!(
-                "Failed to resize: {}",
-                response.text().unwrap_or_default()
-            );
+            bail!("Failed to resize: {}", response.text().unwrap_or_default());
         }
 
         let result: ResizeResponse = response
@@ -117,13 +147,27 @@ impl CliCommand for ResizeCommand {
 
         let mut stdout = StandardStream::stdout(ColorChoice::Always);
         stdout.set_color(ColorSpec::new().set_fg(Some(Color::Green)).set_bold(true))?;
-        write!(stdout, "  Deploying resize")?;
+        let headline = match result.applied.as_deref().unwrap_or(apply) {
+            "deploy" => "  Deploying resize",
+            "release" => "  Release created",
+            _ => "  Instance sizes saved",
+        };
+        write!(stdout, "{}", headline)?;
         stdout.reset()?;
-        writeln!(
-            stdout,
-            "  release {} ({}), deployment {}",
-            result.release_version, result.release_id, result.deployment_id
-        )?;
+        writeln!(stdout)?;
+        for entry in &result.updated {
+            writeln!(
+                stdout,
+                "    {} -> {}",
+                entry.component_name, entry.instance_type
+            )?;
+        }
+        if let (Some(version), Some(id)) = (&result.release_version, &result.release_id) {
+            writeln!(stdout, "  release {} ({})", version, id)?;
+        }
+        if let Some(deployment_id) = &result.deployment_id {
+            writeln!(stdout, "  deployment {}", deployment_id)?;
+        }
         writeln!(stdout, "  {}", result.message)?;
 
         Ok(())
@@ -134,9 +178,23 @@ impl CliCommand for ResizeCommand {
 #[serde(rename_all = "camelCase")]
 struct ResizeResponse {
     message: String,
-    release_id: String,
-    release_version: String,
-    deployment_id: String,
+    #[serde(default)]
+    applied: Option<String>,
+    #[serde(default)]
+    updated: Vec<ResizedComponent>,
+    #[serde(default)]
+    release_id: Option<String>,
+    #[serde(default)]
+    release_version: Option<String>,
+    #[serde(default)]
+    deployment_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ResizedComponent {
+    component_name: String,
+    instance_type: String,
 }
 
 #[cfg(test)]
@@ -158,7 +216,13 @@ mod tests {
         assert!(
             resize_cmd()
                 .try_get_matches_from([
-                    "resize", "-e", "dev", "-r", "us-east-1", "--size", "svc-1=t3.medium"
+                    "resize",
+                    "-e",
+                    "dev",
+                    "-r",
+                    "us-east-1",
+                    "--size",
+                    "svc-1=medium"
                 ])
                 .is_ok()
         );
@@ -174,9 +238,9 @@ mod tests {
                 "-r",
                 "us-east-1",
                 "--size",
-                "svc-1=t3.medium",
+                "svc-1=medium",
                 "--size",
-                "worker-1=t3.small",
+                "worker-1=small",
             ])
             .unwrap();
         let sizes: Vec<&String> = matches.get_many::<String>("size").unwrap().collect();
@@ -191,29 +255,92 @@ mod tests {
         let empty_value = "svc-1=".to_string();
         assert!(parse_instance_sizes(&[&empty_value]).is_err());
 
-        let empty_id = "=t3.medium".to_string();
+        let empty_id = "=medium".to_string();
         assert!(parse_instance_sizes(&[&empty_id]).is_err());
 
-        let dup_a = "svc-1=t3.medium".to_string();
-        let dup_b = "svc-1=t3.large".to_string();
+        let dup_a = "svc-1=medium".to_string();
+        let dup_b = "svc-1=large".to_string();
         assert!(parse_instance_sizes(&[&dup_a, &dup_b]).is_err());
 
-        let valid_a = "svc-1=t3.medium".to_string();
-        let valid_b = "worker-1=t3.small".to_string();
+        // An EC2 instance type is not an instance size.
+        let not_a_size = "svc-1=t3.medium".to_string();
+        let err = parse_instance_sizes(&[&not_a_size])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("not an instance size"), "{err}");
+
+        let valid_a = "svc-1=medium".to_string();
+        let valid_b = "worker-1=small".to_string();
         let parsed = parse_instance_sizes(&[&valid_a, &valid_b]).unwrap();
         assert_eq!(parsed.len(), 2);
-        assert_eq!(parsed.get("svc-1").unwrap(), "t3.medium");
+        assert_eq!(parsed.get("svc-1").unwrap(), "medium");
     }
 
     #[test]
-    fn resize_response_deserializes() {
-        let json = r#"{
+    fn apply_defaults_to_save_and_only_accepts_known_modes() {
+        let m = resize_cmd()
+            .try_get_matches_from([
+                "resize",
+                "-e",
+                "dev",
+                "-r",
+                "us-east-1",
+                "--size",
+                "w=large",
+            ])
+            .unwrap();
+        assert_eq!(m.get_one::<String>("apply").unwrap(), "save");
+        for mode in APPLY_MODES {
+            assert!(
+                resize_cmd()
+                    .try_get_matches_from([
+                        "resize",
+                        "-e",
+                        "dev",
+                        "-r",
+                        "us-east-1",
+                        "--size",
+                        "w=large",
+                        "--apply",
+                        mode
+                    ])
+                    .is_ok()
+            );
+        }
+        assert!(
+            resize_cmd()
+                .try_get_matches_from([
+                    "resize",
+                    "-e",
+                    "dev",
+                    "-r",
+                    "us-east-1",
+                    "--size",
+                    "w=large",
+                    "--apply",
+                    "yolo"
+                ])
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn resize_response_deserializes_with_and_without_release_fields() {
+        let deployed = r#"{
             "message": "Deployment triggered",
+            "applied": "deploy",
+            "updated": [{"componentName": "billing-worker", "instanceType": "large"}],
             "releaseId": "rel-1",
             "releaseVersion": "1.0.1",
             "deploymentId": "dep-1"
         }"#;
-        let response: ResizeResponse = serde_json::from_str(json).unwrap();
-        assert_eq!(response.release_version, "1.0.1");
+        let response: ResizeResponse = serde_json::from_str(deployed).unwrap();
+        assert_eq!(response.release_version.as_deref(), Some("1.0.1"));
+        assert_eq!(response.updated[0].instance_type, "large");
+
+        let saved = r#"{"message": "saved", "applied": "save", "updated": []}"#;
+        let response: ResizeResponse = serde_json::from_str(saved).unwrap();
+        assert!(response.deployment_id.is_none());
+        assert_eq!(response.applied.as_deref(), Some("save"));
     }
 }


### PR DESCRIPTION
## Why

`fl app resize` always created a release and deployed it, its help suggested EC2 instance types (`svc-1=t3.medium`) where the platform wants size names, and it accepted any key. Today that produced a no-op release and deployment from a UUID that matched nothing, and a second run whose size was silently overruled by the dashboard's override.

## What

- `--apply <save|release|deploy>`, default `save`: record the size for the next deploy; `release` also creates a release; `deploy` releases and deploys (previous behaviour).
- Sizes validated locally against `nano micro small medium large xlarge 2xlarge`; the error names the valid list.
- Help text: component is its manifest name (`billing-service`, `billing-worker`), e.g. `--size billing-worker=large`.
- Response fields `releaseId` / `releaseVersion` / `deploymentId` are optional; the command prints `applied` and the updated components.

Pairs with forklaunch-platform #599 (server rejects unknown components with the valid names and writes the size to the per-component override the generator reads).

## Tests

- `app::resize` tests: 6 passing, including size validation, apply-mode parsing, and both response shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWR4xL34BHMe2gjvsdLbRk

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forklaunch/codesmith/forklaunch/pr/336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791156064&installation_model_id=434648&pr_number=336&repository=forklaunch%2Fforklaunch&return_to=https%3A%2F%2Fgithub.com%2Fforklaunch%2Fforklaunch%2Fpull%2F336&signature=f91d6e2fb63ea6f2d9263a79c85642c163fcd1d210bc422836466e999b46cc30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The resize CLI now supports predefined instance sizes with validation.
  - Added an `--apply` option to choose whether changes are saved, released, or deployed.
  - Resize requests now reflect the selected application mode.
  - Status output includes relevant release and deployment details when available.
  - Component information is updated to reflect the latest resize results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->