### PR TITLE
feat(cli): --cluster-type and --frontend-domain on managed template create/update

### DIFF
--- a/cli/src/managed/template/create.rs
+++ b/cli/src/managed/template/create.rs
@@ -10,7 +10,7 @@ use crate::{
     core::command::command,
     managed::{
         client::{Missing, post_json, print_dryrun, require_managed_mode, resolve_managed_auth},
-        types::AppTemplate,
+        types::{AppTemplate, TEMPLATE_CLUSTER_TYPES},
     },
 };
 
@@ -33,10 +33,14 @@ impl CliCommand for CreateCommand {
                  \x20 1. `template publish`          — add a version (a semver pinned to a git ref)\n\
                  \x20 2. `template publish-template` — move the template itself to `published`\n\n\
                  This command takes exactly what the control plane's create API accepts:\n\
-                 slug, name, source repo, and an optional description. The Stripe product is\n\
-                 set afterwards with `template update --stripe-product <id>`. The base domain\n\
-                 is not settable through the API at all — instances use the platform-wide\n\
-                 default.",
+                 slug, name, source repo, an optional description, and an optional cluster\n\
+                 type. The Stripe product is set afterwards with `template update\n\
+                 --stripe-product <id>`. The base domain is not settable through the API at\n\
+                 all — instances use the platform-wide default.\n\n\
+                 --cluster-type decides where every instance of this template runs. It is\n\
+                 the publisher's call, made once here; a customer launching an instance is\n\
+                 never asked. Unset means org-shared (your organization's shared hosts).\n\
+                 A hosting type a component declares in the repo's manifest still wins.",
             )
             .arg(
                 Arg::new("slug")
@@ -60,6 +64,12 @@ impl CliCommand for CreateCommand {
                 Arg::new("description")
                     .long("description")
                     .help("Optional description shown alongside the template"),
+            )
+            .arg(
+                Arg::new("cluster_type")
+                    .long("cluster-type")
+                    .value_parser(TEMPLATE_CLUSTER_TYPES.to_vec())
+                    .help("Where instances of this template run: org-shared (default; your org's shared hosts), platform-shared, or dedicated"),
             )
             .arg(
                 Arg::new("dryrun")
@@ -97,6 +107,9 @@ impl CliCommand for CreateCommand {
         body.insert("sourceRepo".to_string(), json!(repo));
         if let Some(description) = matches.get_one::<String>("description") {
             body.insert("description".to_string(), json!(description));
+        }
+        if let Some(cluster_type) = matches.get_one::<String>("cluster_type") {
+            body.insert("clusterType".to_string(), json!(cluster_type));
         }
 
         let body = Value::Object(body);

--- a/cli/src/managed/template/list.rs
+++ b/cli/src/managed/template/list.rs
@@ -84,15 +84,25 @@ impl CliCommand for ListCommand {
         }
 
         stdout.set_color(ColorSpec::new().set_bold(true))?;
-        writeln!(stdout, "  {:<24} {:<28} {:<12}", "SLUG", "NAME", "STATUS")?;
+        writeln!(
+            stdout,
+            "  {:<24} {:<28} {:<12} {:<16}",
+            "SLUG", "NAME", "STATUS", "CLUSTER"
+        )?;
         stdout.reset()?;
         for template in &templates {
             writeln!(
                 stdout,
-                "  {:<24} {:<28} {:<12}",
+                "  {:<24} {:<28} {:<12} {:<16}",
                 dash(&template.slug),
                 dash(&template.name),
                 dash(&template.status),
+                // Unset means the managed default; say so rather than printing a dash
+                // that reads as "no placement".
+                template
+                    .cluster_type
+                    .as_deref()
+                    .unwrap_or("org-shared (default)"),
             )?;
         }
         writeln!(stdout)?;

--- a/cli/src/managed/template/update.rs
+++ b/cli/src/managed/template/update.rs
@@ -27,6 +27,7 @@ pub(super) struct TemplateUpdate<'a> {
     pub(super) status: Option<&'a str>,
     pub(super) stripe_product: Option<&'a String>,
     pub(super) cluster_type: Option<&'a String>,
+    pub(super) frontend_domain: Option<&'a String>,
     pub(super) dryrun: bool,
     pub(super) json: bool,
 }
@@ -95,6 +96,11 @@ impl CliCommand for UpdateCommand {
                 .help("Where instances of this template run: org-shared (your org's shared hosts), platform-shared, or dedicated. Applies to instances launched from now on"),
         )
         .arg(
+            Arg::new("frontend_domain")
+                .long("frontend-domain")
+                .help("Domain the product's frontend is served from (e.g. app.example.com). Each instance's UI is <hostPrefix>.<domain>; the claim page and `instance list` hand that URL out"),
+        )
+        .arg(
             Arg::new("dryrun")
                 .long("dryrun")
                 .help("Print the request that would be sent without sending it")
@@ -121,6 +127,7 @@ impl CliCommand for UpdateCommand {
                 status: matches.get_one::<String>("status").map(String::as_str),
                 stripe_product: matches.get_one::<String>("stripe_product"),
                 cluster_type: matches.get_one::<String>("cluster_type"),
+                frontend_domain: matches.get_one::<String>("frontend_domain"),
                 dryrun: matches.get_flag("dryrun"),
                 json: matches.get_flag("json"),
             },
@@ -148,6 +155,9 @@ pub(super) fn update_template(slug: &str, update: TemplateUpdate<'_>) -> Result<
     if let Some(cluster_type) = update.cluster_type {
         body.insert("clusterType".to_string(), json!(cluster_type));
     }
+    if let Some(frontend_domain) = update.frontend_domain {
+        body.insert("frontendDomain".to_string(), json!(frontend_domain));
+    }
 
     // An empty PATCH is accepted by the control plane and changes nothing, so it would
     // report success while having done nothing at all. Refuse instead — someone who
@@ -156,8 +166,8 @@ pub(super) fn update_template(slug: &str, update: TemplateUpdate<'_>) -> Result<
     if body.is_empty() {
         bail!(
             "nothing to update — pass at least one of --name, --description, --status, \
-             --stripe-product, or --cluster-type (to publish a template, `forklaunch managed \
-             template publish-template --slug {}` is the shorthand)",
+             --stripe-product, --cluster-type, or --frontend-domain (to publish a template, \
+             `forklaunch managed template publish-template --slug {}` is the shorthand)",
             slug
         );
     }
@@ -246,6 +256,7 @@ mod tests {
         assert!(update.description.is_none());
         assert!(update.stripe_product.is_none());
         assert!(update.cluster_type.is_none());
+        assert!(update.frontend_domain.is_none());
     }
 
     #[test]

--- a/cli/src/managed/template/update.rs
+++ b/cli/src/managed/template/update.rs
@@ -10,7 +10,7 @@ use crate::{
     core::command::command,
     managed::{
         client::{Missing, patch_json, print_dryrun, require_managed_mode, resolve_managed_auth},
-        types::{AppTemplate, TEMPLATE_STATUSES},
+        types::{AppTemplate, TEMPLATE_CLUSTER_TYPES, TEMPLATE_STATUSES},
     },
 };
 
@@ -26,6 +26,7 @@ pub(super) struct TemplateUpdate<'a> {
     pub(super) description: Option<&'a String>,
     pub(super) status: Option<&'a str>,
     pub(super) stripe_product: Option<&'a String>,
+    pub(super) cluster_type: Option<&'a String>,
     pub(super) dryrun: bool,
     pub(super) json: bool,
 }
@@ -43,10 +44,10 @@ impl CliCommand for UpdateCommand {
     fn command(&self) -> Command {
         command(
             "update",
-            "Change a template's name, description, status, or Stripe product",
+            "Change a template's name, description, status, Stripe product, or cluster type",
         )
         .long_about(
-            "Change a template's name, description, status, or Stripe product.\n\n\
+            "Change a template's name, description, status, Stripe product, or cluster type.\n\n\
              Only the fields you pass are changed; everything else is left alone.\n\n\
              --status is the important one. A template is created as `draft`, and\n\
              `instance create` will only launch from a `published` template, so a template\n\
@@ -88,6 +89,12 @@ impl CliCommand for UpdateCommand {
                 .help("Stripe product id to record against the template (not yet read by billing)"),
         )
         .arg(
+            Arg::new("cluster_type")
+                .long("cluster-type")
+                .value_parser(TEMPLATE_CLUSTER_TYPES.to_vec())
+                .help("Where instances of this template run: org-shared (your org's shared hosts), platform-shared, or dedicated. Applies to instances launched from now on"),
+        )
+        .arg(
             Arg::new("dryrun")
                 .long("dryrun")
                 .help("Print the request that would be sent without sending it")
@@ -113,6 +120,7 @@ impl CliCommand for UpdateCommand {
                 description: matches.get_one::<String>("description"),
                 status: matches.get_one::<String>("status").map(String::as_str),
                 stripe_product: matches.get_one::<String>("stripe_product"),
+                cluster_type: matches.get_one::<String>("cluster_type"),
                 dryrun: matches.get_flag("dryrun"),
                 json: matches.get_flag("json"),
             },
@@ -137,6 +145,9 @@ pub(super) fn update_template(slug: &str, update: TemplateUpdate<'_>) -> Result<
     if let Some(stripe_product) = update.stripe_product {
         body.insert("stripeProductId".to_string(), json!(stripe_product));
     }
+    if let Some(cluster_type) = update.cluster_type {
+        body.insert("clusterType".to_string(), json!(cluster_type));
+    }
 
     // An empty PATCH is accepted by the control plane and changes nothing, so it would
     // report success while having done nothing at all. Refuse instead — someone who
@@ -144,9 +155,9 @@ pub(super) fn update_template(slug: &str, update: TemplateUpdate<'_>) -> Result<
     // something had happened.
     if body.is_empty() {
         bail!(
-            "nothing to update — pass at least one of --name, --description, --status, or \
-             --stripe-product (to publish a template, `forklaunch managed template \
-             publish-template --slug {}` is the shorthand)",
+            "nothing to update — pass at least one of --name, --description, --status, \
+             --stripe-product, or --cluster-type (to publish a template, `forklaunch managed \
+             template publish-template --slug {}` is the shorthand)",
             slug
         );
     }
@@ -234,6 +245,18 @@ mod tests {
         assert!(update.name.is_none());
         assert!(update.description.is_none());
         assert!(update.stripe_product.is_none());
+        assert!(update.cluster_type.is_none());
+    }
+
+    #[test]
+    fn the_cli_cluster_type_list_matches_what_the_control_plane_validates() {
+        // managed-apps validates `clusterType` against ClusterPlacementEnum
+        // (org-shared | platform-shared | dedicated). Keep the local list identical so a
+        // typo fails before the round trip and a valid value is never refused locally.
+        assert_eq!(
+            TEMPLATE_CLUSTER_TYPES,
+            &["org-shared", "platform-shared", "dedicated"]
+        );
     }
 
     #[test]

--- a/cli/src/managed/types.rs
+++ b/cli/src/managed/types.rs
@@ -44,7 +44,18 @@ pub(super) struct AppTemplate {
     pub(super) status: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(super) source_repo: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) cluster_type: Option<String>,
 }
+
+/// Where a template's instances run. Same vocabulary as `forklaunch app hosting`
+/// and `deploy create --cluster-type`; the control plane validates it too, but a
+/// typo should fail before the round trip.
+///
+///   org-shared       your organization's shared hosts (the managed default)
+///   platform-shared  ForkLaunch's shared hosts (cheapest, cross-tenant compute)
+///   dedicated        a cluster of the instance's own
+pub(super) const TEMPLATE_CLUSTER_TYPES: &[&str] = &["org-shared", "platform-shared", "dedicated"];
 
 /// The template statuses the platform defines. A template is created as `draft`;
 /// `instance create` requires `published`, so a template stays uninstantiable until

--- a/cli/src/managed/types.rs
+++ b/cli/src/managed/types.rs
@@ -46,6 +46,8 @@ pub(super) struct AppTemplate {
     pub(super) source_repo: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(super) cluster_type: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) frontend_domain: Option<String>,
 }
 
 /// Where a template's instances run. Same vocabulary as `forklaunch app hosting`


### PR DESCRIPTION
## What

- `forklaunch managed template create|update --cluster-type <org-shared|platform-shared|dedicated>` records where every instance of a template runs. `template list` gains a `CLUSTER` column (unset prints `org-shared (default)`, which is what the platform does with null).
- `forklaunch managed template update --frontend-domain <domain>` records the product frontend domain; each instance's UI is `<hostPrefix>.<domain>`, which the claim page and `instance list` hand out.

## Why

Placement is the publisher's call, made once on the template; a customer launching an instance is never asked. Setting a cluster on the publisher's own application does not carry over, because each instance is a new application derived from the template. The frontend domain is the second template-level fact a frontend deployment needs (see forklaunch-platform `docs/managed-instance-frontend.md`).

## Pairs with

forklaunch-platform #612 (template `clusterType`), and the instance endpoints mapping PR (template `frontendDomain`, `hostPrefix`/`endpoints`/`frontendUrl` on instances).

## Tests

`cargo test managed::template` passes; `rustfmt --edition 2024` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWR4xL34BHMe2gjvsdLbRk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cluster placement support when creating templates, including validation for supported cluster types.
  * Template listings now show the assigned cluster, with `org-shared (default)` displayed when no cluster is set.
  * Template updates now support changing cluster placement and configuring a frontend domain.
  * Supported cluster types include `org-shared`, `platform-shared`, and `dedicated`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->