### PR TITLE
fix(managed): instance claim posts to the token-only /claim route

### DIFF
--- a/cli/src/managed/instance/claim.rs
+++ b/cli/src/managed/instance/claim.rs
@@ -66,8 +66,11 @@ impl CliCommand for ClaimCommand {
         .arg(
             Arg::new("id")
                 .long("id")
-                .required(true)
-                .help("Id of the instance being claimed (from the claim link you were given)"),
+                .required(false)
+                .help(
+                    "Ignored. The token alone identifies the instance; accepted so older \
+                     instructions that pass --id keep working",
+                ),
         )
         .arg(
             Arg::new("token")
@@ -101,9 +104,6 @@ impl CliCommand for ClaimCommand {
     fn handler(&self, matches: &ArgMatches) -> Result<()> {
         let mut stdout = StandardStream::stdout(ColorChoice::Always);
 
-        let id = matches
-            .get_one::<String>("id")
-            .context("--id is required")?;
         let token = matches
             .get_one::<String>("token")
             .context("--token is required")?;
@@ -111,13 +111,15 @@ impl CliCommand for ClaimCommand {
             .get_one::<String>("backup_public_key")
             .context("--backup-public-key is required")?;
 
-        let path = format!("/instances/{}/claim", urlencoding::encode(id));
+        // No instance id in the path: the platform resolves the instance from the
+        // token (POST /managed-mode/claim). Requiring an id would only let a caller
+        // probe which ids exist, which is why the id-scoped route was retired.
+        let path = "/claim".to_string();
         let body = json!({ "token": token, "backupPublicKey": backup_public_key });
 
         if matches.get_flag("dryrun") {
             println!(
-                "[DRYRUN] this would CONSUME the one-time claim for instance {}.",
-                id
+                "[DRYRUN] this would CONSUME the one-time claim for the instance this token names."
             );
             // The token is the credential. Echoing it into a dry-run transcript that
             // people paste into issues would be the easiest way to leak one, so show the


### PR DESCRIPTION
`forklaunch managed instance claim` still POSTs `/managed-mode/instances/:id/claim`. The platform retired that route in forklaunch-platform #615 for `POST /managed-mode/claim` (the token alone identifies the instance; an id in the path let callers probe which ids exist). Result: every CLI claim reports "this claim link is not valid" against a valid link, while the claim page / a direct POST succeeds.

- Path is now `/claim`; body unchanged (`token`, `backupPublicKey`).
- `--id` stays accepted, optional and ignored, so existing instructions keep working.
- Dry-run output no longer names an instance id.

Verified: `cargo build` clean; no clippy findings in `claim.rs` (the `--all-targets -D warnings` run reports pre-existing `useless_vec` lints in test modules only). Needs a CLI release together with #337/#334/#336.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWR4xL34BHMe2gjvsdLbRk

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/forklaunch/codesmith/forklaunch/pr/338"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791390366&installation_model_id=434648&pr_number=338&repository=forklaunch%2Fforklaunch&return_to=https%3A%2F%2Fgithub.com%2Fforklaunch%2Fforklaunch%2Fpull%2F338&signature=dc9c2b10aaf762072d110bb1f132df6b340f94f3e709171528a2ae2a1468a9d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->